### PR TITLE
Add Claude Code TDD hooks and Git pre-push CI gate

### DIFF
--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Pre-commit Test Gate — Claude Code PreToolUse Hook (Bash matcher)
+#
+# git commit の実行前に全テストとビルドwarningチェックを行い、
+# 失敗していればコミットをブロックする。
+
+set -uo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | grep -o '"command":"[^"]*"' | sed 's/"command":"//;s/"$//' 2>/dev/null || true)
+
+# git commit 以外は許可
+echo "$COMMAND" | grep -q 'git.*commit' || exit 0
+
+echo "Pre-commit: テスト実行中..." >&2
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+# Build warning check
+WARNINGS=$(mise exec rust -- cargo build 2>&1 | grep "^warning:" | grep -v "generated" | wc -l)
+if [ "$WARNINGS" -gt 0 ]; then
+  echo "⚠ Pre-commit: ビルドwarningが${WARNINGS}件あります。コミットをブロックします。" >&2
+  exit 1
+fi
+
+# Test check (j=1 for memory safety)
+if ! mise exec rust -- cargo test -j 1 2>&1 | tail -1 | grep -q "test result: ok\|^$"; then
+  # Check for any failures
+  FAILURES=$(mise exec rust -- cargo test -j 1 2>&1 | grep "FAILED" | head -3)
+  if [ -n "$FAILURES" ]; then
+    echo "⚠ Pre-commit: テストが失敗しています。コミットをブロックします。" >&2
+    echo "$FAILURES" >&2
+    exit 1
+  fi
+fi
+
+echo "✓ Pre-commit: 全テストパス、warningゼロ — コミットを許可します。" >&2
+exit 0

--- a/.claude/hooks/tdd-check.sh
+++ b/.claude/hooks/tdd-check.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# TDD Red Phase Check — Claude Code PreToolUse Hook
+#
+# src/ 配下の非テストファイルを編集する前に、関連テストが
+# 「失敗している（Red）」ことを確認する。
+#
+# - 関連テストが全パス → ブロック（先にテストを追加/修正せよ）
+# - 関連テストが失敗あり → 許可（Red Phase 確認済み）
+# - 関連テストなし → 許可
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | sed 's/"file_path":"//;s/"$//' 2>/dev/null || true)
+
+# file_path がなければ許可
+[ -z "$FILE_PATH" ] && exit 0
+
+# src/ 配下の .rs ファイルのみ対象（テストファイルは除外）
+echo "$FILE_PATH" | grep -q '/src/' || exit 0
+echo "$FILE_PATH" | grep -q '/tests/' && exit 0
+
+# 変更されたモジュール名を推定
+MODULE=$(basename "$FILE_PATH" .rs)
+# mod.rs の場合は親ディレクトリ名
+[ "$MODULE" = "mod" ] && MODULE=$(basename "$(dirname "$FILE_PATH")")
+
+# 関連テストファイルを探す
+PROJECT_DIR=$(echo "$FILE_PATH" | sed 's|/src/.*||')
+RELATED_TESTS=$(find "$PROJECT_DIR/tests" -name "*.rs" 2>/dev/null | xargs grep -l "$MODULE" 2>/dev/null | head -5)
+
+[ -z "$RELATED_TESTS" ] && {
+  echo "ℹ TDD: 関連テストが見つかりません: $MODULE" >&2
+  exit 0
+}
+
+# 関連テストを実行
+FIRST_TEST=$(echo "$RELATED_TESTS" | head -1)
+TEST_NAME=$(basename "$FIRST_TEST" .rs)
+
+cd "$PROJECT_DIR"
+if mise exec rust -- cargo test --test "$TEST_NAME" 2>&1 | grep -q "test result: ok"; then
+  echo "⚠ TDD: 関連テスト ($TEST_NAME) が全パスしています。先にfailingテストを書いてください。" >&2
+  exit 1
+else
+  echo "✓ TDD: Red Phase 確認済み ($TEST_NAME に失敗テストあり)" >&2
+  exit 0
+fi

--- a/.claude/hooks/tdd-feedback.sh
+++ b/.claude/hooks/tdd-feedback.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# TDD Green Phase Feedback — Claude Code PostToolUse Hook
+#
+# src/ 配下のファイル編集後に関連テストを実行し結果をフィードバック。
+# ブロックしない（情報提供のみ）。
+
+set -uo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | sed 's/"file_path":"//;s/"$//' 2>/dev/null || true)
+
+[ -z "$FILE_PATH" ] && exit 0
+echo "$FILE_PATH" | grep -q '\.rs$' || exit 0
+
+MODULE=$(basename "$FILE_PATH" .rs)
+[ "$MODULE" = "mod" ] && MODULE=$(basename "$(dirname "$FILE_PATH")")
+
+PROJECT_DIR=$(echo "$FILE_PATH" | sed 's|/src/.*||;s|/tests/.*||')
+RELATED_TESTS=$(find "$PROJECT_DIR/tests" -name "*.rs" 2>/dev/null | xargs grep -l "$MODULE" 2>/dev/null | head -3)
+
+[ -z "$RELATED_TESTS" ] && exit 0
+
+FIRST_TEST=$(echo "$RELATED_TESTS" | head -1)
+TEST_NAME=$(basename "$FIRST_TEST" .rs)
+
+cd "$PROJECT_DIR"
+RESULT=$(mise exec rust -- cargo test --test "$TEST_NAME" 2>&1 | tail -3)
+
+if echo "$RESULT" | grep -q "test result: ok"; then
+  echo "✓ Green: $TEST_NAME 全パス" >&2
+else
+  FAILED=$(echo "$RESULT" | grep -o '[0-9]* failed' | head -1)
+  echo "✗ Red: $TEST_NAME — ${FAILED:-テスト失敗}" >&2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,41 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/tdd-check.sh",
+            "timeout": 60,
+            "statusMessage": "TDD Red check..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/pre-commit-check.sh",
+            "timeout": 300,
+            "statusMessage": "Pre-commit test gate..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/tdd-feedback.sh",
+            "timeout": 60,
+            "statusMessage": "TDD feedback..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Claude Code hooks for TDD Red-Green-Refactoring workflow
- Git pre-push hook running CI-equivalent checks locally

## Claude Code hooks (.claude/settings.json)
- **PreToolUse Edit|Write**: TDD Red check — blocks src/ edits if related tests all pass (forces test-first)
- **PostToolUse Edit|Write**: TDD Green feedback — runs related tests after edit, reports pass/fail
- **PreToolUse Bash**: Pre-commit gate — blocks `git commit` if tests fail or build has warnings

## Git pre-push hook
4-stage CI-equivalent gate:
1. Build zero warnings
2. All tests pass (`cargo test -j 1`)
3. Self-host generate + check (0 diff)
4. Self-mine coverage (100+ sigs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)