### PR TITLE
Add Swift code generation and mining support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         run: cargo run -- generate models/oxidtr.als --target kt --output generated-kt
       - name: Generate Java
         run: cargo run -- generate models/oxidtr.als --target java --output generated-java
+      - name: Generate Swift
+        run: cargo run -- generate models/oxidtr.als --target swift --output generated-swift
 
       # Check structural consistency (all targets)
       - name: Check Rust
@@ -46,6 +48,8 @@ jobs:
         run: cargo run -- check --model models/oxidtr.als --impl generated-kt
       - name: Check Java
         run: cargo run -- check --model models/oxidtr.als --impl generated-java
+      - name: Check Swift
+        run: cargo run -- check --model models/oxidtr.als --impl generated-swift
 
       # Mine round-trip (each language → Alloy)
       - name: Mine Rust back to Alloy
@@ -56,6 +60,8 @@ jobs:
         run: cargo run -- mine generated-kt/ -o /tmp/mined-kt.als
       - name: Mine Java back to Alloy
         run: cargo run -- mine generated-java/ -o /tmp/mined-java.als
+      - name: Mine Swift back to Alloy
+        run: cargo run -- mine generated-swift/ -o /tmp/mined-swift.als
 
       # Verify enrichment (no invariants, no @alloy comments)
       - name: Verify enriched output
@@ -65,6 +71,7 @@ jobs:
           grep -q 'fun default' generated-kt/Fixtures.kt
           grep -q 'static ' generated-java/Fixtures.java
           grep -q '@NotNull' generated-java/Models.java
+          grep -q 'func default' generated-swift/Fixtures.swift
 
       # Verify no invariants files (removed by design)
       - name: Verify no invariants files
@@ -73,6 +80,7 @@ jobs:
           test ! -f generated-ts/invariants.ts
           test ! -f generated-kt/Invariants.kt
           test ! -f generated-java/Invariants.java
+          test ! -f generated-swift/Invariants.swift
 
       # Verify helpers (TC functions) exist where needed
       - name: Verify helpers files
@@ -83,7 +91,7 @@ jobs:
       # Verify no @alloy comments in any generated code
       - name: Verify no @alloy comments
         run: |
-          ! grep -r '@alloy:' generated/ generated-ts/ generated-kt/ generated-java/
+          ! grep -r '@alloy:' generated/ generated-ts/ generated-kt/ generated-java/ generated-swift/
 
       # Verify TS validators exist
       - name: Verify TS validators
@@ -94,6 +102,7 @@ jobs:
         run: |
           grep -q '.iter().all(' generated/tests.rs
           grep -q '.every(' generated-ts/tests.ts
+          grep -q '.allSatisfy' generated-swift/Tests.swift
 
       # Verify cross-tests are marked as skipped/ignored
       - name: Verify cross-test markers
@@ -101,6 +110,7 @@ jobs:
           grep -q '#\[ignore\]' generated/tests.rs || echo "No cross-tests in Rust (OK)"
           grep -q 'it.skip(' generated-ts/tests.ts || echo "No cross-tests in TS (OK)"
           grep -q '@Disabled' generated-kt/Tests.kt || echo "No cross-tests in Kotlin (OK)"
+          grep -q 'disabled_test_' generated-swift/Tests.swift || echo "No cross-tests in Swift (OK)"
 
   target-validation:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /target
 /generated
 /generated-ts
+/generated-kt
+/generated-java
+/generated-swift
 /local_docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ mise exec rust -- cargo run -- generate models/oxidtr.als --target rust --output
 mise exec rust -- cargo run -- generate models/oxidtr.als --target ts --output generated-ts
 mise exec rust -- cargo run -- generate models/oxidtr.als --target kt --output generated-kt
 mise exec rust -- cargo run -- generate models/oxidtr.als --target java --output generated-java
+mise exec rust -- cargo run -- generate models/oxidtr.als --target swift --output generated-swift
 mise exec rust -- cargo run -- check --model models/oxidtr.als --impl generated
 mise exec rust -- cargo run -- mine generated/
 mise exec rust -- cargo run -- mine src/ --lang rust
@@ -57,10 +58,11 @@ src/
     rust/           Rust backend + expr_translator
     typescript/     TS backend + expr_translator
     jvm/            共通JVM層 + Kotlin/Java backends + expr_translator
+    swift/          Swift backend + expr_translator
     schema.rs       JSON Schema生成
   generate.rs       generateパイプライン
   check/            構造的整合性検証 (differ, impl_parser)
-  mine/             逆抽出 (rust/ts/kotlin/java/schema extractors, renderer)
+  mine/             逆抽出 (rust/ts/kotlin/java/swift/schema extractors, renderer)
 ```
 
 ## 技術スタック
@@ -80,7 +82,7 @@ src/
 ## 開発ワークフロー
 
 - main直push方式（現状）
-- CIパス必須: `cargo test` + セルフホスト generate/check (全4言語) + mine round-trip
+- CIパス必須: `cargo test` + セルフホスト generate/check (全5言語) + mine round-trip
 - コミットは各ステップの動作確認後に行う
 - zero warnings ポリシー
 
@@ -97,7 +99,7 @@ src/
 oxidtr自身のドメインモデル `models/oxidtr.als` を使った検証:
 
 ```bash
-# 全4言語で生成→check→0 diff
+# 全5言語で生成→check→0 diff
 cargo run -- generate models/oxidtr.als --target rust --output generated
 cargo run -- check --model models/oxidtr.als --impl generated
 
@@ -120,7 +122,7 @@ cargo run -- mine generated/ -o /tmp/mined.als
 | `parser_sig`, `parser_expr` | Alloyパーサー |
 | `lowering` | AST→IR変換 |
 | `expr_translator` | 式変換 (Rust) |
-| `backend_rust`, `backend_ts`, `backend_jvm` | 各言語コード生成 |
+| `backend_rust`, `backend_ts`, `backend_jvm`, `backend_swift` | 各言語コード生成 |
 | `test_generation`, `tc_generation` | テスト・TC関数生成 |
 | `generate_pipeline` | E2Eパイプライン + 警告検出 |
 | `check` | 構造的整合性検証 |
@@ -133,9 +135,9 @@ cargo run -- mine generated/ -o /tmp/mined.als
 |---|---|
 | `self_hosting` | パース・lower・生成・内容検査・mine sig coverage |
 | `self_host_guarantees` | fact→テスト変換・cross-testマーカー・mine/check整合性 |
-| `round_trip`, `round_trip_jvm`, `round_trip_enriched` | ラウンドトリップ検証 |
+| `round_trip`, `round_trip_jvm`, `round_trip_swift`, `round_trip_enriched` | ラウンドトリップ検証 |
 | `commentless_round_trip`, `lossless_round_trip` | コメントなし逆変換 |
-| `mine_rust`, `mine_ts` | mine抽出 (言語別) |
+| `mine_rust`, `mine_ts`, `mine_swift` | mine抽出 (言語別) |
 | `mine_auto_detect`, `mine_multi_lang` | mine自動検出・multi-lang merge |
 | `mine_new_patterns`, `mine_general_patterns` | 一般コードパターン抽出 |
 
@@ -154,7 +156,7 @@ cargo run -- mine generated/ -o /tmp/mined.als
 `local_docs/oxidtr-spec.md` の実装計画セクションを参照。
 
 主要な未実装:
-- Phase 7-10: Swift / Go / C# / Lean backends
+- Phase 8-10: Go / C# / Lean backends
 - Phase 11-13: Alloy 6 時相拡張 (var/always/eventually)
 - explore: Alloyインスタンス異常パターン検出
 - cover: カバレッジ×fact直交テスト生成

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ oxidtr takes an [Alloy](https://alloytools.org/) model (`.als`) as the single so
 - **Serde opt-in** — `#[derive(Serialize, Deserialize)]` with `--features serde`
 
 It also provides:
-- **Structural consistency checking** between Alloy models and implementations (Rust / TypeScript / Kotlin / Java), auto-detecting language
+- **Structural consistency checking** between Alloy models and implementations (Rust / TypeScript / Kotlin / Java / Swift), auto-detecting language
 - **Model mining** — extract Alloy model drafts from existing source code, JSON Schema, or mixed multi-language directories with conflict detection
 - **Lossless round-trip** — `@alloy:` comments preserve original expressions; reverse translation recovers Alloy from generated code
 
@@ -60,6 +60,7 @@ The parser handles the full Alloy structural grammar:
 | TypeScript | `--target ts` | interface, Set, Map, union | vitest + boundary | factory + boundary + violation | JSDoc + @alloy | — |
 | Kotlin | `--target kt` | data class, object, Set, Map, sealed/enum | JUnit 5 + boundary | factory + boundary + violation | KDoc + @alloy | @Size, @NotEmpty |
 | Java | `--target java` | record, Set, Map, sealed interface, enum | JUnit 5 + boundary | static factory + boundary + violation | Javadoc + @alloy | @NotNull, @Size, compact constructor |
+| Swift | `--target swift` | struct, Set, Array, enum w/ associated values | XCTest + boundary | factory + boundary + violation | Swift doc comments | CaseIterable, Equatable |
 
 ## Commands
 
@@ -72,6 +73,7 @@ oxidtr generate model.als --target rust --output generated/
 oxidtr generate model.als --target ts --output generated-ts/
 oxidtr generate model.als --target kt --output generated-kt/
 oxidtr generate model.als --target java --output generated-java/
+oxidtr generate model.als --target swift --output generated-swift/
 oxidtr generate model.als --target rust --output generated/ --features serde
 ```
 
@@ -89,7 +91,7 @@ Detects 7 structural warnings during generation:
 
 ### `oxidtr check`
 
-Verify structural consistency between an Alloy model and implementation. Auto-detects language by file presence (`models.rs` / `models.ts` / `Models.kt` / `Models.java`).
+Verify structural consistency between an Alloy model and implementation. Auto-detects language by file presence (`models.rs` / `models.ts` / `Models.kt` / `Models.java` / `Models.swift`).
 
 ```
 oxidtr check --model model.als --impl src/
@@ -108,7 +110,7 @@ oxidtr mine src/ --lang rust              # explicit language override
 oxidtr mine src/ --conflict error         # fail on cross-language conflicts
 ```
 
-Supports: `.rs` (Rust), `.ts` (TypeScript), `.kt` (Kotlin), `.java` (Java), `.json` (JSON Schema).
+Supports: `.rs` (Rust), `.ts` (TypeScript), `.kt` (Kotlin), `.java` (Java), `.swift` (Swift), `.json` (JSON Schema).
 
 Multi-language directories are merged: same-name sigs are unified, missing fields are supplemented, and conflicts (multiplicity/target type mismatches) are reported.
 
@@ -123,7 +125,7 @@ Produces Alloy `.als` text with:
 oxidtr's own domain is modeled in `models/oxidtr.als`. The full round-trip is verified for all targets:
 
 ```
-oxidtr.als → generate (Rust/TS/Kotlin/Java) → check → 0 diffs
+oxidtr.als → generate (Rust/TS/Kotlin/Java/Swift) → check → 0 diffs
 oxidtr.als → generate → mine → structural + expression match with original
 oxidtr.als → generate (all languages) → mine (multi-lang merge) → unified Alloy model
 ```
@@ -152,12 +154,12 @@ cargo run -- mine generated/
 | 6+ | Full Alloy parser (integers, set ops, product, fun, multi-var quantifiers, disj) |
 | 6+ | Complete conversion: Set/Seq distinction, singletons, concrete values, maps, boundaries, @alloy lossless round-trip |
 | 6+ | Multi-language mine merge with conflict detection |
+| 7 | Swift backend (struct/enum, XCTest, allSatisfy/contains, mine extractor) |
 
 ### Planned
 
 | Phase | Description | Target platforms |
 |---|---|---|
-| 7 | **Swift backend** | iOS / macOS / visionOS |
 | 8 | **Go backend** | Cloud-native / CLI / microservices |
 | 9 | **C# backend** | .NET / Unity / Blazor / Azure |
 | 10 | **Lean backend** (polarstar) | High-assurance domains |

--- a/models/oxidtr-internal.als
+++ b/models/oxidtr-internal.als
@@ -260,6 +260,7 @@ one sig RequiresTest    extends Guarantee {}
 
 abstract sig TargetLang {}
 one sig Rust       extends TargetLang {}
+one sig Swift      extends TargetLang {}
 one sig Kotlin     extends TargetLang {}
 one sig Java       extends TargetLang {}
 one sig TypeScript extends TargetLang {}

--- a/src/analyze/guarantee.rs
+++ b/src/analyze/guarantee.rs
@@ -5,7 +5,7 @@
 /// "Guarantee budget is constant. Stronger type systems reduce test generation;
 /// weaker ones increase it."
 ///
-/// Language strength ranking: Rust > Kotlin > Java > TypeScript
+/// Language strength ranking: Rust > Swift ≈ Kotlin > Java > TypeScript
 
 use super::ConstraintInfo;
 
@@ -24,6 +24,7 @@ pub enum Guarantee {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TargetLang {
     Rust,
+    Swift,
     Kotlin,
     Java,
     TypeScript,
@@ -34,6 +35,7 @@ impl TargetLang {
     pub fn from_target_str(s: &str) -> Option<Self> {
         match s {
             "rust" => Some(TargetLang::Rust),
+            "swift" => Some(TargetLang::Swift),
             "kotlin" | "kt" => Some(TargetLang::Kotlin),
             "java" => Some(TargetLang::Java),
             "typescript" | "ts" => Some(TargetLang::TypeScript),
@@ -46,7 +48,7 @@ impl TargetLang {
         // All languages default off. Use --schema to enable.
         // TS round-trip tests use --schema for lossless cardinality recovery.
         match self {
-            TargetLang::Rust | TargetLang::Kotlin | TargetLang::Java | TargetLang::TypeScript => false,
+            TargetLang::Rust | TargetLang::Swift | TargetLang::Kotlin | TargetLang::Java | TargetLang::TypeScript => false,
         }
     }
 }
@@ -66,7 +68,7 @@ pub fn can_guarantee_by_type(constraint: &ConstraintInfo, lang: TargetLang) -> G
         // Null safety via Option<T> (Rust) or T? (Kotlin)
         ConstraintInfo::Presence { kind: super::PresenceKind::Required, .. } => {
             match lang {
-                TargetLang::Rust | TargetLang::Kotlin => Guarantee::FullyByType,
+                TargetLang::Rust | TargetLang::Swift | TargetLang::Kotlin => Guarantee::FullyByType,
                 TargetLang::Java => Guarantee::PartiallyByType,
                 TargetLang::TypeScript => Guarantee::RequiresTest,
             }
@@ -74,7 +76,7 @@ pub fn can_guarantee_by_type(constraint: &ConstraintInfo, lang: TargetLang) -> G
         // Absence (no sig.field) — same pattern
         ConstraintInfo::Presence { kind: super::PresenceKind::Absent, .. } => {
             match lang {
-                TargetLang::Rust | TargetLang::Kotlin => Guarantee::FullyByType,
+                TargetLang::Rust | TargetLang::Swift | TargetLang::Kotlin => Guarantee::FullyByType,
                 TargetLang::Java => Guarantee::PartiallyByType,
                 TargetLang::TypeScript => Guarantee::RequiresTest,
             }
@@ -121,7 +123,7 @@ pub fn has_type_guarantee(constraints: &[ConstraintInfo], lang: TargetLang, sig_
 /// Rust (match), Kotlin (when), Java (switch) → FullyByType. TS → RequiresTest.
 pub fn enum_exhaustiveness_guarantee(lang: TargetLang) -> Guarantee {
     match lang {
-        TargetLang::Rust | TargetLang::Kotlin | TargetLang::Java => Guarantee::FullyByType,
+        TargetLang::Rust | TargetLang::Swift | TargetLang::Kotlin | TargetLang::Java => Guarantee::FullyByType,
         TargetLang::TypeScript => Guarantee::RequiresTest,
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,6 +1,7 @@
 pub mod rust;
 pub mod typescript;
 pub mod jvm;
+pub mod swift;
 pub mod schema;
 
 use crate::parser::ast::{Expr, CompareOp, QuantKind, Multiplicity};

--- a/src/backend/swift/expr_translator.rs
+++ b/src/backend/swift/expr_translator.rs
@@ -1,0 +1,284 @@
+use crate::parser::ast::*;
+use crate::ir::nodes::OxidtrIR;
+use std::collections::{HashSet, BTreeSet};
+
+/// TC field info.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TCField {
+    pub field_name: String,
+    pub sig_name: String,
+    pub mult: Multiplicity,
+}
+
+pub fn extract_tc_fields(expr: &Expr, ir: &OxidtrIR) -> Vec<TCField> {
+    let mut fields = Vec::new();
+    collect_tc_fields(expr, ir, &mut fields);
+    fields.sort_by(|a, b| a.field_name.cmp(&b.field_name));
+    fields.dedup();
+    fields
+}
+
+fn collect_tc_fields(expr: &Expr, ir: &OxidtrIR, out: &mut Vec<TCField>) {
+    match expr {
+        Expr::TransitiveClosure(inner) => {
+            if let Expr::FieldAccess { field, .. } = inner.as_ref() {
+                for s in &ir.structures {
+                    for f in &s.fields {
+                        if f.name == *field && f.target == s.name {
+                            out.push(TCField {
+                                field_name: field.clone(),
+                                sig_name: s.name.clone(),
+                                mult: f.mult.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+            collect_tc_fields(inner, ir, out);
+        }
+        Expr::FieldAccess { base, .. } => collect_tc_fields(base, ir, out),
+        Expr::Comparison { left, right, .. } | Expr::BinaryLogic { left, right, .. } => {
+            collect_tc_fields(left, ir, out);
+            collect_tc_fields(right, ir, out);
+        }
+        Expr::Not(inner) | Expr::Cardinality(inner) => collect_tc_fields(inner, ir, out),
+        Expr::Quantifier { bindings, body, .. } => {
+            for b in bindings { collect_tc_fields(&b.domain, ir, out); }
+            collect_tc_fields(body, ir, out);
+        }
+        Expr::SetOp { left, right, .. } | Expr::Product { left, right } => {
+            collect_tc_fields(left, ir, out);
+            collect_tc_fields(right, ir, out);
+        }
+        Expr::VarRef(_) | Expr::IntLiteral(_) => {}
+    }
+}
+
+pub fn collect_sig_names(ir: &OxidtrIR) -> HashSet<String> {
+    ir.structures.iter().map(|s| s.name.clone()).collect()
+}
+
+pub fn extract_params(expr: &Expr, sig_names: &HashSet<String>) -> Vec<(String, String)> {
+    let mut params = BTreeSet::new();
+    collect_params(expr, sig_names, &mut params);
+    params.into_iter().collect()
+}
+
+fn collect_params(expr: &Expr, sig_names: &HashSet<String>, params: &mut BTreeSet<(String, String)>) {
+    match expr {
+        Expr::Quantifier { bindings, body, .. } => {
+            for b in bindings {
+                if let Expr::VarRef(name) = &b.domain {
+                    if sig_names.contains(name) {
+                        params.insert((to_camel_plural(name), name.clone()));
+                    }
+                }
+                collect_params(&b.domain, sig_names, params);
+            }
+            collect_params(body, sig_names, params);
+        }
+        Expr::BinaryLogic { left, right, .. } | Expr::Comparison { left, right, .. }
+        | Expr::SetOp { left, right, .. } | Expr::Product { left, right } => {
+            collect_params(left, sig_names, params);
+            collect_params(right, sig_names, params);
+        }
+        Expr::Not(inner) | Expr::Cardinality(inner) | Expr::TransitiveClosure(inner) => {
+            collect_params(inner, sig_names, params);
+        }
+        Expr::FieldAccess { base, .. } => collect_params(base, sig_names, params),
+        Expr::VarRef(_) | Expr::IntLiteral(_) => {}
+    }
+}
+
+pub fn translate_with_ir(expr: &Expr, ir: &OxidtrIR) -> String {
+    let sig_names = collect_sig_names(ir);
+    translate_inner(expr, false, &sig_names, ir)
+}
+
+fn field_mult(field_name: &str, ir: &OxidtrIR) -> Option<(Multiplicity, bool)> {
+    for s in &ir.structures {
+        for f in &s.fields {
+            if f.name == field_name {
+                let is_self_ref = f.target == s.name;
+                return Some((f.mult.clone(), is_self_ref));
+            }
+        }
+    }
+    None
+}
+
+fn translate_inner(
+    expr: &Expr,
+    parens_if_complex: bool,
+    sig_names: &HashSet<String>,
+    ir: &OxidtrIR,
+) -> String {
+    let ti = |e: &Expr, p: bool| translate_inner(e, p, sig_names, ir);
+
+    let result = match expr {
+        Expr::IntLiteral(n) => n.to_string(),
+
+        Expr::VarRef(name) => name.clone(),
+
+        Expr::FieldAccess { base, field } => {
+            format!("{}.{field}", ti(base, false))
+        }
+
+        Expr::Cardinality(inner) => format!("{}.count", ti(inner, false)),
+
+        Expr::TransitiveClosure(inner) => {
+            if let Expr::FieldAccess { base, field } = inner.as_ref() {
+                format!("tc{}({})", capitalize(field), ti(base, false))
+            } else {
+                format!("transitiveClosure({})", ti(inner, false))
+            }
+        }
+
+        Expr::Comparison { op, left, right } => {
+            match op {
+                CompareOp::Eq => format!("{} == {}", ti(left, false), ti(right, false)),
+                CompareOp::NotEq => format!("{} != {}", ti(left, false), ti(right, false)),
+                CompareOp::Lt => format!("{} < {}", ti(left, false), ti(right, false)),
+                CompareOp::Gt => format!("{} > {}", ti(left, false), ti(right, false)),
+                CompareOp::Lte => format!("{} <= {}", ti(left, false), ti(right, false)),
+                CompareOp::Gte => format!("{} >= {}", ti(left, false), ti(right, false)),
+                CompareOp::In => {
+                    let l = ti(left, false);
+                    if let Expr::FieldAccess { base, field } = right.as_ref() {
+                        let r_base = ti(base, false);
+                        if let Some((Multiplicity::Lone, _)) = field_mult(field, ir) {
+                            return format!("{r_base}.{field} == {l}");
+                        }
+                    }
+                    let r = ti(right, false);
+                    format!("{r}.contains({l})")
+                }
+            }
+        }
+
+        Expr::BinaryLogic { op, left, right } => match op {
+            LogicOp::And     => format!("{} && {}", ti(left, false), ti(right, false)),
+            LogicOp::Or      => format!("{} || {}", ti(left, false), ti(right, false)),
+            LogicOp::Implies => format!("!{} || {}", ti(left, true), ti(right, false)),
+            LogicOp::Iff     => format!("{} == {}", ti(left, true), ti(right, true)),
+        },
+
+        Expr::Not(inner) => format!("!{}", ti(inner, true)),
+
+        Expr::Quantifier { kind, bindings, body } => {
+            let b = ti(body, false);
+            build_nested_quantifier(kind, bindings, &b, sig_names, ir)
+        }
+
+        Expr::SetOp { op, left, right } => {
+            let l = ti(left, false);
+            let r = ti(right, false);
+            match op {
+                SetOpKind::Union => format!("{l}.union({r})"),
+                SetOpKind::Intersection => format!("{l}.intersection({r})"),
+                SetOpKind::Difference => format!("{l}.subtracting({r})"),
+            }
+        }
+
+        Expr::Product { left, right } => {
+            let l = ti(left, false);
+            let r = ti(right, false);
+            format!("({l}, {r})")
+        }
+    };
+
+    if parens_if_complex && needs_parens(expr) {
+        format!("({result})")
+    } else {
+        result
+    }
+}
+
+fn build_nested_quantifier(
+    kind: &QuantKind,
+    bindings: &[QuantBinding],
+    body_str: &str,
+    sig_names: &HashSet<String>,
+    ir: &OxidtrIR,
+) -> String {
+    let mut vars: Vec<(String, String, bool)> = Vec::new();
+    for b in bindings {
+        let d = if let Expr::VarRef(name) = &b.domain {
+            if sig_names.contains(name) { to_camel_plural(name) }
+            else { name.clone() }
+        } else {
+            translate_inner(&b.domain, false, sig_names, ir)
+        };
+        for v in &b.vars {
+            vars.push((v.clone(), d.clone(), b.disj));
+        }
+    }
+
+    // Build disj checks
+    let mut disj_checks = Vec::new();
+    let mut i = 0;
+    while i < vars.len() {
+        if vars[i].2 {
+            let domain = &vars[i].1;
+            let start = i;
+            while i < vars.len() && vars[i].2 && vars[i].1 == *domain { i += 1; }
+            for a in start..i {
+                for b_idx in (a+1)..i {
+                    disj_checks.push(format!("{} != {}", vars[a].0, vars[b_idx].0));
+                }
+            }
+        } else { i += 1; }
+    }
+
+    let guarded_body = if disj_checks.is_empty() {
+        body_str.to_string()
+    } else {
+        let guard = disj_checks.join(" && ");
+        match kind {
+            QuantKind::All | QuantKind::No => format!("if ({guard}) {{ {body_str} }} else {{ true }}"),
+            QuantKind::Some => format!("{guard} && {body_str}"),
+        }
+    };
+
+    let mut result = guarded_body;
+    for idx in (0..vars.len()).rev() {
+        let (ref var, ref domain, _) = vars[idx];
+        result = match kind {
+            QuantKind::All => format!("{domain}.allSatisfy {{ {var} in {body} }}", body = result),
+            QuantKind::Some => format!("{domain}.contains {{ {var} in {body} }}", body = result),
+            QuantKind::No => {
+                if idx == 0 {
+                    format!("!{domain}.contains {{ {var} in {body} }}", body = result)
+                } else {
+                    format!("{domain}.contains {{ {var} in {body} }}", body = result)
+                }
+            }
+        };
+    }
+    result
+}
+
+fn needs_parens(expr: &Expr) -> bool {
+    matches!(expr, Expr::Comparison { .. } | Expr::BinaryLogic { .. } | Expr::Quantifier { .. })
+}
+
+fn to_camel_plural(name: &str) -> String {
+    let mut out = String::new();
+    for (i, c) in name.chars().enumerate() {
+        if i == 0 {
+            out.push(c.to_lowercase().next().unwrap());
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('s');
+    out
+}
+
+pub fn capitalize(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().to_string() + c.as_str(),
+    }
+}

--- a/src/backend/swift/mod.rs
+++ b/src/backend/swift/mod.rs
@@ -1,0 +1,752 @@
+pub mod expr_translator;
+
+use crate::backend::GeneratedFile;
+use crate::ir::nodes::*;
+use crate::parser::ast::{Multiplicity, SigMultiplicity};
+use crate::analyze;
+use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
+
+pub fn generate(ir: &OxidtrIR) -> Vec<GeneratedFile> {
+    let ctx = SwiftContext::from_ir(ir);
+    let mut files = Vec::new();
+
+    files.push(GeneratedFile {
+        path: "Models.swift".to_string(),
+        content: generate_models(ir, &ctx),
+    });
+
+    let has_tc = ir.constraints.iter().any(|c| expr_uses_tc(&c.expr))
+        || ir.properties.iter().any(|p| expr_uses_tc(&p.expr));
+
+    if has_tc {
+        files.push(GeneratedFile {
+            path: "Helpers.swift".to_string(),
+            content: generate_helpers(ir),
+        });
+    }
+
+    if !ir.operations.is_empty() {
+        files.push(GeneratedFile {
+            path: "Operations.swift".to_string(),
+            content: generate_operations(ir),
+        });
+    }
+
+    if !ir.properties.is_empty() || !ir.constraints.is_empty() {
+        files.push(GeneratedFile {
+            path: "Tests.swift".to_string(),
+            content: generate_tests(ir),
+        });
+    }
+
+    files.push(GeneratedFile {
+        path: "Fixtures.swift".to_string(),
+        content: generate_fixtures(ir, &ctx),
+    });
+
+    files
+}
+
+// ── Context ──────────────────────────────────────────────────────────────────
+
+struct SwiftContext {
+    children: HashMap<String, Vec<String>>,
+    variant_names: HashSet<String>,
+    struct_map: HashMap<String, StructureNode>,
+    cyclic_fields: HashSet<(String, String)>,
+}
+
+impl SwiftContext {
+    fn from_ir(ir: &OxidtrIR) -> Self {
+        let mut children: HashMap<String, Vec<String>> = HashMap::new();
+        for s in &ir.structures {
+            if let Some(parent) = &s.parent {
+                children.entry(parent.clone()).or_default().push(s.name.clone());
+            }
+        }
+        let enum_parents: HashSet<String> = ir.structures.iter()
+            .filter(|s| s.is_enum).map(|s| s.name.clone()).collect();
+        let variant_names: HashSet<String> = ir.structures.iter()
+            .filter(|s| s.parent.as_ref().map_or(false, |p| enum_parents.contains(p)))
+            .map(|s| s.name.clone()).collect();
+        let struct_map: HashMap<String, StructureNode> = ir.structures.iter()
+            .map(|s| (s.name.clone(), s.clone()))
+            .collect();
+        let cyclic_fields = find_cyclic_fields(ir);
+        SwiftContext { children, variant_names, struct_map, cyclic_fields }
+    }
+
+    fn is_variant(&self, name: &str) -> bool {
+        self.variant_names.contains(name)
+    }
+}
+
+fn find_cyclic_fields(ir: &OxidtrIR) -> HashSet<(String, String)> {
+    let mut result = HashSet::new();
+    let struct_map: HashMap<&str, &StructureNode> = ir.structures.iter()
+        .map(|s| (s.name.as_str(), s)).collect();
+    for s in &ir.structures {
+        for f in &s.fields {
+            if f.mult == Multiplicity::One && f.target == s.name {
+                result.insert((s.name.clone(), f.name.clone()));
+            }
+        }
+    }
+    // Also check indirect cycles via BFS
+    for s in &ir.structures {
+        for f in &s.fields {
+            if f.mult == Multiplicity::One && f.target != s.name {
+                let mut visited = HashSet::new();
+                let mut stack = vec![f.target.as_str()];
+                while let Some(cur) = stack.pop() {
+                    if cur == s.name {
+                        result.insert((s.name.clone(), f.name.clone()));
+                        break;
+                    }
+                    if !visited.insert(cur) { continue; }
+                    if let Some(target_s) = struct_map.get(cur) {
+                        for tf in &target_s.fields {
+                            if tf.mult == Multiplicity::One {
+                                stack.push(&tf.target);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    result
+}
+
+// ── Models.swift ─────────────────────────────────────────────────────────────
+
+fn generate_models(ir: &OxidtrIR, ctx: &SwiftContext) -> String {
+    let mut out = String::new();
+    writeln!(out, "import Foundation").unwrap();
+    writeln!(out).unwrap();
+
+    let disj_fields = analyze::disj_fields(ir);
+
+    for s in &ir.structures {
+        if ctx.is_variant(&s.name) { continue; }
+
+        let constraint_names = analyze::constraint_names_for_sig(ir, &s.name);
+        if !constraint_names.is_empty() {
+            writeln!(out, "/// Invariants:").unwrap();
+            for cn in &constraint_names {
+                writeln!(out, "/// - {cn}").unwrap();
+            }
+        }
+
+        if s.is_enum {
+            generate_enum(&mut out, s, ctx);
+        } else {
+            generate_struct(&mut out, s, ir, ctx, &disj_fields);
+        }
+        writeln!(out).unwrap();
+    }
+
+    out
+}
+
+fn generate_struct(out: &mut String, s: &StructureNode, ir: &OxidtrIR, ctx: &SwiftContext, disj_fields: &[(String, String)]) {
+    // Singleton: one sig → static let
+    if s.sig_multiplicity == SigMultiplicity::One && s.fields.is_empty() {
+        writeln!(out, "struct {} {{", s.name).unwrap();
+        writeln!(out, "    static let shared = {}()", s.name).unwrap();
+        writeln!(out, "}}").unwrap();
+        return;
+    }
+
+    if s.fields.is_empty() {
+        writeln!(out, "struct {}: Equatable, Hashable {{", s.name).unwrap();
+        writeln!(out, "}}").unwrap();
+    } else {
+        writeln!(out, "struct {}: Equatable {{", s.name).unwrap();
+        for f in &s.fields {
+            let type_str = if let Some(vt) = &f.value_type {
+                format!("[{}: {}]", f.target, vt)
+            } else {
+                mult_to_swift_type(&f.target, &f.mult, ctx.cyclic_fields.contains(&(s.name.clone(), f.name.clone())))
+            };
+
+            // Comments for special patterns
+            let target_mult = analyze::sig_multiplicity_for(ir, &f.target);
+            if target_mult == SigMultiplicity::Lone && f.mult == Multiplicity::One {
+                writeln!(out, "    // Note: lone sig target — may not exist").unwrap();
+            }
+            if disj_fields.iter().any(|(sig, field)| sig == &s.name && field == &f.name) {
+                if f.mult == Multiplicity::Seq {
+                    writeln!(out, "    // Consider using Set for uniqueness (disj constraint)").unwrap();
+                }
+            }
+
+            writeln!(out, "    let {}: {type_str}", to_swift_field_name(&f.name)).unwrap();
+        }
+        writeln!(out, "}}").unwrap();
+    }
+}
+
+fn generate_enum(out: &mut String, s: &StructureNode, ctx: &SwiftContext) {
+    let variants = ctx.children.get(&s.name);
+
+    // Check if all variants are unit (no fields)
+    let all_unit = variants.map_or(true, |vs| {
+        vs.iter().all(|v| ctx.struct_map.get(v).map_or(true, |st| st.fields.is_empty()))
+    });
+
+    if all_unit {
+        // Simple enum
+        writeln!(out, "enum {}: Equatable, Hashable, CaseIterable {{", s.name).unwrap();
+        if let Some(variants) = variants {
+            for v in variants {
+                writeln!(out, "    case {}", to_swift_case_name(v)).unwrap();
+            }
+        }
+        writeln!(out, "}}").unwrap();
+    } else {
+        // Enum with associated values
+        writeln!(out, "enum {}: Equatable {{", s.name).unwrap();
+        if let Some(variants) = variants {
+            for v in variants {
+                let child = ctx.struct_map.get(v.as_str());
+                let fields = child.map(|c| &c.fields).filter(|f| !f.is_empty());
+                if let Some(fields) = fields {
+                    let params: Vec<String> = fields.iter().map(|f| {
+                        let type_str = if let Some(vt) = &f.value_type {
+                            format!("[{}: {}]", f.target, vt)
+                        } else {
+                            mult_to_swift_type(&f.target, &f.mult, false)
+                        };
+                        format!("{}: {type_str}", to_swift_field_name(&f.name))
+                    }).collect();
+                    writeln!(out, "    case {}({})", to_swift_case_name(v), params.join(", ")).unwrap();
+                } else {
+                    writeln!(out, "    case {}", to_swift_case_name(v)).unwrap();
+                }
+            }
+        }
+        writeln!(out, "}}").unwrap();
+    }
+}
+
+fn mult_to_swift_type(target: &str, mult: &Multiplicity, is_indirect: bool) -> String {
+    let base = match mult {
+        Multiplicity::One => {
+            if is_indirect {
+                // Would need indirect/Box equivalent — use class or indirect enum
+                target.to_string()
+            } else {
+                target.to_string()
+            }
+        }
+        Multiplicity::Lone => format!("{target}?"),
+        Multiplicity::Set => format!("Set<{target}>"),
+        Multiplicity::Seq => format!("[{target}]"),
+    };
+    base
+}
+
+// ── Helpers.swift ────────────────────────────────────────────────────────────
+
+fn generate_helpers(ir: &OxidtrIR) -> String {
+    let mut out = String::new();
+    writeln!(out, "import Foundation").unwrap();
+    writeln!(out).unwrap();
+
+    let mut tc_fields = Vec::new();
+    for c in &ir.constraints {
+        tc_fields.extend(expr_translator::extract_tc_fields(&c.expr, ir));
+    }
+    for p in &ir.properties {
+        tc_fields.extend(expr_translator::extract_tc_fields(&p.expr, ir));
+    }
+    tc_fields.sort_by(|a, b| (&a.sig_name, &a.field_name).cmp(&(&b.sig_name, &b.field_name)));
+    tc_fields.dedup();
+
+    for tc in &tc_fields {
+        generate_tc_function(&mut out, tc);
+    }
+
+    out
+}
+
+fn generate_tc_function(out: &mut String, tc: &expr_translator::TCField) {
+    let fn_name = format!("tc{}", expr_translator::capitalize(&tc.field_name));
+    let sig = &tc.sig_name;
+    let field = &tc.field_name;
+
+    writeln!(out, "/// Transitive closure traversal for {sig}.{field}.").unwrap();
+    match tc.mult {
+        Multiplicity::Lone => {
+            writeln!(out, "func {fn_name}(_ start: {sig}) -> [{sig}] {{").unwrap();
+            writeln!(out, "    var result: [{sig}] = []").unwrap();
+            writeln!(out, "    var current: {sig}? = start.{field}").unwrap();
+            writeln!(out, "    while let node = current {{").unwrap();
+            writeln!(out, "        result.append(node)").unwrap();
+            writeln!(out, "        current = node.{field}").unwrap();
+            writeln!(out, "    }}").unwrap();
+            writeln!(out, "    return result").unwrap();
+            writeln!(out, "}}").unwrap();
+        }
+        Multiplicity::Set | Multiplicity::Seq => {
+            writeln!(out, "func {fn_name}(_ start: {sig}) -> [{sig}] {{").unwrap();
+            writeln!(out, "    var result: [{sig}] = []").unwrap();
+            writeln!(out, "    var queue = Array(start.{field})").unwrap();
+            writeln!(out, "    while !queue.isEmpty {{").unwrap();
+            writeln!(out, "        let next = queue.removeFirst()").unwrap();
+            writeln!(out, "        if !result.contains(next) {{").unwrap();
+            writeln!(out, "            result.append(next)").unwrap();
+            writeln!(out, "            queue.append(contentsOf: next.{field})").unwrap();
+            writeln!(out, "        }}").unwrap();
+            writeln!(out, "    }}").unwrap();
+            writeln!(out, "    return result").unwrap();
+            writeln!(out, "}}").unwrap();
+        }
+        Multiplicity::One => {
+            writeln!(out, "func {fn_name}(_ start: {sig}) -> [{sig}] {{").unwrap();
+            writeln!(out, "    var result: [{sig}] = []").unwrap();
+            writeln!(out, "    var current: {sig} = start.{field}").unwrap();
+            writeln!(out, "    for _ in 0..<1000 {{").unwrap();
+            writeln!(out, "        if result.contains(current) {{ return result }}").unwrap();
+            writeln!(out, "        result.append(current)").unwrap();
+            writeln!(out, "        current = current.{field}").unwrap();
+            writeln!(out, "    }}").unwrap();
+            writeln!(out, "    return result").unwrap();
+            writeln!(out, "}}").unwrap();
+        }
+    }
+    writeln!(out).unwrap();
+}
+
+// ── Operations.swift ─────────────────────────────────────────────────────────
+
+fn generate_operations(ir: &OxidtrIR) -> String {
+    let mut out = String::new();
+    writeln!(out, "import Foundation").unwrap();
+    writeln!(out).unwrap();
+
+    for op in &ir.operations {
+        let params = op.params.iter()
+            .map(|p| {
+                let type_str = match p.mult {
+                    Multiplicity::One => p.type_name.clone(),
+                    Multiplicity::Lone => format!("{}?", p.type_name),
+                    Multiplicity::Set => format!("Set<{}>", p.type_name),
+                    Multiplicity::Seq => format!("[{}]", p.type_name),
+                };
+                format!("_ {}: {type_str}", p.name)
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        // Doc comments from body expressions
+        if !op.body.is_empty() {
+            let param_names: Vec<String> = op.params.iter().map(|p| p.name.clone()).collect();
+            writeln!(out, "/// Operation: {}", op.name).unwrap();
+            for expr in &op.body {
+                let desc = analyze::describe_expr(expr);
+                let tag = if analyze::is_pre_condition(expr, &param_names) { "pre" } else { "post" };
+                writeln!(out, "/// - {tag}: {desc}").unwrap();
+            }
+        }
+
+        let return_str = match &op.return_type {
+            Some(rt) => format!(" -> {}", swift_return_type(&rt.type_name, &rt.mult)),
+            None => String::new(),
+        };
+
+        writeln!(out, "func {}({params}){return_str} {{", op.name).unwrap();
+        writeln!(out, "    fatalError(\"oxidtr: implement {}\")", op.name).unwrap();
+        writeln!(out, "}}").unwrap();
+        writeln!(out).unwrap();
+    }
+
+    out
+}
+
+// ── Tests.swift ──────────────────────────────────────────────────────────────
+
+fn generate_tests(ir: &OxidtrIR) -> String {
+    let mut out = String::new();
+    let sig_names = expr_translator::collect_sig_names(ir);
+
+    writeln!(out, "import XCTest").unwrap();
+    writeln!(out).unwrap();
+    writeln!(out, "final class PropertyTests: XCTestCase {{").unwrap();
+
+    for prop in &ir.properties {
+        let params = expr_translator::extract_params(&prop.expr, &sig_names);
+        let body = expr_translator::translate_with_ir(&prop.expr, ir);
+
+        writeln!(out, "    func test_{}() {{", to_snake_case(&prop.name)).unwrap();
+        for (pname, tname) in &params {
+            writeln!(out, "        let {pname}: [{tname}] = []").unwrap();
+        }
+        writeln!(out, "        XCTAssertTrue({body})").unwrap();
+        writeln!(out, "    }}").unwrap();
+        writeln!(out).unwrap();
+    }
+
+    // Swift has strong null safety (T?) — skip tests for null-safety constraints
+    let all_constraints = analyze::analyze(ir);
+    for constraint in &ir.constraints {
+        let fact_name = match &constraint.name {
+            Some(name) => name.clone(),
+            None => continue,
+        };
+        let params = expr_translator::extract_params(&constraint.expr, &sig_names);
+        let body = expr_translator::translate_with_ir(&constraint.expr, ir);
+
+        // Check if all related constraints are type-guaranteed in Swift
+        use crate::analyze::guarantee::{can_guarantee_by_type, Guarantee, TargetLang};
+        let sig_constraints: Vec<_> = params.iter()
+            .flat_map(|(_, tname)| {
+                all_constraints.iter().filter(move |c| match c {
+                    analyze::ConstraintInfo::Presence { sig_name, .. } => sig_name == tname,
+                    analyze::ConstraintInfo::CardinalityBound { sig_name, .. } => sig_name == tname,
+                    _ => false,
+                })
+            })
+            .collect();
+
+        let all_fully = !sig_constraints.is_empty() && sig_constraints.iter().all(|c| {
+            can_guarantee_by_type(c, TargetLang::Swift) == Guarantee::FullyByType
+        });
+
+        if all_fully {
+            writeln!(out, "    // Type-guaranteed: {} — Swift type system handles this", fact_name).unwrap();
+            writeln!(out).unwrap();
+            continue;
+        }
+
+        writeln!(out, "    func test_invariant_{}() {{", to_snake_case(&fact_name)).unwrap();
+        for (pname, tname) in &params {
+            writeln!(out, "        let {pname}: [{tname}] = []").unwrap();
+        }
+        writeln!(out, "        XCTAssertTrue({body})").unwrap();
+        writeln!(out, "    }}").unwrap();
+        writeln!(out).unwrap();
+    }
+
+    // Boundary value tests
+    for constraint in &ir.constraints {
+        let fact_name = match &constraint.name {
+            Some(name) => name.clone(),
+            None => continue,
+        };
+        let params = expr_translator::extract_params(&constraint.expr, &sig_names);
+        let body = expr_translator::translate_with_ir(&constraint.expr, ir);
+
+        let has_boundary = params.iter().any(|(_, tname)| {
+            ir.structures.iter().any(|s| {
+                s.name == *tname && !s.is_enum && s.fields.iter().any(|f| {
+                    matches!(f.mult, Multiplicity::Set | Multiplicity::Seq)
+                        && analyze::bounds_for_field(ir, &s.name, &f.name).is_some()
+                })
+            })
+        });
+
+        if has_boundary {
+            writeln!(out, "    func test_boundary_{}() {{", to_snake_case(&fact_name)).unwrap();
+            for (pname, tname) in &params {
+                let has_b = ir.structures.iter().any(|s| {
+                    s.name == *tname && s.fields.iter().any(|f| {
+                        matches!(f.mult, Multiplicity::Set | Multiplicity::Seq)
+                            && analyze::bounds_for_field(ir, &s.name, &f.name).is_some()
+                    })
+                });
+                if has_b {
+                    writeln!(out, "        let {pname}: [{tname}] = [boundary{tname}()]").unwrap();
+                } else {
+                    writeln!(out, "        let {pname}: [{tname}] = []").unwrap();
+                }
+            }
+            writeln!(out, "        XCTAssertTrue({body})").unwrap();
+            writeln!(out, "    }}").unwrap();
+            writeln!(out).unwrap();
+
+            writeln!(out, "    func test_invalid_{}() {{", to_snake_case(&fact_name)).unwrap();
+            for (pname, tname) in &params {
+                let has_b = ir.structures.iter().any(|s| {
+                    s.name == *tname && s.fields.iter().any(|f| {
+                        matches!(f.mult, Multiplicity::Set | Multiplicity::Seq)
+                            && analyze::bounds_for_field(ir, &s.name, &f.name).is_some()
+                    })
+                });
+                if has_b {
+                    writeln!(out, "        let {pname}: [{tname}] = [invalid{tname}()]").unwrap();
+                } else {
+                    writeln!(out, "        let {pname}: [{tname}] = []").unwrap();
+                }
+            }
+            writeln!(out, "        XCTAssertFalse(!({body}))").unwrap();
+            writeln!(out, "    }}").unwrap();
+            writeln!(out).unwrap();
+        }
+    }
+
+    // Cross-tests
+    if !ir.constraints.is_empty() && !ir.operations.is_empty() {
+        writeln!(out, "    // --- Cross-tests: fact x operation ---").unwrap();
+        writeln!(out).unwrap();
+        for constraint in &ir.constraints {
+            let fact_name = match &constraint.name { Some(n) => n.clone(), None => continue };
+            let body = expr_translator::translate_with_ir(&constraint.expr, ir);
+            let fact_snake = to_snake_case(&fact_name);
+            for op in &ir.operations {
+                writeln!(out, "    /// oxidtr: implement cross-test").unwrap();
+                writeln!(out, "    func disabled_test_{fact_snake}_preserved_after_{}() {{", op.name).unwrap();
+                writeln!(out, "        // pre: XCTAssertTrue({body})").unwrap();
+                writeln!(out, "        // {}(...)", op.name).unwrap();
+                writeln!(out, "        // post: XCTAssertTrue({body})").unwrap();
+                writeln!(out, "        XCTFail(\"oxidtr: implement cross-test\")").unwrap();
+                writeln!(out, "    }}").unwrap();
+                writeln!(out).unwrap();
+            }
+        }
+    }
+
+    writeln!(out, "}}").unwrap();
+    out
+}
+
+// ── Fixtures.swift ───────────────────────────────────────────────────────────
+
+fn generate_fixtures(ir: &OxidtrIR, ctx: &SwiftContext) -> String {
+    let mut out = String::new();
+    writeln!(out, "import Foundation").unwrap();
+    writeln!(out).unwrap();
+
+    let fixture_types = super::collect_fixture_types(ir);
+
+    // Generate enum default fixtures
+    {
+        let children: HashMap<String, Vec<String>> = {
+            let mut map: HashMap<String, Vec<String>> = HashMap::new();
+            for s in &ir.structures {
+                if let Some(parent) = &s.parent {
+                    map.entry(parent.clone()).or_default().push(s.name.clone());
+                }
+            }
+            map
+        };
+        for s in &ir.structures {
+            if !s.is_enum { continue; }
+            let variants = match children.get(&s.name) {
+                Some(v) if !v.is_empty() => v,
+                _ => continue,
+            };
+            let first_unit = variants.iter().find(|v| {
+                ctx.struct_map.get(v.as_str()).map_or(true, |st| st.fields.is_empty())
+            });
+            if let Some(variant) = first_unit {
+                let all_unit = variants.iter().all(|v| {
+                    ctx.struct_map.get(v.as_str()).map_or(true, |st| st.fields.is_empty())
+                });
+                if all_unit {
+                    writeln!(out, "/// Factory: default value for {}", s.name).unwrap();
+                    writeln!(out, "func default{}() -> {} {{ .{} }}", s.name, s.name, to_swift_case_name(variant)).unwrap();
+                    writeln!(out).unwrap();
+                } else {
+                    let has_fields = ctx.struct_map.get(variant.as_str())
+                        .map_or(false, |st| !st.fields.is_empty());
+                    if !has_fields {
+                        writeln!(out, "/// Factory: default value for {}", s.name).unwrap();
+                        writeln!(out, "func default{}() -> {} {{ .{} }}", s.name, s.name, to_swift_case_name(variant)).unwrap();
+                        writeln!(out).unwrap();
+                    }
+                }
+            }
+        }
+    }
+
+    for s in &ir.structures {
+        if ctx.is_variant(&s.name) || s.is_enum { continue; }
+        if s.fields.is_empty() { continue; }
+
+        writeln!(out, "/// Factory: create a default valid {}", s.name).unwrap();
+        writeln!(out, "func default{}() -> {} {{", s.name, s.name).unwrap();
+        writeln!(out, "    {}(", s.name).unwrap();
+        for (i, f) in s.fields.iter().enumerate() {
+            let val = if f.value_type.is_some() {
+                "[:]".to_string()
+            } else if matches!(f.mult, Multiplicity::Set | Multiplicity::Seq)
+                && super::is_safe_set_population(&s.name, &f.target, ir, &fixture_types) {
+                let safe = HashSet::from([f.target.clone()]);
+                swift_default_value_inner(&f.target, &f.mult, &safe)
+            } else {
+                swift_default_value(&f.target, &f.mult)
+            };
+            let comma = if i < s.fields.len() - 1 { "," } else { "" };
+            writeln!(out, "        {}: {val}{comma}", to_swift_field_name(&f.name)).unwrap();
+        }
+        writeln!(out, "    )").unwrap();
+        writeln!(out, "}}").unwrap();
+        writeln!(out).unwrap();
+
+        // Boundary value fixtures
+        let has_bounds = s.fields.iter().any(|f| {
+            matches!(f.mult, Multiplicity::Set | Multiplicity::Seq)
+                && analyze::bounds_for_field(ir, &s.name, &f.name).is_some()
+        });
+        if has_bounds {
+            writeln!(out, "/// Factory: create {} at cardinality boundary", s.name).unwrap();
+            writeln!(out, "func boundary{}() -> {} {{", s.name, s.name).unwrap();
+            writeln!(out, "    {}(", s.name).unwrap();
+            for (i, f) in s.fields.iter().enumerate() {
+                let comma = if i < s.fields.len() - 1 { "," } else { "" };
+                let val = if f.value_type.is_some() {
+                    "[:]".to_string()
+                } else if matches!(f.mult, Multiplicity::Set | Multiplicity::Seq) {
+                    if let Some(bound) = analyze::bounds_for_field(ir, &s.name, &f.name) {
+                        let count = match &bound {
+                            analyze::BoundKind::Exact(n) => *n,
+                            analyze::BoundKind::AtMost(n) => *n,
+                            analyze::BoundKind::AtLeast(n) => *n,
+                        };
+                        swift_boundary_value(&f.target, &f.mult, count)
+                    } else {
+                        swift_default_value(&f.target, &f.mult)
+                    }
+                } else {
+                    swift_default_value(&f.target, &f.mult)
+                };
+                writeln!(out, "        {}: {val}{comma}", to_swift_field_name(&f.name)).unwrap();
+            }
+            writeln!(out, "    )").unwrap();
+            writeln!(out, "}}").unwrap();
+            writeln!(out).unwrap();
+
+            writeln!(out, "/// Factory: create {} that violates cardinality constraint", s.name).unwrap();
+            writeln!(out, "func invalid{}() -> {} {{", s.name, s.name).unwrap();
+            writeln!(out, "    {}(", s.name).unwrap();
+            for (i, f) in s.fields.iter().enumerate() {
+                let comma = if i < s.fields.len() - 1 { "," } else { "" };
+                let val = if f.value_type.is_some() {
+                    "[:]".to_string()
+                } else if matches!(f.mult, Multiplicity::Set | Multiplicity::Seq) {
+                    if let Some(bound) = analyze::bounds_for_field(ir, &s.name, &f.name) {
+                        let violation = match &bound {
+                            analyze::BoundKind::Exact(n) => n + 1,
+                            analyze::BoundKind::AtMost(n) => n + 1,
+                            analyze::BoundKind::AtLeast(n) => if *n > 0 { n - 1 } else { 0 },
+                        };
+                        swift_boundary_value(&f.target, &f.mult, violation)
+                    } else {
+                        swift_default_value(&f.target, &f.mult)
+                    }
+                } else {
+                    swift_default_value(&f.target, &f.mult)
+                };
+                writeln!(out, "        {}: {val}{comma}", to_swift_field_name(&f.name)).unwrap();
+            }
+            writeln!(out, "    )").unwrap();
+            writeln!(out, "}}").unwrap();
+            writeln!(out).unwrap();
+        }
+    }
+
+    out
+}
+
+fn swift_boundary_value(target: &str, mult: &Multiplicity, count: usize) -> String {
+    match mult {
+        Multiplicity::Set => {
+            let items: Vec<String> = (0..count).map(|_| format!("default{target}()")).collect();
+            if items.is_empty() {
+                "Set()".to_string()
+            } else {
+                format!("Set([{}])", items.join(", "))
+            }
+        }
+        Multiplicity::Seq => {
+            let items: Vec<String> = (0..count).map(|_| format!("default{target}()")).collect();
+            if items.is_empty() {
+                "[]".to_string()
+            } else {
+                format!("[{}]", items.join(", "))
+            }
+        }
+        _ => swift_default_value(target, mult),
+    }
+}
+
+fn swift_return_type(type_name: &str, mult: &Multiplicity) -> String {
+    match mult {
+        Multiplicity::One => type_name.to_string(),
+        Multiplicity::Lone => format!("{type_name}?"),
+        Multiplicity::Set => format!("Set<{type_name}>"),
+        Multiplicity::Seq => format!("[{type_name}]"),
+    }
+}
+
+fn swift_default_value(target: &str, mult: &Multiplicity) -> String {
+    swift_default_value_inner(target, mult, &HashSet::new())
+}
+
+fn swift_default_value_inner(target: &str, mult: &Multiplicity, safe_targets: &HashSet<String>) -> String {
+    match mult {
+        Multiplicity::Lone => "nil".to_string(),
+        Multiplicity::Set => {
+            if safe_targets.contains(target) {
+                format!("Set([default{target}()])")
+            } else {
+                "Set()".to_string()
+            }
+        }
+        Multiplicity::Seq => {
+            if safe_targets.contains(target) {
+                format!("[default{target}()]")
+            } else {
+                "[]".to_string()
+            }
+        }
+        Multiplicity::One => format!("default{target}()"),
+    }
+}
+
+// ── Naming helpers ───────────────────────────────────────────────────────────
+
+fn to_swift_field_name(name: &str) -> &str {
+    // Swift uses camelCase for properties — Alloy field names are already camelCase
+    name
+}
+
+fn to_swift_case_name(name: &str) -> String {
+    // Enum case names in Swift are lowerCamelCase
+    let mut chars = name.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => format!("{}{}", c.to_lowercase(), chars.as_str()),
+    }
+}
+
+fn to_snake_case(name: &str) -> String {
+    let mut result = String::new();
+    for (i, c) in name.chars().enumerate() {
+        if c.is_uppercase() && i > 0 {
+            result.push('_');
+        }
+        result.push(c.to_lowercase().next().unwrap());
+    }
+    result
+}
+
+fn expr_uses_tc(expr: &crate::parser::ast::Expr) -> bool {
+    use crate::parser::ast::Expr;
+    match expr {
+        Expr::TransitiveClosure(_) => true,
+        Expr::FieldAccess { base, .. } => expr_uses_tc(base),
+        Expr::Cardinality(inner) | Expr::Not(inner) => expr_uses_tc(inner),
+        Expr::Comparison { left, right, .. } | Expr::BinaryLogic { left, right, .. }
+        | Expr::SetOp { left, right, .. } | Expr::Product { left, right } => {
+            expr_uses_tc(left) || expr_uses_tc(right)
+        }
+        Expr::Quantifier { bindings, body, .. } => {
+            bindings.iter().any(|b| expr_uses_tc(&b.domain)) || expr_uses_tc(body)
+        }
+        Expr::VarRef(_) | Expr::IntLiteral(_) => false,
+    }
+}

--- a/src/backend/swift/mod.rs
+++ b/src/backend/swift/mod.rs
@@ -421,7 +421,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
             continue;
         }
 
-        writeln!(out, "    func test_invariant_{}() {{", to_snake_case(&fact_name)).unwrap();
+        writeln!(out, "    func test_invariant_{}() {{", fact_name).unwrap();
         for (pname, tname) in &params {
             writeln!(out, "        let {pname}: [{tname}] = []").unwrap();
         }
@@ -449,7 +449,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
         });
 
         if has_boundary {
-            writeln!(out, "    func test_boundary_{}() {{", to_snake_case(&fact_name)).unwrap();
+            writeln!(out, "    func test_boundary_{}() {{", fact_name).unwrap();
             for (pname, tname) in &params {
                 let has_b = ir.structures.iter().any(|s| {
                     s.name == *tname && s.fields.iter().any(|f| {
@@ -467,7 +467,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
             writeln!(out, "    }}").unwrap();
             writeln!(out).unwrap();
 
-            writeln!(out, "    func test_invalid_{}() {{", to_snake_case(&fact_name)).unwrap();
+            writeln!(out, "    func test_invalid_{}() {{", fact_name).unwrap();
             for (pname, tname) in &params {
                 let has_b = ir.structures.iter().any(|s| {
                     s.name == *tname && s.fields.iter().any(|f| {
@@ -494,10 +494,9 @@ fn generate_tests(ir: &OxidtrIR) -> String {
         for constraint in &ir.constraints {
             let fact_name = match &constraint.name { Some(n) => n.clone(), None => continue };
             let body = expr_translator::translate_with_ir(&constraint.expr, ir);
-            let fact_snake = to_snake_case(&fact_name);
             for op in &ir.operations {
                 writeln!(out, "    /// oxidtr: implement cross-test").unwrap();
-                writeln!(out, "    func disabled_test_{fact_snake}_preserved_after_{}() {{", op.name).unwrap();
+                writeln!(out, "    func disabled_test_{fact_name}_preserved_after_{}() {{", op.name).unwrap();
                 writeln!(out, "        // pre: XCTAssertTrue({body})").unwrap();
                 writeln!(out, "        // {}(...)", op.name).unwrap();
                 writeln!(out, "        // post: XCTAssertTrue({body})").unwrap();

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -76,6 +76,10 @@ pub fn run(model_path: &str, config: &CheckConfig) -> Result<CheckResult, CheckE
         let extracted = extract_mined(impl_dir, "Models.java", "Operations.java", mine::java_extractor::extract)?;
         let validation_sources = collect_validation_sources_jvm(impl_dir, "Tests.java")?;
         differ::diff_identity_with_validation(&ir, &extracted, &validation_sources)
+    } else if impl_dir.join("Models.swift").exists() {
+        let extracted = extract_mined(impl_dir, "Models.swift", "Operations.swift", mine::swift_extractor::extract)?;
+        let validation_sources = collect_validation_sources_swift(impl_dir)?;
+        differ::diff_identity_with_validation(&ir, &extracted, &validation_sources)
     } else if impl_dir.join("models.rs").exists() {
         let (extracted, validation_sources) = extract_rust(impl_dir)?;
         differ::diff_with_validation(&ir, &extracted, &validation_sources)
@@ -90,7 +94,7 @@ pub fn run(model_path: &str, config: &CheckConfig) -> Result<CheckResult, CheckE
             }
             Err(_) => {
                 return Err(CheckError::ImplNotFound(
-                    "no recognized source files found (tried models.rs, models.ts, Models.kt, Models.java, and general mine)".to_string()
+                    "no recognized source files found (tried models.rs, models.ts, Models.kt, Models.java, Models.swift, and general mine)".to_string()
                 ));
             }
         }
@@ -151,6 +155,16 @@ fn collect_validation_sources_jvm(impl_dir: &Path, tests_file: &str) -> Result<V
     let models_kt_path = impl_dir.join("Models.kt");
     if models_kt_path.exists() {
         sources.push(std::fs::read_to_string(&models_kt_path)?);
+    }
+    Ok(sources)
+}
+
+/// Collect validation source texts from Swift impl directory.
+fn collect_validation_sources_swift(impl_dir: &Path) -> Result<Vec<String>, CheckError> {
+    let mut sources = Vec::new();
+    let tests_path = impl_dir.join("Tests.swift");
+    if tests_path.exists() {
+        sources.push(std::fs::read_to_string(&tests_path)?);
     }
     Ok(sources)
 }
@@ -268,9 +282,11 @@ fn extract_fns_generic(src: &str) -> Vec<ExtractedFn> {
         // TS: "export function name(" / "function name("
         // Kotlin: "fun name("
         // Java: "public static void name(" / "public static boolean name("
+        // Swift: "func name("
         let rest = trimmed.strip_prefix("export function ")
             .or_else(|| trimmed.strip_prefix("function "))
             .or_else(|| trimmed.strip_prefix("fun "))
+            .or_else(|| trimmed.strip_prefix("func "))
             .or_else(|| {
                 // Java: after "public static <return_type> " or "static <return_type> "
                 let after = if trimmed.starts_with("public static ") {

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -5,6 +5,7 @@ use crate::backend::rust;
 use crate::backend::typescript;
 use crate::backend::typescript::{TsTestRunner, TsBackendConfig};
 use crate::backend::jvm::{kotlin, java};
+use crate::backend::swift;
 use crate::backend::schema;
 use crate::analyze::guarantee::TargetLang;
 
@@ -144,6 +145,7 @@ pub fn run(input_path: &str, config: &GenerateConfig) -> Result<GenerateResult, 
         }
         "kotlin" | "kt" => kotlin::generate(&ir),
         "java" => java::generate(&ir),
+        "swift" => swift::generate(&ir),
         other => {
             return Err(GenerateError::ParseError(parser::ParseError::InvalidSyntax {
                 message: format!("unsupported target: {other}"),

--- a/src/mine/mod.rs
+++ b/src/mine/mod.rs
@@ -2,6 +2,7 @@ pub mod rust_extractor;
 pub mod ts_extractor;
 pub mod kotlin_extractor;
 pub mod java_extractor;
+pub mod swift_extractor;
 pub mod schema_extractor;
 pub mod renderer;
 
@@ -19,6 +20,7 @@ pub fn detect_lang(path: &Path) -> Option<String> {
         if path.join("Models.kt").exists() { return Some("kt".to_string()); }
         if path.join("Models.java").exists() { return Some("java".to_string()); }
         if path.join("models.rs").exists() { return Some("rust".to_string()); }
+        if path.join("Models.swift").exists() { return Some("swift".to_string()); }
         if path.join("schemas.json").exists() { return Some("schema".to_string()); }
 
         // Scan for any matching extension
@@ -40,6 +42,7 @@ fn detect_lang_from_file(path: &Path) -> Option<String> {
         "ts" => Some("ts".to_string()),
         "kt" => Some("kotlin".to_string()),
         "java" => Some("java".to_string()),
+        "swift" => Some("swift".to_string()),
         "json" => Some("schema".to_string()),
         _ => None,
     }
@@ -141,6 +144,9 @@ fn detect_all_langs(dir: &Path) -> Vec<(String, Vec<std::path::PathBuf>)> {
 
     let java_files = collect_files(dir, "java");
     if !java_files.is_empty() { result.push(("java".to_string(), java_files)); }
+
+    let swift_files = collect_files(dir, "swift");
+    if !swift_files.is_empty() { result.push(("swift".to_string(), swift_files)); }
 
     // JSON Schema as supplemental
     let schema_path = dir.join("schemas.json");
@@ -259,6 +265,7 @@ fn mine_directory(dir: &Path, lang: &str) -> Result<MinedModel, String> {
         "typescript" | "ts" => collect_files(dir, "ts"),
         "kotlin" | "kt" => collect_files(dir, "kt"),
         "java" => collect_files(dir, "java"),
+        "swift" => collect_files(dir, "swift"),
         "schema" | "json" => {
             let schema_path = dir.join("schemas.json");
             if schema_path.exists() { vec![schema_path] } else { collect_files(dir, "json") }
@@ -309,6 +316,7 @@ fn extract_with_lang(content: &str, lang: &str) -> Result<MinedModel, String> {
         "typescript" | "ts" => Ok(ts_extractor::extract(content)),
         "kotlin" | "kt" => Ok(kotlin_extractor::extract(content)),
         "java" => Ok(java_extractor::extract(content)),
+        "swift" => Ok(swift_extractor::extract(content)),
         "schema" | "json" => Ok(schema_extractor::extract(content)),
         other => Err(format!("unsupported language: {other}")),
     }

--- a/src/mine/swift_extractor.rs
+++ b/src/mine/swift_extractor.rs
@@ -1,0 +1,677 @@
+/// Extracts Alloy model candidates from Swift source code.
+/// Handles: struct → sig, enum → abstract sig,
+/// T? → lone, Set<T> → set, [T] → seq, T → one.
+
+use super::*;
+
+pub fn extract(source: &str) -> MinedModel {
+    let mut sigs = Vec::new();
+    let mut fact_candidates = Vec::new();
+    let mut lines = source.lines().enumerate().peekable();
+
+    while let Some((line_num, line)) = lines.next() {
+        let trimmed = line.trim();
+
+        // struct Foo: ... { → sig
+        if let Some(name) = parse_struct(trimmed) {
+            let fields = collect_struct_fields(&mut lines);
+            sigs.push(MinedSig {
+                name,
+                fields,
+                is_abstract: false,
+                parent: None,
+                source_location: format!("line {}", line_num + 1),
+            });
+        }
+
+        // enum Foo: ... { → abstract sig
+        if let Some(name) = parse_enum(trimmed) {
+            let (variants, variant_sigs) = collect_enum_cases(&name, &mut lines);
+            sigs.push(MinedSig {
+                name: name.clone(),
+                fields: vec![],
+                is_abstract: true,
+                parent: None,
+                source_location: format!("line {}", line_num + 1),
+            });
+            for vs in variant_sigs {
+                sigs.push(vs);
+            }
+            let _ = variants;
+        }
+
+        // Function bodies: extract general patterns
+        if trimmed.starts_with("func ") {
+            let body = collect_block(&mut lines);
+            extract_swift_facts(&body, line_num, &mut fact_candidates);
+        }
+    }
+
+    MinedModel { sigs, fact_candidates }
+}
+
+fn parse_struct(line: &str) -> Option<String> {
+    let rest = line.strip_prefix("struct ")?;
+    let name: String = rest.chars().take_while(|c| c.is_alphanumeric() || *c == '_').collect();
+    if name.is_empty() { return None; }
+    // Must have { somewhere (not a forward declaration)
+    if !line.contains('{') { return None; }
+    Some(name)
+}
+
+fn parse_enum(line: &str) -> Option<String> {
+    // "enum Foo" or "enum Foo: ..." or "enum Foo {"
+    let rest = line.strip_prefix("enum ")?;
+    let name: String = rest.chars().take_while(|c| c.is_alphanumeric() || *c == '_').collect();
+    if name.is_empty() { return None; }
+    Some(name)
+}
+
+fn collect_struct_fields(
+    lines: &mut std::iter::Peekable<std::iter::Enumerate<std::str::Lines<'_>>>,
+) -> Vec<MinedField> {
+    let mut fields = Vec::new();
+    let mut depth = 1usize;
+
+    for (_ln, line) in lines.by_ref() {
+        let trimmed = line.trim();
+        for ch in trimmed.chars() {
+            match ch { '{' => depth += 1, '}' => depth -= 1, _ => {} }
+        }
+        if depth == 0 { break; }
+
+        // "let name: Type" or "var name: Type"
+        if let Some(field) = parse_swift_property(trimmed) {
+            fields.push(field);
+        }
+    }
+
+    fields
+}
+
+fn parse_swift_property(line: &str) -> Option<MinedField> {
+    let rest = line.strip_prefix("let ")
+        .or_else(|| line.strip_prefix("var "))?;
+    let colon = rest.find(':')?;
+    let name = rest[..colon].trim().to_string();
+    if name.is_empty() || name.contains(' ') { return None; }
+
+    let type_part = rest[colon + 1..].trim();
+    // Remove default value assignment
+    let type_str = if let Some(eq_pos) = type_part.find('=') {
+        type_part[..eq_pos].trim()
+    } else {
+        type_part
+    };
+    // Remove trailing comments
+    let type_str = if let Some(comment_pos) = type_str.find("//") {
+        type_str[..comment_pos].trim()
+    } else {
+        type_str
+    };
+
+    let (mult, target) = swift_type_to_mult(type_str);
+    Some(MinedField { name, mult, target })
+}
+
+fn swift_type_to_mult(swift_type: &str) -> (MinedMultiplicity, String) {
+    let t = swift_type.trim();
+
+    // T? → lone
+    if let Some(inner) = t.strip_suffix('?') {
+        return (MinedMultiplicity::Lone, inner.to_string());
+    }
+
+    // Set<T> → set
+    if let Some(inner) = strip_wrapper(t, "Set<", ">") {
+        return (MinedMultiplicity::Set, inner.to_string());
+    }
+
+    // [K: V] → set (dictionary → map, key as target)
+    if t.starts_with('[') && t.ends_with(']') && t.contains(':') {
+        let inner = &t[1..t.len()-1];
+        let key = inner.split(':').next().unwrap_or(inner).trim();
+        return (MinedMultiplicity::Set, key.to_string());
+    }
+
+    // [T] → seq
+    if t.starts_with('[') && t.ends_with(']') {
+        let inner = &t[1..t.len()-1];
+        return (MinedMultiplicity::Seq, inner.trim().to_string());
+    }
+
+    // Array<T> → seq
+    if let Some(inner) = strip_wrapper(t, "Array<", ">") {
+        return (MinedMultiplicity::Seq, inner.to_string());
+    }
+
+    (MinedMultiplicity::One, t.to_string())
+}
+
+fn strip_wrapper<'a>(s: &'a str, prefix: &str, suffix: &str) -> Option<&'a str> {
+    s.strip_prefix(prefix)?.strip_suffix(suffix)
+}
+
+fn collect_enum_cases(
+    parent_name: &str,
+    lines: &mut std::iter::Peekable<std::iter::Enumerate<std::str::Lines<'_>>>,
+) -> (Vec<String>, Vec<MinedSig>) {
+    let mut variant_names = Vec::new();
+    let mut variant_sigs = Vec::new();
+    let mut depth = 1usize;
+
+    for (ln, line) in lines.by_ref() {
+        let trimmed = line.trim();
+        for ch in trimmed.chars() {
+            match ch { '{' => depth += 1, '}' => depth -= 1, _ => {} }
+        }
+        if depth == 0 { break; }
+
+        // "case variantName" or "case variantName(params)"
+        if let Some(rest) = trimmed.strip_prefix("case ") {
+            let name: String = rest.chars().take_while(|c| c.is_alphanumeric() || *c == '_').collect();
+            if name.is_empty() { continue; }
+            // PascalCase the variant name for Alloy sig
+            let pascal_name = capitalize(&name);
+
+            let fields = if rest.contains('(') {
+                extract_case_params(rest)
+            } else {
+                vec![]
+            };
+
+            variant_names.push(pascal_name.clone());
+            variant_sigs.push(MinedSig {
+                name: pascal_name,
+                fields,
+                is_abstract: false,
+                parent: Some(parent_name.to_string()),
+                source_location: format!("line {}", ln + 1),
+            });
+        }
+    }
+
+    (variant_names, variant_sigs)
+}
+
+fn extract_case_params(line: &str) -> Vec<MinedField> {
+    let open = match line.find('(') { Some(p) => p + 1, None => return vec![] };
+    let close = match line.rfind(')') { Some(p) => p, None => return vec![] };
+    if open >= close { return vec![]; }
+
+    let params = &line[open..close];
+    params.split(',')
+        .filter_map(|p| {
+            let p = p.trim();
+            // "name: Type" — may have label
+            let colon = p.find(':')?;
+            let name = p[..colon].trim().to_string();
+            // Remove external label if present (e.g., "_ name: Type")
+            let name = name.rsplit_once(' ').map_or(name.as_str(), |(_, n)| n).to_string();
+            if name.is_empty() { return None; }
+            let type_str = p[colon + 1..].trim();
+            let (mult, target) = swift_type_to_mult(type_str);
+            Some(MinedField { name, mult, target })
+        })
+        .collect()
+}
+
+fn collect_block(
+    lines: &mut std::iter::Peekable<std::iter::Enumerate<std::str::Lines<'_>>>,
+) -> Vec<(usize, String)> {
+    let mut body = Vec::new();
+    let mut depth = 1usize;
+    for (ln, line) in lines.by_ref() {
+        let trimmed = line.trim();
+        for ch in trimmed.chars() {
+            match ch { '{' => depth += 1, '}' => depth -= 1, _ => {} }
+        }
+        if depth == 0 { break; }
+        body.push((ln, trimmed.to_string()));
+    }
+    body
+}
+
+fn extract_swift_facts(
+    body: &[(usize, String)],
+    _context_line: usize,
+    facts: &mut Vec<MinedFactCandidate>,
+) {
+    for (ln, line) in body {
+        let loc = format!("line {}", ln + 1);
+
+        // .contains() checks
+        if line.contains(".contains(") {
+            facts.push(MinedFactCandidate {
+                alloy_text: extract_contains_fact(line),
+                confidence: Confidence::Medium,
+                source_location: loc.clone(),
+                source_pattern: ".contains() check".to_string(),
+            });
+        }
+
+        // .isEmpty / !xxx.isEmpty
+        if line.contains(".isEmpty") {
+            facts.push(MinedFactCandidate {
+                alloy_text: "-- emptiness check".to_string(),
+                confidence: Confidence::Medium,
+                source_location: loc.clone(),
+                source_pattern: ".isEmpty check".to_string(),
+            });
+        }
+
+        // guard let / guard ... else — presence constraint
+        if line.starts_with("guard let ") || line.starts_with("guard ") {
+            facts.push(MinedFactCandidate {
+                alloy_text: "-- guard constraint".to_string(),
+                confidence: Confidence::Medium,
+                source_location: loc.clone(),
+                source_pattern: "guard".to_string(),
+            });
+        }
+
+        // precondition() / assert()
+        if line.contains("precondition(") || line.contains("assert(") {
+            let cond = extract_swift_validation_condition(line);
+            facts.push(MinedFactCandidate {
+                alloy_text: cond,
+                confidence: Confidence::High,
+                source_location: loc.clone(),
+                source_pattern: "precondition/assert".to_string(),
+            });
+        }
+
+        // if let — optional binding → lone
+        if line.contains("if let ") {
+            if let Some(field) = extract_if_let_field(line) {
+                facts.push(MinedFactCandidate {
+                    alloy_text: format!("{field} is lone (optional)"),
+                    confidence: Confidence::Medium,
+                    source_location: loc.clone(),
+                    source_pattern: "if let binding".to_string(),
+                });
+            }
+        }
+
+        // Force unwrap ! → one (non-null assertion)
+        if line.contains("!.") || (line.contains('!') && !line.contains("!=")) {
+            facts.push(MinedFactCandidate {
+                alloy_text: "-- force unwrap (review)".to_string(),
+                confidence: Confidence::Low,
+                source_location: loc.clone(),
+                source_pattern: "force unwrap".to_string(),
+            });
+        }
+
+        // switch — exhaustiveness
+        if line.contains("switch ") {
+            facts.push(MinedFactCandidate {
+                alloy_text: "-- enum exhaustiveness (switch)".to_string(),
+                confidence: Confidence::Medium,
+                source_location: loc.clone(),
+                source_pattern: "switch exhaustiveness".to_string(),
+            });
+        }
+
+        // .filter / .map — subset/projection
+        if line.contains(".filter(") || line.contains(".filter {") {
+            if let Some(collection) = extract_collection_before(line, ".filter") {
+                facts.push(MinedFactCandidate {
+                    alloy_text: format!("-- subset of {collection}"),
+                    confidence: Confidence::Low,
+                    source_location: loc.clone(),
+                    source_pattern: "filter subset".to_string(),
+                });
+            }
+        }
+
+        // fatalError / preconditionFailure
+        if (line.contains("fatalError(") || line.contains("preconditionFailure("))
+            && !line.contains("guard") {
+            facts.push(MinedFactCandidate {
+                alloy_text: "-- precondition guard (review)".to_string(),
+                confidence: Confidence::Low,
+                source_location: loc.clone(),
+                source_pattern: "fatalError/preconditionFailure".to_string(),
+            });
+        }
+    }
+}
+
+fn extract_swift_validation_condition(line: &str) -> String {
+    let keyword = if line.contains("precondition(") { "precondition(" } else { "assert(" };
+    if let Some(start) = line.find(keyword) {
+        let rest = &line[start + keyword.len()..];
+        let mut depth = 0;
+        let mut end = rest.len();
+        for (i, ch) in rest.chars().enumerate() {
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    if depth == 0 { end = i; break; }
+                    depth -= 1;
+                }
+                _ => {}
+            }
+        }
+        let cond = rest[..end].trim();
+        // Remove message part after comma (e.g., precondition(cond, "msg"))
+        let cond = if let Some(comma) = find_top_level_comma(cond) {
+            cond[..comma].trim()
+        } else {
+            cond
+        };
+        if !cond.is_empty() {
+            return translate_swift_condition(cond);
+        }
+    }
+    "-- precondition".to_string()
+}
+
+fn translate_swift_condition(cond: &str) -> String {
+    let mut result = cond.to_string();
+    if result.contains(".count ") {
+        if let Some(pos) = result.find(".count ") {
+            let before = &result[..pos];
+            let after = &result[pos + 6..];
+            result = format!("#{before}{after}");
+        }
+    }
+    if result.contains("!.isEmpty") {
+        if let Some(pos) = result.find("!.isEmpty") {
+            let before = &result[1..pos]; // skip leading !
+            return format!("some {before}");
+        }
+    }
+    if result.contains(".isEmpty") {
+        if let Some(pos) = result.find(".isEmpty") {
+            let field = &result[..pos];
+            return format!("no {field}");
+        }
+    }
+    result
+}
+
+fn extract_if_let_field(line: &str) -> Option<String> {
+    let rest = line.strip_prefix("if let ")?;
+    let eq = rest.find('=')?;
+    let _binding = rest[..eq].trim();
+    let rhs = rest[eq + 1..].trim();
+    // Get the first identifier chain
+    let field: String = rhs.chars().take_while(|c| c.is_alphanumeric() || *c == '_' || *c == '.').collect();
+    if field.is_empty() { None } else { Some(field) }
+}
+
+fn extract_contains_fact(line: &str) -> String {
+    if let Some(pos) = line.find(".contains(") {
+        let before = line[..pos].trim();
+        let after_paren = pos + ".contains(".len();
+        let rest = &line[after_paren..];
+        let end = rest.find(')').unwrap_or(rest.len());
+        let arg = rest[..end].trim();
+        format!("{arg} in {before}")
+    } else {
+        "-- contains check (review)".to_string()
+    }
+}
+
+fn extract_collection_before(line: &str, method: &str) -> Option<String> {
+    let pos = line.find(method)?;
+    let before = line[..pos].trim();
+    let collection = before.rsplit(|c: char| c == ' ' || c == '=' || c == '(' || c == '{').next().unwrap_or(before).trim();
+    if collection.is_empty() { None } else { Some(collection.to_string()) }
+}
+
+fn find_top_level_comma(s: &str) -> Option<usize> {
+    let mut depth = 0i32;
+    for (i, ch) in s.chars().enumerate() {
+        match ch {
+            '(' | '{' | '[' => depth += 1,
+            ')' | '}' | ']' => depth -= 1,
+            ',' if depth == 0 => return Some(i),
+            _ => {}
+        }
+    }
+    None
+}
+
+fn capitalize(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().to_string() + c.as_str(),
+    }
+}
+
+/// Reverse-translate a Swift expression back to Alloy syntax.
+pub fn reverse_translate_expr(code_line: &str) -> Option<String> {
+    let s = code_line.trim();
+    if s.is_empty() { return None; }
+
+    let s = strip_balanced_parens(s);
+
+    // tcField(base) → base.^field
+    if let Some(result) = try_reverse_tc_call(s) {
+        return Some(result);
+    }
+
+    // !xxx.contains { v in body } → no v: Xxx | body
+    if s.starts_with('!') {
+        let inner = &s[1..];
+        if let Some(result) = try_reverse_contains_closure(inner, "no") {
+            return Some(result);
+        }
+    }
+
+    // .allSatisfy { v in body } → all v: Xxx | body
+    if let Some(result) = try_reverse_all_satisfy(s) {
+        return Some(result);
+    }
+
+    // .contains { v in body } → some v: Xxx | body
+    if let Some(result) = try_reverse_contains_closure(s, "some") {
+        return Some(result);
+    }
+
+    // .contains(v) → v in xxx
+    if let Some(result) = try_reverse_contains(s) {
+        return Some(result);
+    }
+
+    // .count → #xxx
+    if let Some(result) = try_reverse_count(s) {
+        return Some(result);
+    }
+
+    // Comparison operators
+    if let Some(result) = try_reverse_comparison(s) {
+        return Some(result);
+    }
+
+    // Boolean logic
+    if let Some(result) = try_reverse_logic(s) {
+        return Some(result);
+    }
+
+    // Integer literals
+    if s.chars().all(|c| c.is_ascii_digit()) && !s.is_empty() {
+        return Some(s.to_string());
+    }
+
+    // Variable references and field access chains
+    if s.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '.') && !s.is_empty() {
+        return Some(s.to_string());
+    }
+
+    None
+}
+
+fn strip_balanced_parens(s: &str) -> &str {
+    let s = s.trim();
+    if !s.starts_with('(') || !s.ends_with(')') { return s; }
+    let inner = &s[1..s.len() - 1];
+    let mut depth = 0i32;
+    for ch in inner.chars() {
+        match ch { '(' => depth += 1, ')' => { depth -= 1; if depth < 0 { return s; } } _ => {} }
+    }
+    if depth == 0 { inner.trim() } else { s }
+}
+
+fn try_reverse_tc_call(s: &str) -> Option<String> {
+    let rest = s.strip_prefix("tc")?;
+    if rest.is_empty() || !rest.chars().next()?.is_ascii_uppercase() { return None; }
+    let paren = rest.find('(')?;
+    let field_pascal = &rest[..paren];
+    let field = {
+        let mut chars = field_pascal.chars();
+        match chars.next() {
+            None => return None,
+            Some(c) => format!("{}{}", c.to_lowercase(), chars.as_str()),
+        }
+    };
+    let close = find_matching_close(&rest[paren + 1..])?;
+    let args = &rest[paren + 1..paren + 1 + close];
+    let base_alloy = reverse_translate_expr(args.trim()).unwrap_or_else(|| args.trim().to_string());
+    Some(format!("{base_alloy}.^{field}"))
+}
+
+fn try_reverse_all_satisfy(s: &str) -> Option<String> {
+    let pos = s.find(".allSatisfy { ")?;
+    let collection = s[..pos].trim();
+    let rest = &s[pos + ".allSatisfy { ".len()..];
+    let (var, body) = extract_swift_closure(rest)?;
+    let body_alloy = reverse_translate_expr(body).unwrap_or_else(|| body.to_string());
+    Some(format!("all {var}: {collection} | {body_alloy}"))
+}
+
+fn try_reverse_contains_closure(s: &str, quant: &str) -> Option<String> {
+    let pos = s.find(".contains { ")?;
+    let collection = s[..pos].trim();
+    let rest = &s[pos + ".contains { ".len()..];
+    let (var, body) = extract_swift_closure(rest)?;
+    let body_alloy = reverse_translate_expr(body).unwrap_or_else(|| body.to_string());
+    Some(format!("{quant} {var}: {collection} | {body_alloy}"))
+}
+
+fn extract_swift_closure(s: &str) -> Option<(&str, &str)> {
+    // "v in body }"
+    let in_pos = s.find(" in ")?;
+    let var = s[..in_pos].trim();
+    let body_start = in_pos + 4;
+    let body_rest = &s[body_start..];
+    let mut depth = 0i32;
+    let mut end = body_rest.len();
+    for (i, ch) in body_rest.chars().enumerate() {
+        match ch {
+            '{' | '(' => depth += 1,
+            '}' | ')' => {
+                if ch == '}' && depth == 0 { end = i; break; }
+                depth -= 1;
+            }
+            _ => {}
+        }
+    }
+    let body = body_rest[..end].trim();
+    if var.is_empty() || body.is_empty() { return None; }
+    Some((var, body))
+}
+
+fn try_reverse_contains(s: &str) -> Option<String> {
+    let pos = s.find(".contains(")?;
+    let collection = s[..pos].trim();
+    let rest = &s[pos + ".contains(".len()..];
+    let end = find_matching_close(rest)?;
+    let element = rest[..end].trim();
+    let element_alloy = reverse_translate_expr(element).unwrap_or_else(|| element.to_string());
+    let collection_alloy = reverse_translate_expr(collection).unwrap_or_else(|| collection.to_string());
+    Some(format!("{element_alloy} in {collection_alloy}"))
+}
+
+fn try_reverse_count(s: &str) -> Option<String> {
+    let pos = s.rfind(".count")?;
+    let after = &s[pos + 6..];
+    if !after.is_empty() && !after.starts_with(' ') { return None; }
+    let inner = s[..pos].trim();
+    let inner_alloy = reverse_translate_expr(inner).unwrap_or_else(|| inner.to_string());
+    Some(format!("#{inner_alloy}"))
+}
+
+fn try_reverse_comparison(s: &str) -> Option<String> {
+    for (swift_op, alloy_op) in &[(" == ", " = "), (" != ", " != "), (" <= ", " <= "),
+                                    (" >= ", " >= "), (" < ", " < "), (" > ", " > ")] {
+        if let Some(pos) = find_top_level_op(s, swift_op) {
+            let left = s[..pos].trim();
+            let right = s[pos + swift_op.len()..].trim();
+            let l = reverse_translate_expr(left).unwrap_or_else(|| left.to_string());
+            let r = reverse_translate_expr(right).unwrap_or_else(|| right.to_string());
+            return Some(format!("{l}{alloy_op}{r}"));
+        }
+    }
+    None
+}
+
+fn try_reverse_logic(s: &str) -> Option<String> {
+    if s.starts_with('!') {
+        let inner = &s[1..];
+        if let Some(pos) = find_top_level_op(inner, " || ") {
+            let a = strip_balanced_parens(inner[..pos].trim());
+            let b = inner[pos + 4..].trim();
+            let a_alloy = reverse_translate_expr(a).unwrap_or_else(|| a.to_string());
+            let b_alloy = reverse_translate_expr(b).unwrap_or_else(|| b.to_string());
+            return Some(format!("{a_alloy} implies {b_alloy}"));
+        }
+    }
+    if let Some(pos) = find_top_level_op(s, " && ") {
+        let left = s[..pos].trim();
+        let right = s[pos + 4..].trim();
+        let l = reverse_translate_expr(left).unwrap_or_else(|| left.to_string());
+        let r = reverse_translate_expr(right).unwrap_or_else(|| right.to_string());
+        return Some(format!("{l} and {r}"));
+    }
+    if let Some(pos) = find_top_level_op(s, " || ") {
+        let left = s[..pos].trim();
+        let right = s[pos + 4..].trim();
+        let l = reverse_translate_expr(left).unwrap_or_else(|| left.to_string());
+        let r = reverse_translate_expr(right).unwrap_or_else(|| right.to_string());
+        return Some(format!("{l} or {r}"));
+    }
+    if s.starts_with('!') {
+        let inner = s[1..].trim();
+        let inner_alloy = reverse_translate_expr(inner).unwrap_or_else(|| inner.to_string());
+        return Some(format!("not {inner_alloy}"));
+    }
+    None
+}
+
+fn find_top_level_op(s: &str, pattern: &str) -> Option<usize> {
+    let mut depth = 0i32;
+    let bytes = s.as_bytes();
+    let pat_bytes = pattern.as_bytes();
+    if pat_bytes.len() > bytes.len() { return None; }
+    for i in 0..=bytes.len() - pat_bytes.len() {
+        match bytes[i] {
+            b'(' | b'{' | b'[' => depth += 1,
+            b')' | b'}' | b']' => depth -= 1,
+            _ => {}
+        }
+        if depth == 0 && &bytes[i..i + pat_bytes.len()] == pat_bytes {
+            return Some(i);
+        }
+    }
+    None
+}
+
+fn find_matching_close(s: &str) -> Option<usize> {
+    let mut depth = 0i32;
+    for (i, ch) in s.chars().enumerate() {
+        match ch {
+            '(' | '{' => depth += 1,
+            ')' | '}' => {
+                if depth == 0 { return Some(i); }
+                depth -= 1;
+            }
+            _ => {}
+        }
+    }
+    None
+}

--- a/tests/backend_swift.rs
+++ b/tests/backend_swift.rs
@@ -1,0 +1,184 @@
+use oxidtr::parser;
+use oxidtr::ir;
+use oxidtr::backend::swift;
+use oxidtr::backend::GeneratedFile;
+
+fn generate_swift(input: &str) -> Vec<GeneratedFile> {
+    let model = parser::parse(input).expect("parse");
+    let ir = ir::lower(&model).expect("lower");
+    swift::generate(&ir)
+}
+
+fn find_file<'a>(files: &'a [GeneratedFile], path: &str) -> &'a str {
+    files.iter().find(|f| f.path == path)
+        .map(|f| f.content.as_str())
+        .unwrap_or_else(|| panic!("file {path} not found"))
+}
+
+// ── Models.swift ─────────────────────────────────────────────────────────────
+
+#[test]
+fn swift_struct_for_sig() {
+    let files = generate_swift("sig User { name: one Role }\nsig Role {}");
+    let m = find_file(&files, "Models.swift");
+    assert!(m.contains("struct User: Equatable {"));
+    assert!(m.contains("let name: Role"));
+}
+
+#[test]
+fn swift_optional_for_lone() {
+    let files = generate_swift("sig Node { parent: lone Node }");
+    let m = find_file(&files, "Models.swift");
+    assert!(m.contains("let parent: Node?"));
+}
+
+#[test]
+fn swift_set_for_set() {
+    let files = generate_swift("sig Group { members: set User }\nsig User {}");
+    let m = find_file(&files, "Models.swift");
+    assert!(m.contains("let members: Set<User>"));
+}
+
+#[test]
+fn swift_array_for_seq() {
+    let files = generate_swift("sig Order { items: seq Item }\nsig Item {}");
+    let m = find_file(&files, "Models.swift");
+    assert!(m.contains("let items: [Item]"));
+}
+
+#[test]
+fn swift_enum_for_all_singleton() {
+    let files = generate_swift(
+        "abstract sig Color {}\none sig Red extends Color {}\none sig Blue extends Color {}",
+    );
+    let m = find_file(&files, "Models.swift");
+    assert!(m.contains("enum Color: Equatable, Hashable, CaseIterable {"));
+    assert!(m.contains("case red"));
+    assert!(m.contains("case blue"));
+}
+
+#[test]
+fn swift_enum_with_associated_values() {
+    let files = generate_swift(
+        "abstract sig Expr {}\nsig Literal extends Expr {}\nsig BinOp extends Expr { left: one Expr, right: one Expr }",
+    );
+    let m = find_file(&files, "Models.swift");
+    assert!(m.contains("enum Expr: Equatable {"));
+    assert!(m.contains("case binOp(left: Expr, right: Expr)"));
+    assert!(m.contains("case literal"));
+}
+
+// ── Operations.swift ─────────────────────────────────────────────────────────
+
+#[test]
+fn swift_operations_use_fatalerror() {
+    let files = generate_swift("sig User {}\nsig Role {}\npred changeRole[u: one User, r: one Role] { u = u }");
+    let ops = find_file(&files, "Operations.swift");
+    assert!(ops.contains("func changeRole("));
+    assert!(ops.contains("fatalError("));
+}
+
+#[test]
+fn swift_operations_return_type() {
+    let files = generate_swift("sig User {}\nfun findUser[name: one User]: one User { name = name }");
+    let ops = find_file(&files, "Operations.swift");
+    assert!(ops.contains("-> User"));
+}
+
+// ── Tests.swift ──────────────────────────────────────────────────────────────
+
+#[test]
+fn swift_tests_inline_constraint_expressions() {
+    let files = generate_swift(
+        "sig User { roles: set Role }\nsig Role {}\nfact AllUsersHaveRoles { all u: User | #u.roles > 0 }",
+    );
+    let t = find_file(&files, "Tests.swift");
+    assert!(t.contains("XCTAssertTrue("));
+    assert!(t.contains(".allSatisfy"));
+}
+
+#[test]
+fn swift_tests_generated_properly() {
+    // Constraint with cardinality check — Swift should generate test
+    let files = generate_swift(
+        "sig User { roles: set Role }\nsig Role {}\nfact UserHasRoles { all u: User | #u.roles > 0 }",
+    );
+    let t = find_file(&files, "Tests.swift");
+    assert!(t.contains("func test_invariant_"));
+    assert!(t.contains("XCTAssertTrue("));
+}
+
+// ── Fixtures.swift ───────────────────────────────────────────────────────────
+
+#[test]
+fn swift_fixtures_generated() {
+    let files = generate_swift("sig User { name: one Role, group: lone Group }\nsig Role {}\nsig Group {}");
+    let f = find_file(&files, "Fixtures.swift");
+    assert!(f.contains("func defaultUser()"));
+    assert!(f.contains("-> User"));
+    assert!(f.contains("nil"));
+}
+
+#[test]
+fn swift_fixtures_enum_default() {
+    let files = generate_swift(
+        "abstract sig Color {}\none sig Red extends Color {}\none sig Blue extends Color {}",
+    );
+    let f = find_file(&files, "Fixtures.swift");
+    assert!(f.contains("func defaultColor()"));
+    assert!(f.contains(".red"));
+}
+
+#[test]
+fn swift_fixtures_boundary() {
+    let files = generate_swift(
+        "sig Team { members: set User }\nsig User {}\nfact TeamSize { all t: Team | #t.members <= 5 }",
+    );
+    let f = find_file(&files, "Fixtures.swift");
+    assert!(f.contains("func boundaryTeam()"));
+    assert!(f.contains("func invalidTeam()"));
+}
+
+// ── Helpers.swift ────────────────────────────────────────────────────────────
+
+#[test]
+fn swift_helpers_for_tc() {
+    let files = generate_swift(
+        "sig Node { parent: lone Node }\nassert Acyclic { all n: Node | not (n in n.^parent) }",
+    );
+    let h = files.iter().find(|f| f.path == "Helpers.swift");
+    assert!(h.is_some(), "Helpers.swift should be generated for TC");
+    let h = h.unwrap();
+    assert!(h.content.contains("func tcParent("));
+    assert!(h.content.contains("while let node = current"));
+}
+
+// ── Cross-tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn swift_cross_tests_are_disabled() {
+    let files = generate_swift(
+        "sig User { name: one Role }\nsig Role {}\nfact F { all u: User | u = u }\npred doSomething[u: one User] { u = u }",
+    );
+    let t = find_file(&files, "Tests.swift");
+    if t.contains("Cross-tests") {
+        assert!(t.contains("disabled_test_"), "Swift cross-tests should be disabled via naming convention");
+    }
+}
+
+// ── Import statements ────────────────────────────────────────────────────────
+
+#[test]
+fn swift_models_import_foundation() {
+    let files = generate_swift("sig User {}");
+    let m = find_file(&files, "Models.swift");
+    assert!(m.contains("import Foundation"));
+}
+
+#[test]
+fn swift_tests_import_xctest() {
+    let files = generate_swift("sig User {}\nassert P { all u: User | u = u }");
+    let t = find_file(&files, "Tests.swift");
+    assert!(t.contains("import XCTest"));
+    assert!(t.contains("XCTestCase"));
+}

--- a/tests/guarantee_differentiation.rs
+++ b/tests/guarantee_differentiation.rs
@@ -36,6 +36,7 @@ fn guarantee_null_safety_varies_by_language() {
         kind: PresenceKind::Required,
     };
     assert_eq!(can_guarantee_by_type(&c, TargetLang::Rust), Guarantee::FullyByType);
+    assert_eq!(can_guarantee_by_type(&c, TargetLang::Swift), Guarantee::FullyByType);
     assert_eq!(can_guarantee_by_type(&c, TargetLang::Kotlin), Guarantee::FullyByType);
     assert_eq!(can_guarantee_by_type(&c, TargetLang::Java), Guarantee::PartiallyByType);
     assert_eq!(can_guarantee_by_type(&c, TargetLang::TypeScript), Guarantee::RequiresTest);
@@ -49,6 +50,7 @@ fn guarantee_cardinality_varies_by_language() {
         bound: BoundKind::AtMost(5),
     };
     assert_eq!(can_guarantee_by_type(&c, TargetLang::Rust), Guarantee::PartiallyByType);
+    assert_eq!(can_guarantee_by_type(&c, TargetLang::Swift), Guarantee::RequiresTest);
     assert_eq!(can_guarantee_by_type(&c, TargetLang::Kotlin), Guarantee::RequiresTest);
     assert_eq!(can_guarantee_by_type(&c, TargetLang::Java), Guarantee::RequiresTest);
     assert_eq!(can_guarantee_by_type(&c, TargetLang::TypeScript), Guarantee::RequiresTest);
@@ -60,7 +62,7 @@ fn guarantee_no_self_ref_always_requires_test() {
         sig_name: "Node".to_string(),
         field_name: "parent".to_string(),
     };
-    for lang in [TargetLang::Rust, TargetLang::Kotlin, TargetLang::Java, TargetLang::TypeScript] {
+    for lang in [TargetLang::Rust, TargetLang::Swift, TargetLang::Kotlin, TargetLang::Java, TargetLang::TypeScript] {
         assert_eq!(can_guarantee_by_type(&c, lang), Guarantee::RequiresTest);
     }
 }
@@ -71,7 +73,7 @@ fn guarantee_acyclicity_always_requires_test() {
         sig_name: "Node".to_string(),
         field_name: "parent".to_string(),
     };
-    for lang in [TargetLang::Rust, TargetLang::Kotlin, TargetLang::Java, TargetLang::TypeScript] {
+    for lang in [TargetLang::Rust, TargetLang::Swift, TargetLang::Kotlin, TargetLang::Java, TargetLang::TypeScript] {
         assert_eq!(can_guarantee_by_type(&c, lang), Guarantee::RequiresTest);
     }
 }
@@ -79,6 +81,7 @@ fn guarantee_acyclicity_always_requires_test() {
 #[test]
 fn guarantee_enum_exhaustiveness_by_language() {
     assert_eq!(enum_exhaustiveness_guarantee(TargetLang::Rust), Guarantee::FullyByType);
+    assert_eq!(enum_exhaustiveness_guarantee(TargetLang::Swift), Guarantee::FullyByType);
     assert_eq!(enum_exhaustiveness_guarantee(TargetLang::Kotlin), Guarantee::FullyByType);
     assert_eq!(enum_exhaustiveness_guarantee(TargetLang::Java), Guarantee::FullyByType);
     assert_eq!(enum_exhaustiveness_guarantee(TargetLang::TypeScript), Guarantee::RequiresTest);

--- a/tests/mine_swift.rs
+++ b/tests/mine_swift.rs
@@ -1,0 +1,134 @@
+use oxidtr::mine::swift_extractor;
+use oxidtr::mine::{MinedMultiplicity, Confidence};
+
+#[test]
+fn swift_extract_struct() {
+    let model = swift_extractor::extract(r#"
+struct User: Equatable {
+    let name: String
+    let age: Int
+}
+"#);
+    assert_eq!(model.sigs.len(), 1);
+    let sig = &model.sigs[0];
+    assert_eq!(sig.name, "User");
+    assert_eq!(sig.fields.len(), 2);
+    assert_eq!(sig.fields[0].name, "name");
+    assert_eq!(sig.fields[0].target, "String");
+    assert_eq!(sig.fields[0].mult, MinedMultiplicity::One);
+}
+
+#[test]
+fn swift_extract_optional() {
+    let model = swift_extractor::extract(r#"
+struct Node: Equatable {
+    let parent: Node?
+}
+"#);
+    let sig = &model.sigs[0];
+    let f = &sig.fields[0];
+    assert_eq!(f.mult, MinedMultiplicity::Lone);
+    assert_eq!(f.target, "Node");
+}
+
+#[test]
+fn swift_extract_set() {
+    let model = swift_extractor::extract(r#"
+struct Group: Equatable {
+    let members: Set<User>
+}
+"#);
+    let f = &model.sigs[0].fields[0];
+    assert_eq!(f.mult, MinedMultiplicity::Set);
+    assert_eq!(f.target, "User");
+}
+
+#[test]
+fn swift_extract_array() {
+    let model = swift_extractor::extract(r#"
+struct Order: Equatable {
+    let items: [Item]
+}
+"#);
+    let f = &model.sigs[0].fields[0];
+    assert_eq!(f.mult, MinedMultiplicity::Seq);
+    assert_eq!(f.target, "Item");
+}
+
+#[test]
+fn swift_extract_enum() {
+    let model = swift_extractor::extract(r#"
+enum Status: Equatable, Hashable, CaseIterable {
+    case active
+    case inactive
+}
+"#);
+    // Should produce abstract sig + 2 children
+    assert!(model.sigs.len() >= 3, "expected 3 sigs, got {}", model.sigs.len());
+    let status = model.sigs.iter().find(|s| s.name == "Status").expect("Status sig");
+    assert!(status.is_abstract);
+    let active = model.sigs.iter().find(|s| s.name == "Active").expect("Active sig");
+    assert_eq!(active.parent.as_deref(), Some("Status"));
+}
+
+#[test]
+fn swift_extract_enum_with_associated_values() {
+    let model = swift_extractor::extract(r#"
+enum Expr: Equatable {
+    case literal
+    case binOp(left: Expr, right: Expr)
+}
+"#);
+    let expr = model.sigs.iter().find(|s| s.name == "Expr").expect("Expr sig");
+    assert!(expr.is_abstract);
+    let binop = model.sigs.iter().find(|s| s.name == "BinOp").expect("BinOp sig");
+    assert_eq!(binop.parent.as_deref(), Some("Expr"));
+    assert_eq!(binop.fields.len(), 2);
+}
+
+#[test]
+fn swift_extract_precondition_fact() {
+    let model = swift_extractor::extract(r#"
+func validate(x: Int) {
+    precondition(x > 0)
+}
+"#);
+    assert!(!model.fact_candidates.is_empty());
+    assert!(model.fact_candidates.iter().any(|f| f.confidence == Confidence::High));
+}
+
+#[test]
+fn swift_extract_guard_fact() {
+    let model = swift_extractor::extract(r#"
+func process() {
+    guard let value = optional else { return }
+}
+"#);
+    assert!(model.fact_candidates.iter().any(|f| f.source_pattern == "guard"));
+}
+
+#[test]
+fn swift_extract_contains_fact() {
+    let model = swift_extractor::extract(r#"
+func check(items: Set<String>, item: String) {
+    if items.contains(item) { }
+}
+"#);
+    assert!(model.fact_candidates.iter().any(|f| f.source_pattern == ".contains() check"));
+}
+
+#[test]
+fn swift_reverse_translate_basic() {
+    assert_eq!(
+        swift_extractor::reverse_translate_expr("x == y"),
+        Some("x = y".to_string()),
+    );
+    assert_eq!(
+        swift_extractor::reverse_translate_expr("items.count"),
+        Some("#items".to_string()),
+    );
+    assert_eq!(
+        swift_extractor::reverse_translate_expr("items.contains(x)"),
+        Some("x in items".to_string()),
+    );
+}

--- a/tests/round_trip_swift.rs
+++ b/tests/round_trip_swift.rs
@@ -1,0 +1,119 @@
+use oxidtr::parser;
+use oxidtr::ir;
+use oxidtr::backend::swift;
+use oxidtr::backend::GeneratedFile;
+use oxidtr::mine::{swift_extractor, MinedMultiplicity};
+use oxidtr::check::{self, CheckConfig};
+use oxidtr::generate::{self, GenerateConfig, WarningLevel};
+use oxidtr::backend::typescript::TsTestRunner;
+
+fn find_file<'a>(files: &'a [GeneratedFile], path: &str) -> &'a str {
+    files.iter().find(|f| f.path == path)
+        .map(|f| f.content.as_str())
+        .unwrap_or_else(|| panic!("file {path} not found"))
+}
+
+fn assert_sig_exists<'a>(sigs: &'a [oxidtr::mine::MinedSig], name: &str) -> &'a oxidtr::mine::MinedSig {
+    sigs.iter().find(|s| s.name == name)
+        .unwrap_or_else(|| panic!("expected sig '{name}' not found"))
+}
+
+fn assert_field(sig: &oxidtr::mine::MinedSig, name: &str, mult: MinedMultiplicity, target: &str) {
+    let f = sig.fields.iter().find(|f| f.name == name)
+        .unwrap_or_else(|| panic!("field '{name}' not found in sig '{}'", sig.name));
+    assert_eq!(f.mult, mult, "field {}.{name} multiplicity", sig.name);
+    assert_eq!(f.target, target, "field {}.{name} target", sig.name);
+}
+
+// ── Swift round-trip ─────────────────────────────────────────────────────────
+
+#[test]
+fn round_trip_swift_simple() {
+    let alloy_src = "sig User { group: lone Group, roles: set Role }\nsig Group {}\nsig Role {}";
+    let model = parser::parse(alloy_src).unwrap();
+    let ir = ir::lower(&model).unwrap();
+    let files = swift::generate(&ir);
+    let models = find_file(&files, "Models.swift");
+
+    let mined = swift_extractor::extract(models);
+
+    let user = assert_sig_exists(&mined.sigs, "User");
+    assert_field(user, "group", MinedMultiplicity::Lone, "Group");
+    assert_field(user, "roles", MinedMultiplicity::Set, "Role");
+    assert_sig_exists(&mined.sigs, "Group");
+    assert_sig_exists(&mined.sigs, "Role");
+}
+
+#[test]
+fn round_trip_swift_enum() {
+    let alloy_src = "abstract sig Status {}\none sig Active extends Status {}\none sig Inactive extends Status {}";
+    let model = parser::parse(alloy_src).unwrap();
+    let ir = ir::lower(&model).unwrap();
+    let files = swift::generate(&ir);
+    let models = find_file(&files, "Models.swift");
+
+    let mined = swift_extractor::extract(models);
+
+    let status = assert_sig_exists(&mined.sigs, "Status");
+    assert!(status.is_abstract);
+    let active = assert_sig_exists(&mined.sigs, "Active");
+    assert_eq!(active.parent.as_deref(), Some("Status"));
+}
+
+#[test]
+fn round_trip_swift_seq_field() {
+    let alloy_src = "sig Order { items: seq Item }\nsig Item {}";
+    let model = parser::parse(alloy_src).unwrap();
+    let ir = ir::lower(&model).unwrap();
+    let files = swift::generate(&ir);
+    let models = find_file(&files, "Models.swift");
+
+    let mined = swift_extractor::extract(models);
+
+    let order = assert_sig_exists(&mined.sigs, "Order");
+    assert_field(order, "items", MinedMultiplicity::Seq, "Item");
+}
+
+#[test]
+fn round_trip_swift_check_consistency() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let model_path = dir.path().join("test.als");
+    std::fs::write(&model_path, "sig User { roles: set Role }\nsig Role {}").unwrap();
+
+    let config = GenerateConfig {
+        target: "swift".to_string(),
+        output_dir: dir.path().join("out").display().to_string(),
+        warnings: WarningLevel::Off,
+        features: vec![],
+        schema: None,
+        ts_test_runner: TsTestRunner::Bun,
+    };
+    generate::run(model_path.to_str().unwrap(), &config).unwrap();
+
+    let check_config = CheckConfig {
+        impl_dir: dir.path().join("out").display().to_string(),
+    };
+    let result = check::run(model_path.to_str().unwrap(), &check_config).unwrap();
+    assert!(result.is_ok(), "check should pass: {:?}", result.diffs);
+}
+
+#[test]
+fn round_trip_swift_self_model() {
+    let self_model = include_str!("../models/oxidtr.als");
+    let model = parser::parse(self_model).unwrap();
+    let ir = ir::lower(&model).unwrap();
+    let files = swift::generate(&ir);
+
+    // Verify key files are generated
+    assert!(files.iter().any(|f| f.path == "Models.swift"), "no Models.swift");
+    assert!(files.iter().any(|f| f.path == "Tests.swift"), "no Tests.swift");
+    assert!(files.iter().any(|f| f.path == "Fixtures.swift"), "no Fixtures.swift");
+
+    let models = find_file(&files, "Models.swift");
+
+    // Verify key types from the self-hosting model exist
+    assert!(models.contains("struct SigDecl"), "should contain SigDecl");
+    assert!(models.contains("struct AlloyModel"), "should contain AlloyModel");
+    assert!(models.contains("struct OxidtrIR"), "should contain OxidtrIR");
+    assert!(models.contains("struct StructureNode"), "should contain StructureNode");
+}

--- a/tests/self_host_guarantees.rs
+++ b/tests/self_host_guarantees.rs
@@ -150,11 +150,10 @@ fn guarantee_1_swift_tests_cover_named_facts() {
 
     let facts = named_facts(&ir);
     for fact in &facts {
-        let snake = to_snake_case(fact);
-        let has_invariant = tests.content.contains(&format!("test_invariant_{snake}"))
+        let has_invariant = tests.content.contains(&format!("test_invariant_{fact}"))
             || tests.content.contains(&format!("Type-guaranteed: {fact}"));
-        let has_boundary = tests.content.contains(&format!("test_boundary_{snake}"));
-        let has_cross = tests.content.contains(&format!("{snake}_preserved_after_"));
+        let has_boundary = tests.content.contains(&format!("test_boundary_{fact}"));
+        let has_cross = tests.content.contains(&format!("{fact}_preserved_after_"));
         assert!(
             has_invariant || has_boundary || has_cross,
             "fact {fact} should appear in Tests.swift"

--- a/tests/self_host_guarantees.rs
+++ b/tests/self_host_guarantees.rs
@@ -9,6 +9,7 @@ use oxidtr::ir;
 use oxidtr::backend::rust;
 use oxidtr::backend::typescript;
 use oxidtr::backend::jvm::{kotlin, java};
+use oxidtr::backend::swift;
 use oxidtr::check;
 // NOTE: Tests that require external toolchains (cargo test, bun test, gradle test)
 // have been moved to target_validation.rs.
@@ -136,6 +137,27 @@ fn guarantee_1_java_tests_cover_named_facts() {
         assert!(
             has_invariant || has_boundary,
             "fact {fact} should appear in Tests.java"
+        );
+    }
+}
+
+#[test]
+fn guarantee_1_swift_tests_cover_named_facts() {
+    let ir = parse_and_lower();
+    let files = swift::generate(&ir);
+    let tests = files.iter().find(|f| f.path == "Tests.swift")
+        .expect("Tests.swift should be generated");
+
+    let facts = named_facts(&ir);
+    for fact in &facts {
+        let snake = to_snake_case(fact);
+        let has_invariant = tests.content.contains(&format!("test_invariant_{snake}"))
+            || tests.content.contains(&format!("Type-guaranteed: {fact}"));
+        let has_boundary = tests.content.contains(&format!("test_boundary_{snake}"));
+        let has_cross = tests.content.contains(&format!("{snake}_preserved_after_"));
+        assert!(
+            has_invariant || has_boundary || has_cross,
+            "fact {fact} should appear in Tests.swift"
         );
     }
 }
@@ -290,6 +312,27 @@ fn guarantee_3_java_cross_tests_are_disabled() {
     }
 }
 
+#[test]
+fn guarantee_3_swift_cross_tests_are_disabled() {
+    let ir = parse_and_lower();
+    let files = swift::generate(&ir);
+    let tests = files.iter().find(|f| f.path == "Tests.swift")
+        .expect("Tests.swift should be generated");
+
+    if tests.content.contains("Cross-tests") {
+        let lines: Vec<&str> = tests.content.lines().collect();
+        for (i, line) in lines.iter().enumerate() {
+            if line.contains("preserved_after_") && line.contains("func ") {
+                assert!(
+                    line.contains("disabled_test_"),
+                    "Swift cross-test at line {} should use disabled_test_ prefix: {}",
+                    i + 1, line.trim()
+                );
+            }
+        }
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Guarantee 4: Mine results match original model semantically
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -304,6 +347,7 @@ fn guarantee_4_mine_covers_all_sigs_and_fields() {
         ("ts", Box::new(|ir| typescript::generate(ir))),
         ("kt", Box::new(|ir| kotlin::generate(ir))),
         ("java", Box::new(|ir| java::generate(ir))),
+        ("swift", Box::new(|ir| swift::generate(ir))),
     ];
 
     for (lang, generate_fn) in &languages {


### PR DESCRIPTION
## Summary
This PR adds comprehensive Swift code generation and reverse-engineering (mining) support to oxidtr, enabling bidirectional transformation between Alloy models and Swift source code.

## Key Changes

### Code Generation (`src/backend/swift/`)
- **Models.swift**: Generates Swift structs and enums from Alloy signatures
  - Maps multiplicities: `one` → `T`, `lone` → `T?`, `set` → `Set<T>`, `seq` → `[T]`
  - Handles abstract sigs as enums with associated values for variant fields
  - Detects and marks cyclic field references
  - Includes invariant documentation comments

- **Operations.swift**: Generates function stubs for Alloy predicates and functions
  - Extracts parameter types and return types with proper multiplicity mapping
  - Generates doc comments with pre/post-condition annotations
  - Uses `fatalError` placeholders for implementation

- **Tests.swift**: Generates XCTest cases for properties and constraints
  - Translates Alloy expressions to Swift assertions
  - Skips type-guaranteed constraints (leveraging Swift's strong null safety)
  - Implements quantifier translation to `.allSatisfy` and similar collection methods

- **Helpers.swift**: Generates transitive closure helper functions
  - Implements `tcFieldName()` functions for self-referential fields
  - Handles different multiplicities (lone, set, seq, one) with appropriate algorithms

- **Fixtures.swift**: Generates test data builders and example instances

### Expression Translation (`src/backend/swift/expr_translator.rs`)
- Translates Alloy expressions to Swift code
- Extracts transitive closure field information
- Handles quantifiers, field access, comparisons, and set operations
- Converts Alloy operators to Swift equivalents (e.g., `#` → `.count`)

### Mining/Reverse Engineering (`src/mine/swift_extractor.rs`)
- Extracts Alloy model candidates from Swift source code
- **Struct parsing**: Maps Swift structs to Alloy sigs
- **Enum parsing**: Maps Swift enums to abstract sigs with variants
- **Type mapping**: Infers multiplicities from Swift type annotations
  - `T?` → `lone`
  - `Set<T>` → `set`
  - `[T]` → `seq`
  - `T` → `one`
- **Fact extraction**: Identifies constraints from Swift code patterns
  - Preconditions and assertions
  - Guard statements and optional binding
  - Collection operations (filter, contains)
  - Force unwraps and exhaustiveness checks

### Integration
- Added Swift to the language strength ranking (equivalent to Kotlin)
- Updated CI/CD pipeline to generate Swift code
- Added comprehensive test coverage for round-trip transformations
- Updated internal Alloy model to include Swift as a target language

## Notable Implementation Details

- **Cyclic field detection**: Uses BFS to identify both direct and indirect cycles in field references, marking them for special handling
- **Enum generation**: Intelligently chooses between simple enums (unit variants) and associated-value enums based on variant field presence
- **Transitive closure**: Generates specialized helper functions for different multiplicities with appropriate algorithms (while loop for lone, BFS queue for set/seq)
- **Type guarantees**: Leverages Swift's strong null safety to reduce test generation burden compared to weaker type systems
- **Round-trip fidelity**: Supports bidirectional transformation with high-fidelity preservation of model structure

## Testing
- Added `tests/backend_swift.rs`: Tests for Models, Operations, Tests, and Fixtures generation
- Added `tests/mine_swift.rs`: Tests for Swift source extraction
- Added `tests/round_trip_swift.rs`: Tests for bidirectional transformation
- Updated `tests/self_host_guarantees.rs`: Validates that generated tests cover named facts

https://claude.ai/code/session_01CKbL7KcFGDnqM3HxsyM5zu