### PR TITLE
Expand constraint analysis with 6 new ConstraintInfo variants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,29 @@ cargo run -- mine generated/ -o /tmp/mined.als
 - explore: Alloyインスタンス異常パターン検出
 - cover: カバレッジ×fact直交テスト生成
 
+### fact本体式の活用における伸びしろ
+
+現在の実装状況と残課題:
+
+**実装済み（テスト生成 + ランタイム検証コード）:**
+- NoSelfRef: Rust TryFrom / TS validator / Kotlin・Java注釈
+- Acyclic: Rust TryFrom（チェーン走査） / TS validator（Setベース）
+- Disj一意性: Rust TryFrom（HashSet） / TS validator（Set.size）
+- FieldOrdering: Rust TryFrom / TS validator / Kotlin init block / Java compact constructor
+- Implication: TS validator（translate_validator_expr） / Kotlin・Java コメント
+- Iff / Prohibition: TS validator（translate_validator_expr）
+
+**検出済みだがコード生成がコメント止まり:**
+- Disjoint (`no (A & B)`): TSコメント出力のみ。switch/matchの排他性チェック生成が可能
+- Exhaustive (`all x | x in A or x in B or ...`): TSコメント出力のみ。switch/matchのdefault: never型チェック、Rustのunreachable!()アーム生成が可能
+
+**パーサー拡張済み・活用余地あり:**
+- `some expr`/`no expr`フォーミュラ: パーサーとexpr_translatorは対応済み。solidionのドメインモデルでimpliesパターンの記述が可能に
+
+**未到達の領域:**
+- 派生フィールド（`totalDelta`は`behaviorDeltas`から計算される等）: Alloy静的モデルの表現限界。Alloy 6時相拡張（`var`/`always`/`eventually`）の領域
+- Lean backend: fact本体式を定理として完全変換する最終目標。「制約を実行時に検証する」から「制約を証明する」への移行
+
 ## Alloyモデルへのフィードバック
 
 コード生成やテストの改善に伴い `models/oxidtr.als` も更新すること:

--- a/models/oxidtr-domain.als
+++ b/models/oxidtr-domain.als
@@ -44,6 +44,10 @@ sig Product extends Expr {
   prodLeft:  one Expr,
   prodRight: one Expr
 }
+sig MultFormula extends Expr {
+  mfKind: one QuantKind,
+  mfExpr: one Expr
+}
 
 abstract sig CompareOp {}
 one sig In    extends CompareOp {}
@@ -215,6 +219,39 @@ sig OxidtrIR {
   constraints: set ConstraintNode,
   operations:  set OperationNode,
   properties:  set PropertyNode
+}
+
+-------------------------------------------------------------------------------
+-- Constraint analysis (ConstraintInfo variants)
+-------------------------------------------------------------------------------
+
+sig FieldOrdering {
+  foSig:        one StructureNode,
+  foLeftField:  one FieldDecl,
+  foOp:         one CompareOp,
+  foRightField: one FieldDecl
+}
+
+sig Implication {
+  implSig:        one StructureNode,
+  implCondition:  one Expr,
+  implConsequent: one Expr
+}
+
+sig Prohibition {
+  prohSig:       one StructureNode,
+  prohCondition: one Expr
+}
+
+sig Disjoint {
+  disjSig:   one StructureNode,
+  disjLeft:  one Expr,
+  disjRight: one Expr
+}
+
+sig Exhaustive {
+  exhSig:        one StructureNode,
+  exhCategories: set Expr
 }
 
 -------------------------------------------------------------------------------

--- a/models/oxidtr.als
+++ b/models/oxidtr.als
@@ -44,6 +44,10 @@ sig Product extends Expr {
   prodLeft:  one Expr,
   prodRight: one Expr
 }
+sig MultFormula extends Expr {
+  mfKind: one QuantKind,
+  mfExpr: one Expr
+}
 
 abstract sig CompareOp {}
 one sig In    extends CompareOp {}
@@ -215,6 +219,39 @@ sig OxidtrIR {
   constraints: set ConstraintNode,
   operations:  set OperationNode,
   properties:  set PropertyNode
+}
+
+-------------------------------------------------------------------------------
+-- Constraint analysis (ConstraintInfo variants)
+-------------------------------------------------------------------------------
+
+sig FieldOrdering {
+  foSig:        one StructureNode,
+  foLeftField:  one FieldDecl,
+  foOp:         one CompareOp,
+  foRightField: one FieldDecl
+}
+
+sig Implication {
+  implSig:        one StructureNode,
+  implCondition:  one Expr,
+  implConsequent: one Expr
+}
+
+sig Prohibition {
+  prohSig:       one StructureNode,
+  prohCondition: one Expr
+}
+
+sig Disjoint {
+  disjSig:   one StructureNode,
+  disjLeft:  one Expr,
+  disjRight: one Expr
+}
+
+sig Exhaustive {
+  exhSig:        one StructureNode,
+  exhCategories: set Expr
 }
 
 -------------------------------------------------------------------------------

--- a/src/analyze/guarantee.rs
+++ b/src/analyze/guarantee.rs
@@ -100,6 +100,9 @@ pub fn can_guarantee_by_type(constraint: &ConstraintInfo, lang: TargetLang) -> G
         ConstraintInfo::Iff { .. } => Guarantee::RequiresTest,
         // Implication: no type system can encode conditional constraints
         ConstraintInfo::Implication { .. } => Guarantee::RequiresTest,
+        // Disjoint/Exhaustive: no type system can fully encode partition constraints
+        ConstraintInfo::Disjoint { .. } => Guarantee::RequiresTest,
+        ConstraintInfo::Exhaustive { .. } => Guarantee::RequiresTest,
         // Field ordering: no type system can encode field ordering
         ConstraintInfo::FieldOrdering { .. } => Guarantee::RequiresTest,
         // Prohibition: no type system can encode negated existentials

--- a/src/analyze/guarantee.rs
+++ b/src/analyze/guarantee.rs
@@ -96,6 +96,12 @@ pub fn can_guarantee_by_type(constraint: &ConstraintInfo, lang: TargetLang) -> G
         ConstraintInfo::Acyclic { .. } => Guarantee::RequiresTest,
         // Membership: no type system can encode this
         ConstraintInfo::Membership { .. } => Guarantee::RequiresTest,
+        // Iff: no type system can encode biconditional constraints
+        ConstraintInfo::Iff { .. } => Guarantee::RequiresTest,
+        // Field ordering: no type system can encode field ordering
+        ConstraintInfo::FieldOrdering { .. } => Guarantee::RequiresTest,
+        // Prohibition: no type system can encode negated existentials
+        ConstraintInfo::Prohibition { .. } => Guarantee::RequiresTest,
         // Named/generic constraints: no type system can encode these
         ConstraintInfo::Named { .. } => Guarantee::RequiresTest,
     }

--- a/src/analyze/guarantee.rs
+++ b/src/analyze/guarantee.rs
@@ -98,6 +98,8 @@ pub fn can_guarantee_by_type(constraint: &ConstraintInfo, lang: TargetLang) -> G
         ConstraintInfo::Membership { .. } => Guarantee::RequiresTest,
         // Iff: no type system can encode biconditional constraints
         ConstraintInfo::Iff { .. } => Guarantee::RequiresTest,
+        // Implication: no type system can encode conditional constraints
+        ConstraintInfo::Implication { .. } => Guarantee::RequiresTest,
         // Field ordering: no type system can encode field ordering
         ConstraintInfo::FieldOrdering { .. } => Guarantee::RequiresTest,
         // Prohibition: no type system can encode negated existentials

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -49,6 +49,12 @@ pub enum ConstraintInfo {
         op: CompareOp,
         right_field: String,
     },
+    /// Implication: all s: S | condition implies consequent
+    Implication {
+        sig_name: String,
+        condition: Expr,
+        consequent: Expr,
+    },
     /// Prohibition: no s: S | condition (negated existential)
     Prohibition {
         sig_name: String,
@@ -94,6 +100,7 @@ pub fn constraints_for_sig(ir: &OxidtrIR, sig_name: &str) -> Vec<ConstraintInfo>
         ConstraintInfo::Acyclic { sig_name: s, .. } => s == sig_name,
         ConstraintInfo::Iff { sig_name: s, .. } => s == sig_name,
         ConstraintInfo::FieldOrdering { sig_name: s, .. } => s == sig_name,
+        ConstraintInfo::Implication { sig_name: s, .. } => s == sig_name,
         ConstraintInfo::Prohibition { sig_name: s, .. } => s == sig_name,
         ConstraintInfo::Named { .. } => false,
     }).collect()
@@ -318,8 +325,13 @@ fn analyze_body_for_sig(
                 right: substitute_var(right, var, sig_name),
             });
         }
-        // Implication body
-        Expr::BinaryLogic { op: LogicOp::Implies, right, .. } => {
+        // Implication: A implies B → emit Implication + recurse into consequent
+        Expr::BinaryLogic { op: LogicOp::Implies, left, right } => {
+            results.push(ConstraintInfo::Implication {
+                sig_name: sig_name.to_string(),
+                condition: substitute_var(left, var, sig_name),
+                consequent: substitute_var(right, var, sig_name),
+            });
             analyze_body_for_sig(right, sig_name, var, results);
         }
         _ => {}

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -49,6 +49,17 @@ pub enum ConstraintInfo {
         op: CompareOp,
         right_field: String,
     },
+    /// Disjoint: no (A & B) — two sets must not overlap
+    Disjoint {
+        sig_name: String,
+        left: String,   // e.g. "additive.covers"
+        right: String,  // e.g. "multiplicative.covers"
+    },
+    /// Exhaustive: all x: S | x in A or x in B or ... — covers all instances
+    Exhaustive {
+        sig_name: String,
+        categories: Vec<String>, // e.g. ["additive.covers", "multiplicative.covers", "override.covers"]
+    },
     /// Implication: all s: S | condition implies consequent
     Implication {
         sig_name: String,
@@ -100,6 +111,8 @@ pub fn constraints_for_sig(ir: &OxidtrIR, sig_name: &str) -> Vec<ConstraintInfo>
         ConstraintInfo::Acyclic { sig_name: s, .. } => s == sig_name,
         ConstraintInfo::Iff { sig_name: s, .. } => s == sig_name,
         ConstraintInfo::FieldOrdering { sig_name: s, .. } => s == sig_name,
+        ConstraintInfo::Disjoint { sig_name: s, .. } => s == sig_name,
+        ConstraintInfo::Exhaustive { sig_name: s, .. } => s == sig_name,
         ConstraintInfo::Implication { sig_name: s, .. } => s == sig_name,
         ConstraintInfo::Prohibition { sig_name: s, .. } => s == sig_name,
         ConstraintInfo::Named { .. } => false,
@@ -229,6 +242,21 @@ fn analyze_expr(expr: &Expr, fact_name: &str) -> Vec<ConstraintInfo> {
                 }
             }
         }
+        // no (A & B) → Disjoint
+        Expr::MultFormula { kind: QuantKind::No, expr } => {
+            if let Expr::SetOp { op: SetOpKind::Intersection, left, right } = expr.as_ref() {
+                let l = describe_expr(left);
+                let r = describe_expr(right);
+                // Infer sig name from field access paths
+                let sig = infer_sig_from_expr(left).or_else(|| infer_sig_from_expr(right))
+                    .unwrap_or_default();
+                results.push(ConstraintInfo::Disjoint {
+                    sig_name: sig,
+                    left: l,
+                    right: r,
+                });
+            }
+        }
         _ => {}
     }
 
@@ -310,6 +338,16 @@ fn analyze_body_for_sig(
                         }
                     }
                 }
+            }
+        }
+        // Disjunction: check for exhaustive classification (x in A or x in B or ...)
+        Expr::BinaryLogic { op: LogicOp::Or, .. } => {
+            let mut categories = Vec::new();
+            if collect_exhaustive_categories(body, var, &mut categories) && categories.len() >= 2 {
+                results.push(ConstraintInfo::Exhaustive {
+                    sig_name: sig_name.to_string(),
+                    categories,
+                });
             }
         }
         // Conjunction: analyze both sides
@@ -436,6 +474,42 @@ fn extract_int(expr: &Expr) -> Option<i64> {
         Some(*n)
     } else {
         None
+    }
+}
+
+/// Collect categories from an exhaustive disjunction: x in A or x in B or ...
+/// Returns true if the entire expression is a chain of `var in expr` comparisons.
+fn collect_exhaustive_categories(expr: &Expr, var: &str, categories: &mut Vec<String>) -> bool {
+    match expr {
+        Expr::BinaryLogic { op: LogicOp::Or, left, right } => {
+            collect_exhaustive_categories(left, var, categories)
+                && collect_exhaustive_categories(right, var, categories)
+        }
+        Expr::Comparison { op: CompareOp::In, left, right } => {
+            if let Expr::VarRef(v) = left.as_ref() {
+                if v == var {
+                    categories.push(describe_expr(right));
+                    return true;
+                }
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+/// Infer a sig name from a field access expression (e.g., "additive.covers" → "additive").
+fn infer_sig_from_expr(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::FieldAccess { base, .. } => {
+            if let Expr::VarRef(name) = base.as_ref() {
+                Some(name.clone())
+            } else {
+                infer_sig_from_expr(base)
+            }
+        }
+        Expr::VarRef(name) => Some(name.clone()),
+        _ => None,
     }
 }
 

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -36,6 +36,24 @@ pub enum ConstraintInfo {
         sig_name: String,
         field_name: String,
     },
+    /// Biconditional: all s: S | A iff B
+    Iff {
+        sig_name: String,
+        left: Expr,
+        right: Expr,
+    },
+    /// Field ordering: all s: S | s.x <= s.y (direct field-to-field comparison)
+    FieldOrdering {
+        sig_name: String,
+        left_field: String,
+        op: CompareOp,
+        right_field: String,
+    },
+    /// Prohibition: no s: S | condition (negated existential)
+    Prohibition {
+        sig_name: String,
+        condition: Expr,
+    },
     /// Generic named constraint (for doc comments)
     Named {
         name: String,
@@ -74,6 +92,9 @@ pub fn constraints_for_sig(ir: &OxidtrIR, sig_name: &str) -> Vec<ConstraintInfo>
         ConstraintInfo::Membership { sig_name: s, .. } => s == sig_name,
         ConstraintInfo::NoSelfRef { sig_name: s, .. } => s == sig_name,
         ConstraintInfo::Acyclic { sig_name: s, .. } => s == sig_name,
+        ConstraintInfo::Iff { sig_name: s, .. } => s == sig_name,
+        ConstraintInfo::FieldOrdering { sig_name: s, .. } => s == sig_name,
+        ConstraintInfo::Prohibition { sig_name: s, .. } => s == sig_name,
         ConstraintInfo::Named { .. } => false,
     }).collect()
 }
@@ -160,12 +181,14 @@ fn analyze_expr(expr: &Expr, fact_name: &str) -> Vec<ConstraintInfo> {
                 }
             }
         }
-        // no s: Sig | s in s.^field → Acyclic
+        // no s: Sig | ... → Acyclic or Prohibition
         Expr::Quantifier { kind: QuantKind::No, bindings, body } => {
             if bindings.len() == 1 && bindings[0].vars.len() == 1 {
                 let var = &bindings[0].vars[0];
                 let domain = &bindings[0].domain;
                 if let Expr::VarRef(sig_name) = domain {
+                    let mut is_acyclic = false;
+                    // s in s.^field → Acyclic
                     if let Expr::Comparison { op: CompareOp::In, left, right } = body.as_ref() {
                         if let Expr::VarRef(v) = left.as_ref() {
                             if v == var {
@@ -175,10 +198,18 @@ fn analyze_expr(expr: &Expr, fact_name: &str) -> Vec<ConstraintInfo> {
                                             sig_name: sig_name.clone(),
                                             field_name: field.clone(),
                                         });
+                                        is_acyclic = true;
                                     }
                                 }
                             }
                         }
+                    }
+                    // Other no-quantifier patterns → Prohibition
+                    if !is_acyclic {
+                        results.push(ConstraintInfo::Prohibition {
+                            sig_name: sig_name.clone(),
+                            condition: substitute_var(body, var, sig_name),
+                        });
                     }
                 }
             }
@@ -222,6 +253,7 @@ fn analyze_body_for_sig(
             }
         }
         // #s.field = N or #s.field <= N etc. (via Comparison on Cardinality)
+        // OR s.fieldA op s.fieldB → FieldOrdering
         Expr::Comparison { op, left, right } => {
             // Look for cardinality on left
             if let Expr::Cardinality(inner) = left.as_ref() {
@@ -244,11 +276,39 @@ fn analyze_body_for_sig(
                     }
                 }
             }
+            // FieldOrdering: s.fieldA op s.fieldB (non-cardinality, non-tautological)
+            if !matches!(left.as_ref(), Expr::Cardinality(_))
+                && matches!(op, CompareOp::Lt | CompareOp::Gt | CompareOp::Lte | CompareOp::Gte)
+            {
+                if let (
+                    Expr::FieldAccess { base: bl, field: fl },
+                    Expr::FieldAccess { base: br, field: fr },
+                ) = (left.as_ref(), right.as_ref()) {
+                    if let (Expr::VarRef(vl), Expr::VarRef(vr)) = (bl.as_ref(), br.as_ref()) {
+                        if vl == var && vr == var && fl != fr {
+                            results.push(ConstraintInfo::FieldOrdering {
+                                sig_name: sig_name.to_string(),
+                                left_field: fl.clone(),
+                                op: op.clone(),
+                                right_field: fr.clone(),
+                            });
+                        }
+                    }
+                }
+            }
         }
         // Conjunction: analyze both sides
         Expr::BinaryLogic { op: LogicOp::And, left, right } => {
             analyze_body_for_sig(left, sig_name, var, results);
             analyze_body_for_sig(right, sig_name, var, results);
+        }
+        // Iff: A iff B → biconditional constraint
+        Expr::BinaryLogic { op: LogicOp::Iff, left, right } => {
+            results.push(ConstraintInfo::Iff {
+                sig_name: sig_name.to_string(),
+                left: substitute_var(left, var, sig_name),
+                right: substitute_var(right, var, sig_name),
+            });
         }
         // Implication body
         Expr::BinaryLogic { op: LogicOp::Implies, right, .. } => {
@@ -356,6 +416,52 @@ fn extract_int(expr: &Expr) -> Option<i64> {
         Some(*n)
     } else {
         None
+    }
+}
+
+/// Substitute a quantifier variable in an expression with the sig name.
+/// This normalizes expressions so they reference the sig name directly.
+fn substitute_var(expr: &Expr, var: &str, sig_name: &str) -> Expr {
+    match expr {
+        Expr::VarRef(name) => {
+            if name == var {
+                Expr::VarRef(sig_name.to_string())
+            } else {
+                expr.clone()
+            }
+        }
+        Expr::FieldAccess { base, field } => Expr::FieldAccess {
+            base: Box::new(substitute_var(base, var, sig_name)),
+            field: field.clone(),
+        },
+        Expr::Comparison { op, left, right } => Expr::Comparison {
+            op: op.clone(),
+            left: Box::new(substitute_var(left, var, sig_name)),
+            right: Box::new(substitute_var(right, var, sig_name)),
+        },
+        Expr::BinaryLogic { op, left, right } => Expr::BinaryLogic {
+            op: op.clone(),
+            left: Box::new(substitute_var(left, var, sig_name)),
+            right: Box::new(substitute_var(right, var, sig_name)),
+        },
+        Expr::Not(inner) => Expr::Not(Box::new(substitute_var(inner, var, sig_name))),
+        Expr::Cardinality(inner) => Expr::Cardinality(Box::new(substitute_var(inner, var, sig_name))),
+        Expr::TransitiveClosure(inner) => Expr::TransitiveClosure(Box::new(substitute_var(inner, var, sig_name))),
+        Expr::SetOp { op, left, right } => Expr::SetOp {
+            op: *op,
+            left: Box::new(substitute_var(left, var, sig_name)),
+            right: Box::new(substitute_var(right, var, sig_name)),
+        },
+        Expr::Product { left, right } => Expr::Product {
+            left: Box::new(substitute_var(left, var, sig_name)),
+            right: Box::new(substitute_var(right, var, sig_name)),
+        },
+        Expr::Quantifier { kind, bindings, body } => Expr::Quantifier {
+            kind: kind.clone(),
+            bindings: bindings.clone(),
+            body: Box::new(substitute_var(body, var, sig_name)),
+        },
+        Expr::IntLiteral(_) => expr.clone(),
     }
 }
 

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -163,6 +163,14 @@ pub fn describe_expr(expr: &Expr) -> String {
         Expr::Product { left, right } => {
             format!("{} -> {}", describe_expr(left), describe_expr(right))
         }
+        Expr::MultFormula { kind, expr } => {
+            let q = match kind {
+                QuantKind::Some => "some",
+                QuantKind::No => "no",
+                _ => "all",
+            };
+            format!("{q} {}", describe_expr(expr))
+        }
     }
 }
 
@@ -461,6 +469,10 @@ fn substitute_var(expr: &Expr, var: &str, sig_name: &str) -> Expr {
             bindings: bindings.clone(),
             body: Box::new(substitute_var(body, var, sig_name)),
         },
+        Expr::MultFormula { kind, expr } => Expr::MultFormula {
+            kind: kind.clone(),
+            expr: Box::new(substitute_var(expr, var, sig_name)),
+        },
         Expr::IntLiteral(_) => expr.clone(),
     }
 }
@@ -515,6 +527,7 @@ fn collect_disj_fields(expr: &Expr, results: &mut Vec<(String, String)>) {
         Expr::Not(inner) | Expr::Cardinality(inner) | Expr::TransitiveClosure(inner) => {
             collect_disj_fields(inner, results);
         }
+        Expr::MultFormula { expr: inner, .. } => collect_disj_fields(inner, results),
         Expr::FieldAccess { base, .. } => collect_disj_fields(base, results),
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
@@ -555,7 +568,8 @@ fn expr_only_refs_params(expr: &Expr, param_names: &[String]) -> bool {
             // Field access on a param is still a param reference (e.g., a.balance)
             expr_only_refs_params(base, param_names)
         }
-        Expr::Cardinality(inner) | Expr::Not(inner) | Expr::TransitiveClosure(inner) => {
+        Expr::Cardinality(inner) | Expr::Not(inner) | Expr::TransitiveClosure(inner)
+        | Expr::MultFormula { expr: inner, .. } => {
             expr_only_refs_params(inner, param_names)
         }
         Expr::Comparison { left, right, .. } | Expr::BinaryLogic { left, right, .. }
@@ -632,6 +646,14 @@ pub fn alloy_repr(expr: &Expr) -> String {
         }
         Expr::Product { left, right } => {
             format!("{} -> {}", alloy_repr(left), alloy_repr(right))
+        }
+        Expr::MultFormula { kind, expr } => {
+            let q = match kind {
+                QuantKind::Some => "some",
+                QuantKind::No => "no",
+                _ => "all",
+            };
+            format!("{q} {}", alloy_repr(expr))
         }
     }
 }
@@ -761,7 +783,8 @@ fn expr_references_sig(expr: &Expr, sig_name: &str) -> bool {
         | Expr::SetOp { left, right, .. } | Expr::Product { left, right } => {
             expr_references_sig(left, sig_name) || expr_references_sig(right, sig_name)
         }
-        Expr::Not(inner) | Expr::Cardinality(inner) | Expr::TransitiveClosure(inner) => {
+        Expr::Not(inner) | Expr::Cardinality(inner) | Expr::TransitiveClosure(inner)
+        | Expr::MultFormula { expr: inner, .. } => {
             expr_references_sig(inner, sig_name)
         }
         Expr::FieldAccess { base, .. } => expr_references_sig(base, sig_name),

--- a/src/backend/go/expr_translator.rs
+++ b/src/backend/go/expr_translator.rs
@@ -50,6 +50,7 @@ fn collect_tc_fields(expr: &Expr, ir: &OxidtrIR, out: &mut Vec<TCField>) {
             collect_tc_fields(left, ir, out);
             collect_tc_fields(right, ir, out);
         }
+        Expr::MultFormula { expr: inner, .. } => collect_tc_fields(inner, ir, out),
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
 }
@@ -86,6 +87,7 @@ fn collect_params(expr: &Expr, sig_names: &HashSet<String>, params: &mut BTreeSe
             collect_params(inner, sig_names, params);
         }
         Expr::FieldAccess { base, .. } => collect_params(base, sig_names, params),
+        Expr::MultFormula { expr: inner, .. } => collect_params(inner, sig_names, params),
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
 }
@@ -184,6 +186,15 @@ fn translate_inner(
             let l = ti(left, false);
             let r = ti(right, false);
             format!("Pair{{{l}, {r}}}")
+        }
+
+        Expr::MultFormula { kind, expr: inner } => {
+            let translated = ti(inner, false);
+            match kind {
+                crate::parser::ast::QuantKind::Some => format!("{translated} != nil"),
+                crate::parser::ast::QuantKind::No => format!("{translated} == nil"),
+                _ => format!("{kind:?}({translated})"),
+            }
         }
     };
 

--- a/src/backend/go/mod.rs
+++ b/src/backend/go/mod.rs
@@ -729,6 +729,7 @@ fn expr_uses_tc(expr: &crate::parser::ast::Expr) -> bool {
         Expr::Quantifier { bindings, body, .. } => {
             bindings.iter().any(|b| expr_uses_tc(&b.domain)) || expr_uses_tc(body)
         }
+        Expr::MultFormula { expr: inner, .. } => expr_uses_tc(inner),
         Expr::VarRef(_) | Expr::IntLiteral(_) => false,
     }
 }

--- a/src/backend/jvm/expr_translator.rs
+++ b/src/backend/jvm/expr_translator.rs
@@ -74,6 +74,7 @@ fn collect_tc_fields(expr: &Expr, ir: &OxidtrIR, out: &mut Vec<TCField>) {
             collect_tc_fields(right, ir, out);
         }
         Expr::Not(inner) | Expr::Cardinality(inner) => collect_tc_fields(inner, ir, out),
+        Expr::MultFormula { expr: inner, .. } => collect_tc_fields(inner, ir, out),
         Expr::Quantifier { bindings, body, .. } => {
             for b in bindings { collect_tc_fields(&b.domain, ir, out); }
             collect_tc_fields(body, ir, out);
@@ -105,6 +106,9 @@ fn collect_params(expr: &Expr, sig_names: &HashSet<String>, params: &mut BTreeSe
             collect_params(right, sig_names, params);
         }
         Expr::Not(inner) | Expr::Cardinality(inner) | Expr::TransitiveClosure(inner) => {
+            collect_params(inner, sig_names, params);
+        }
+        Expr::MultFormula { expr: inner, .. } => {
             collect_params(inner, sig_names, params);
         }
         Expr::FieldAccess { base, .. } => collect_params(base, sig_names, params),
@@ -202,6 +206,15 @@ fn translate_inner(
             let l = ti(left, false);
             let r = ti(right, false);
             format!("Pair({l}, {r})")
+        }
+
+        Expr::MultFormula { kind, expr } => {
+            let inner = ti(expr, false);
+            match kind {
+                QuantKind::Some => format!("{inner} != null"),
+                QuantKind::No => format!("{inner} == null"),
+                _ => inner,
+            }
         }
     };
 

--- a/src/backend/jvm/java.rs
+++ b/src/backend/jvm/java.rs
@@ -561,6 +561,7 @@ fn expr_uses_tc(expr: &crate::parser::ast::Expr) -> bool {
         Expr::TransitiveClosure(_) => true,
         Expr::FieldAccess { base, .. } => expr_uses_tc(base),
         Expr::Cardinality(inner) | Expr::Not(inner) => expr_uses_tc(inner),
+        Expr::MultFormula { expr: inner, .. } => expr_uses_tc(inner),
         Expr::Comparison { left, right, .. } | Expr::BinaryLogic { left, right, .. }
         | Expr::SetOp { left, right, .. } | Expr::Product { left, right } => {
             expr_uses_tc(left) || expr_uses_tc(right)

--- a/src/backend/jvm/java.rs
+++ b/src/backend/jvm/java.rs
@@ -168,6 +168,13 @@ fn generate_record(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_fiel
                         }
                     }
                 }
+                // NoSelfRef: field must not reference self
+                let no_self_ref = analyze::constraints_for_sig(ir, &s.name).iter().any(|c| {
+                    matches!(c, analyze::ConstraintInfo::NoSelfRef { field_name: fname, .. } if fname == &f.name)
+                });
+                if no_self_ref {
+                    annotations.push(format!("/* requires {} != this — no self-reference */", f.name));
+                }
                 // Gap 3: disj → suggest Set
                 if disj_fields.iter().any(|(sig, field)| sig == &s.name && field == &f.name) {
                     if f.mult == Multiplicity::Seq {

--- a/src/backend/jvm/java.rs
+++ b/src/backend/jvm/java.rs
@@ -169,11 +169,19 @@ fn generate_record(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_fiel
                     }
                 }
                 // NoSelfRef: field must not reference self
-                let no_self_ref = analyze::constraints_for_sig(ir, &s.name).iter().any(|c| {
+                let sig_constraints = analyze::constraints_for_sig(ir, &s.name);
+                let no_self_ref = sig_constraints.iter().any(|c| {
                     matches!(c, analyze::ConstraintInfo::NoSelfRef { field_name: fname, .. } if fname == &f.name)
                 });
                 if no_self_ref {
                     annotations.push(format!("/* requires {} != this — no self-reference */", f.name));
+                }
+                // Acyclic: field chain must not form a cycle
+                let acyclic = sig_constraints.iter().any(|c| {
+                    matches!(c, analyze::ConstraintInfo::Acyclic { field_name: fname, .. } if fname == &f.name)
+                });
+                if acyclic {
+                    annotations.push(format!("/* acyclic: {}.^{} must not contain this */", f.name, f.name));
                 }
                 // Gap 3: disj → suggest Set
                 if disj_fields.iter().any(|(sig, field)| sig == &s.name && field == &f.name) {

--- a/src/backend/jvm/java.rs
+++ b/src/backend/jvm/java.rs
@@ -2,7 +2,7 @@ use super::{JvmContext, expr_translator};
 use super::expr_translator::JvmLang;
 use crate::backend::GeneratedFile;
 use crate::ir::nodes::*;
-use crate::parser::ast::{Multiplicity, SigMultiplicity};
+use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity};
 use crate::analyze;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
@@ -203,7 +203,40 @@ fn generate_record(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_fiel
             })
             .collect();
 
-        writeln!(out, "record {}({}) {{}}", s.name, params.join(", ")).unwrap();
+        // FieldOrdering → compact constructor with validation
+        let sig_constraints = analyze::constraints_for_sig(ir, &s.name);
+        let field_orderings: Vec<_> = sig_constraints.iter().filter_map(|c| {
+            if let analyze::ConstraintInfo::FieldOrdering { left_field, op, right_field, .. } = c {
+                let op_str = match op {
+                    CompareOp::Lt => "<",
+                    CompareOp::Gt => ">",
+                    CompareOp::Lte => "<=",
+                    CompareOp::Gte => ">=",
+                    _ => return None,
+                };
+                Some((left_field.clone(), op_str, right_field.clone()))
+            } else {
+                None
+            }
+        }).collect();
+        if field_orderings.is_empty() {
+            writeln!(out, "record {}({}) {{}}", s.name, params.join(", ")).unwrap();
+        } else {
+            writeln!(out, "record {}({}) {{", s.name, params.join(", ")).unwrap();
+            writeln!(out, "    {} {{", s.name).unwrap();
+            for (lf, op, rf) in &field_orderings {
+                let negated = match *op {
+                    "<" => ">=",
+                    ">" => "<=",
+                    "<=" => ">",
+                    ">=" => "<",
+                    _ => continue,
+                };
+                writeln!(out, "        if ({lf} {negated} {rf}) throw new IllegalArgumentException(\"{lf} must be {op} {rf}\");").unwrap();
+            }
+            writeln!(out, "    }}").unwrap();
+            writeln!(out, "}}").unwrap();
+        }
     }
 }
 

--- a/src/backend/jvm/java.rs
+++ b/src/backend/jvm/java.rs
@@ -205,34 +205,33 @@ fn generate_record(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_fiel
 
         // FieldOrdering → compact constructor with validation
         let sig_constraints = analyze::constraints_for_sig(ir, &s.name);
-        let field_orderings: Vec<_> = sig_constraints.iter().filter_map(|c| {
-            if let analyze::ConstraintInfo::FieldOrdering { left_field, op, right_field, .. } = c {
-                let op_str = match op {
-                    CompareOp::Lt => "<",
-                    CompareOp::Gt => ">",
-                    CompareOp::Lte => "<=",
-                    CompareOp::Gte => ">=",
-                    _ => return None,
-                };
-                Some((left_field.clone(), op_str, right_field.clone()))
-            } else {
-                None
+        let mut constructor_checks: Vec<String> = Vec::new();
+        for c in &sig_constraints {
+            match c {
+                analyze::ConstraintInfo::FieldOrdering { left_field, op, right_field, .. } => {
+                    let (op_str, negated) = match op {
+                        CompareOp::Lt => ("<", ">="),
+                        CompareOp::Gt => (">", "<="),
+                        CompareOp::Lte => ("<=", ">"),
+                        CompareOp::Gte => (">=", "<"),
+                        _ => continue,
+                    };
+                    constructor_checks.push(format!("if ({left_field} {negated} {right_field}) throw new IllegalArgumentException(\"{left_field} must be {op_str} {right_field}\");"));
+                }
+                analyze::ConstraintInfo::Implication { condition, consequent, .. } => {
+                    let desc = format!("{} implies {}", analyze::describe_expr(condition), analyze::describe_expr(consequent));
+                    constructor_checks.push(format!("// {desc}"));
+                }
+                _ => {}
             }
-        }).collect();
-        if field_orderings.is_empty() {
+        }
+        if constructor_checks.is_empty() {
             writeln!(out, "record {}({}) {{}}", s.name, params.join(", ")).unwrap();
         } else {
             writeln!(out, "record {}({}) {{", s.name, params.join(", ")).unwrap();
             writeln!(out, "    {} {{", s.name).unwrap();
-            for (lf, op, rf) in &field_orderings {
-                let negated = match *op {
-                    "<" => ">=",
-                    ">" => "<=",
-                    "<=" => ">",
-                    ">=" => "<",
-                    _ => continue,
-                };
-                writeln!(out, "        if ({lf} {negated} {rf}) throw new IllegalArgumentException(\"{lf} must be {op} {rf}\");").unwrap();
+            for check in &constructor_checks {
+                writeln!(out, "        {check}").unwrap();
             }
             writeln!(out, "    }}").unwrap();
             writeln!(out, "}}").unwrap();

--- a/src/backend/jvm/kotlin.rs
+++ b/src/backend/jvm/kotlin.rs
@@ -174,11 +174,19 @@ fn generate_data_class(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_
                 annotations.push("/* @Nullable — lone sig may not exist */".to_string());
             }
             // NoSelfRef: field must not reference self
-            let no_self_ref = analyze::constraints_for_sig(ir, &s.name).iter().any(|c| {
+            let sig_constraints = analyze::constraints_for_sig(ir, &s.name);
+            let no_self_ref = sig_constraints.iter().any(|c| {
                 matches!(c, analyze::ConstraintInfo::NoSelfRef { field_name: fname, .. } if fname == &f.name)
             });
             if no_self_ref {
                 annotations.push(format!("/* require({} != this) — no self-reference */", f.name));
+            }
+            // Acyclic: field chain must not form a cycle
+            let acyclic = sig_constraints.iter().any(|c| {
+                matches!(c, analyze::ConstraintInfo::Acyclic { field_name: fname, .. } if fname == &f.name)
+            });
+            if acyclic {
+                annotations.push(format!("/* acyclic: {}.^{} must not contain this */", f.name, f.name));
             }
             // Gap 3: disj → suggest Set
             if disj_fields.iter().any(|(sig, field)| sig == &s.name && field == &f.name) {

--- a/src/backend/jvm/kotlin.rs
+++ b/src/backend/jvm/kotlin.rs
@@ -561,6 +561,7 @@ fn expr_uses_tc(expr: &crate::parser::ast::Expr) -> bool {
         Expr::TransitiveClosure(_) => true,
         Expr::FieldAccess { base, .. } => expr_uses_tc(base),
         Expr::Cardinality(inner) | Expr::Not(inner) => expr_uses_tc(inner),
+        Expr::MultFormula { expr: inner, .. } => expr_uses_tc(inner),
         Expr::Comparison { left, right, .. } | Expr::BinaryLogic { left, right, .. }
         | Expr::SetOp { left, right, .. } | Expr::Product { left, right } => {
             expr_uses_tc(left) || expr_uses_tc(right)

--- a/src/backend/jvm/kotlin.rs
+++ b/src/backend/jvm/kotlin.rs
@@ -2,7 +2,7 @@ use super::{JvmContext, expr_translator};
 use super::expr_translator::JvmLang;
 use crate::backend::GeneratedFile;
 use crate::ir::nodes::*;
-use crate::parser::ast::{Multiplicity, SigMultiplicity};
+use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity};
 use crate::analyze;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
@@ -199,7 +199,33 @@ fn generate_data_class(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_
             }
             writeln!(out, "    val {}: {type_str}{comma}", f.name).unwrap();
         }
-        writeln!(out, ")").unwrap();
+        // Sig-level constraint annotations (FieldOrdering → init block)
+        let sig_constraints = analyze::constraints_for_sig(ir, &s.name);
+        let field_orderings: Vec<_> = sig_constraints.iter().filter_map(|c| {
+            if let analyze::ConstraintInfo::FieldOrdering { left_field, op, right_field, .. } = c {
+                let op_str = match op {
+                    CompareOp::Lt => "<",
+                    CompareOp::Gt => ">",
+                    CompareOp::Lte => "<=",
+                    CompareOp::Gte => ">=",
+                    _ => return None,
+                };
+                Some((left_field.clone(), op_str, right_field.clone()))
+            } else {
+                None
+            }
+        }).collect();
+        if field_orderings.is_empty() {
+            writeln!(out, ")").unwrap();
+        } else {
+            writeln!(out, ") {{").unwrap();
+            writeln!(out, "    init {{").unwrap();
+            for (lf, op, rf) in &field_orderings {
+                writeln!(out, "        require({lf} {op} {rf}) {{ \"{lf} must be {op} {rf}\" }}").unwrap();
+            }
+            writeln!(out, "    }}").unwrap();
+            writeln!(out, "}}").unwrap();
+        }
     }
 }
 

--- a/src/backend/jvm/kotlin.rs
+++ b/src/backend/jvm/kotlin.rs
@@ -173,6 +173,13 @@ fn generate_data_class(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_
             if target_mult == SigMultiplicity::Lone && f.mult == Multiplicity::One {
                 annotations.push("/* @Nullable — lone sig may not exist */".to_string());
             }
+            // NoSelfRef: field must not reference self
+            let no_self_ref = analyze::constraints_for_sig(ir, &s.name).iter().any(|c| {
+                matches!(c, analyze::ConstraintInfo::NoSelfRef { field_name: fname, .. } if fname == &f.name)
+            });
+            if no_self_ref {
+                annotations.push(format!("/* require({} != this) — no self-reference */", f.name));
+            }
             // Gap 3: disj → suggest Set
             if disj_fields.iter().any(|(sig, field)| sig == &s.name && field == &f.name) {
                 if f.mult == Multiplicity::Seq {

--- a/src/backend/jvm/kotlin.rs
+++ b/src/backend/jvm/kotlin.rs
@@ -201,27 +201,33 @@ fn generate_data_class(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_
         }
         // Sig-level constraint annotations (FieldOrdering → init block)
         let sig_constraints = analyze::constraints_for_sig(ir, &s.name);
-        let field_orderings: Vec<_> = sig_constraints.iter().filter_map(|c| {
-            if let analyze::ConstraintInfo::FieldOrdering { left_field, op, right_field, .. } = c {
-                let op_str = match op {
-                    CompareOp::Lt => "<",
-                    CompareOp::Gt => ">",
-                    CompareOp::Lte => "<=",
-                    CompareOp::Gte => ">=",
-                    _ => return None,
-                };
-                Some((left_field.clone(), op_str, right_field.clone()))
-            } else {
-                None
+        let mut init_checks: Vec<String> = Vec::new();
+        for c in &sig_constraints {
+            match c {
+                analyze::ConstraintInfo::FieldOrdering { left_field, op, right_field, .. } => {
+                    let op_str = match op {
+                        CompareOp::Lt => "<",
+                        CompareOp::Gt => ">",
+                        CompareOp::Lte => "<=",
+                        CompareOp::Gte => ">=",
+                        _ => continue,
+                    };
+                    init_checks.push(format!("require({left_field} {op_str} {right_field}) {{ \"{left_field} must be {op_str} {right_field}\" }}"));
+                }
+                analyze::ConstraintInfo::Implication { condition, consequent, .. } => {
+                    let desc = format!("{} implies {}", analyze::describe_expr(condition), analyze::describe_expr(consequent));
+                    init_checks.push(format!("// {desc}"));
+                }
+                _ => {}
             }
-        }).collect();
-        if field_orderings.is_empty() {
+        }
+        if init_checks.is_empty() {
             writeln!(out, ")").unwrap();
         } else {
             writeln!(out, ") {{").unwrap();
             writeln!(out, "    init {{").unwrap();
-            for (lf, op, rf) in &field_orderings {
-                writeln!(out, "        require({lf} {op} {rf}) {{ \"{lf} must be {op} {rf}\" }}").unwrap();
+            for check in &init_checks {
+                writeln!(out, "        {check}").unwrap();
             }
             writeln!(out, "    }}").unwrap();
             writeln!(out, "}}").unwrap();

--- a/src/backend/rust/expr_translator.rs
+++ b/src/backend/rust/expr_translator.rs
@@ -64,6 +64,7 @@ fn collect_tc_fields(expr: &Expr, ir: &OxidtrIR, out: &mut Vec<TCField>) {
             collect_tc_fields(right, ir, out);
         }
         Expr::Not(inner) | Expr::Cardinality(inner) => collect_tc_fields(inner, ir, out),
+        Expr::MultFormula { expr: inner, .. } => collect_tc_fields(inner, ir, out),
         Expr::Quantifier { bindings, body, .. } => {
             for b in bindings { collect_tc_fields(&b.domain, ir, out); }
             collect_tc_fields(body, ir, out);
@@ -94,6 +95,9 @@ fn collect_params(expr: &Expr, sig_names: &HashSet<String>, params: &mut BTreeSe
             collect_params(right, sig_names, params);
         }
         Expr::Not(inner) | Expr::Cardinality(inner) | Expr::TransitiveClosure(inner) => {
+            collect_params(inner, sig_names, params);
+        }
+        Expr::MultFormula { expr: inner, .. } => {
             collect_params(inner, sig_names, params);
         }
         Expr::Comparison { left, right, .. } | Expr::SetOp { left, right, .. }
@@ -197,6 +201,15 @@ fn translate_inner(expr: &Expr, parens_if_complex: bool, sig_names: &HashSet<Str
             let l = translate_inner(left, false, sig_names);
             let r = translate_inner(right, false, sig_names);
             format!("({l}, {r})")
+        }
+
+        Expr::MultFormula { kind, expr } => {
+            let inner = translate_inner(expr, false, sig_names);
+            match kind {
+                QuantKind::Some => format!("{inner}.is_some()"),
+                QuantKind::No => format!("{inner}.is_none()"),
+                _ => inner,
+            }
         }
     };
 
@@ -472,6 +485,15 @@ fn translate_inner_ir(
             let l = ti(left, false);
             let r = ti(right, false);
             format!("({l}, {r})")
+        }
+
+        Expr::MultFormula { kind, expr } => {
+            let inner = ti(expr, false);
+            match kind {
+                QuantKind::Some => format!("{inner}.is_some()"),
+                QuantKind::No => format!("{inner}.is_none()"),
+                _ => inner,
+            }
         }
     };
 

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -2,7 +2,7 @@ pub mod expr_translator;
 
 use super::GeneratedFile;
 use crate::ir::nodes::*;
-use crate::parser::ast::{Expr, Multiplicity, SigMultiplicity};
+use crate::parser::ast::{CompareOp, Expr, Multiplicity, SigMultiplicity};
 use crate::analyze;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
@@ -891,6 +891,31 @@ fn generate_newtypes(ir: &OxidtrIR) -> String {
                             writeln!(out, "        }}").unwrap();
                         }
                     }
+                }
+            }
+        }
+
+        // FieldOrdering checks
+        for c in &all_constraints {
+            if let analyze::ConstraintInfo::FieldOrdering { sig_name: s, left_field, op, right_field } = c {
+                if s == sig_name {
+                    let rust_op = match op {
+                        CompareOp::Lt => "<",
+                        CompareOp::Gt => ">",
+                        CompareOp::Lte => "<=",
+                        CompareOp::Gte => ">=",
+                        _ => continue,
+                    };
+                    let negated = match op {
+                        CompareOp::Lt => ">=",
+                        CompareOp::Gt => "<=",
+                        CompareOp::Lte => ">",
+                        CompareOp::Gte => "<",
+                        _ => continue,
+                    };
+                    writeln!(out, "        if value.{left_field} {negated} value.{right_field} {{").unwrap();
+                    writeln!(out, "            return Err(\"{left_field} must be {rust_op} {right_field}\");").unwrap();
+                    writeln!(out, "        }}").unwrap();
                 }
             }
         }

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -408,6 +408,7 @@ fn expr_uses_tc(expr: &crate::parser::ast::Expr) -> bool {
         Expr::TransitiveClosure(_) => true,
         Expr::FieldAccess { base, .. } => expr_uses_tc(base),
         Expr::Cardinality(inner) | Expr::Not(inner) => expr_uses_tc(inner),
+        Expr::MultFormula { expr: inner, .. } => expr_uses_tc(inner),
         Expr::Comparison { left, right, .. } | Expr::BinaryLogic { left, right, .. }
         | Expr::SetOp { left, right, .. } | Expr::Product { left, right } => {
             expr_uses_tc(left) || expr_uses_tc(right)
@@ -963,6 +964,7 @@ fn expr_has_comparison(expr: &crate::parser::ast::Expr) -> bool {
         Expr::Not(inner) | Expr::Cardinality(inner) | Expr::TransitiveClosure(inner) => {
             expr_has_comparison(inner)
         }
+        Expr::MultFormula { expr: inner, .. } => expr_has_comparison(inner),
         Expr::FieldAccess { base, .. } => expr_has_comparison(base),
         Expr::VarRef(_) | Expr::IntLiteral(_) => false,
     }

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -843,6 +843,27 @@ fn generate_newtypes(ir: &OxidtrIR) -> String {
             }
         }
 
+        // Disj uniqueness checks for seq fields
+        {
+            let disj = analyze::disj_fields(ir);
+            if let Some(structure) = ir.structures.iter().find(|s| s.name == *sig_name) {
+                for (dsig, dfield) in &disj {
+                    if dsig == sig_name {
+                        if let Some(f) = structure.fields.iter().find(|f| f.name == *dfield) {
+                            if f.mult == Multiplicity::Seq {
+                                writeln!(out, "        {{").unwrap();
+                                writeln!(out, "            let mut seen = std::collections::HashSet::new();").unwrap();
+                                writeln!(out, "            if !value.{dfield}.iter().all(|e| seen.insert(e)) {{").unwrap();
+                                writeln!(out, "                return Err(\"{dfield} must not contain duplicates (disj constraint)\");").unwrap();
+                                writeln!(out, "            }}").unwrap();
+                                writeln!(out, "        }}").unwrap();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         // Acyclic field checks (walk the chain, detect if value is reachable from itself)
         {
             let acyclic_fields: Vec<String> = all_constraints.iter()

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -843,6 +843,37 @@ fn generate_newtypes(ir: &OxidtrIR) -> String {
             }
         }
 
+        // Acyclic field checks (walk the chain, detect if value is reachable from itself)
+        {
+            let acyclic_fields: Vec<String> = all_constraints.iter()
+                .filter_map(|c| {
+                    if let analyze::ConstraintInfo::Acyclic { sig_name: s, field_name } = c {
+                        if s == sig_name {
+                            return Some(field_name.clone());
+                        }
+                    }
+                    None
+                })
+                .collect();
+            if let Some(structure) = ir.structures.iter().find(|s| s.name == *sig_name) {
+                for field_name in &acyclic_fields {
+                    if let Some(f) = structure.fields.iter().find(|f| f.name == *field_name) {
+                        if f.mult == Multiplicity::Lone && f.target == *sig_name {
+                            writeln!(out, "        {{").unwrap();
+                            writeln!(out, "            let mut cur = value.{field_name}.as_deref();").unwrap();
+                            writeln!(out, "            while let Some(node) = cur {{").unwrap();
+                            writeln!(out, "                if node == &value {{").unwrap();
+                            writeln!(out, "                    return Err(\"{field_name} must not form a cycle\");").unwrap();
+                            writeln!(out, "                }}").unwrap();
+                            writeln!(out, "                cur = node.{field_name}.as_deref();").unwrap();
+                            writeln!(out, "            }}").unwrap();
+                            writeln!(out, "        }}").unwrap();
+                        }
+                    }
+                }
+            }
+        }
+
         // Inline the constraint expression directly instead of calling invariant function
         // Bind param names with type annotations for closure inference
         // Only the param matching sig_name gets value.clone(); others get empty Vec

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -787,6 +787,18 @@ fn generate_newtypes(ir: &OxidtrIR) -> String {
             })
             .collect();
 
+        // Collect NoSelfRef fields for this sig
+        let no_self_ref_fields: Vec<String> = all_constraints.iter()
+            .filter_map(|c| {
+                if let analyze::ConstraintInfo::NoSelfRef { sig_name: s, field_name } = c {
+                    if s == sig_name {
+                        return Some(field_name.clone());
+                    }
+                }
+                None
+            })
+            .collect();
+
         writeln!(out, "/// Newtype wrapper: {sig_name} validated by {fact_name}.").unwrap();
         writeln!(out, "#[derive(Debug, Clone, PartialEq, Eq, Hash)]").unwrap();
         writeln!(out, "pub struct {newtype_name}(pub {sig_name});").unwrap();
@@ -807,6 +819,27 @@ fn generate_newtypes(ir: &OxidtrIR) -> String {
                 writeln!(out, "        if value.{field_name}.len() > {n} {{").unwrap();
                 writeln!(out, "            return Err(\"{fact_name}: {field_name} has more than {n} elements\");").unwrap();
                 writeln!(out, "        }}").unwrap();
+            }
+        }
+
+        // NoSelfRef field checks
+        if let Some(structure) = ir.structures.iter().find(|s| s.name == *sig_name) {
+            for field_name in &no_self_ref_fields {
+                if let Some(f) = structure.fields.iter().find(|f| f.name == *field_name) {
+                    match f.mult {
+                        Multiplicity::Lone => {
+                            writeln!(out, "        if value.{field_name}.as_ref().map_or(false, |f| f.as_ref() == &value) {{").unwrap();
+                            writeln!(out, "            return Err(\"{field_name} must not reference self\");").unwrap();
+                            writeln!(out, "        }}").unwrap();
+                        }
+                        Multiplicity::One => {
+                            writeln!(out, "        if *value.{field_name} == value {{").unwrap();
+                            writeln!(out, "            return Err(\"{field_name} must not reference self\");").unwrap();
+                            writeln!(out, "        }}").unwrap();
+                        }
+                        _ => {}
+                    }
+                }
             }
         }
 

--- a/src/backend/swift/expr_translator.rs
+++ b/src/backend/swift/expr_translator.rs
@@ -42,6 +42,7 @@ fn collect_tc_fields(expr: &Expr, ir: &OxidtrIR, out: &mut Vec<TCField>) {
             collect_tc_fields(right, ir, out);
         }
         Expr::Not(inner) | Expr::Cardinality(inner) => collect_tc_fields(inner, ir, out),
+        Expr::MultFormula { expr: inner, .. } => collect_tc_fields(inner, ir, out),
         Expr::Quantifier { bindings, body, .. } => {
             for b in bindings { collect_tc_fields(&b.domain, ir, out); }
             collect_tc_fields(body, ir, out);
@@ -83,6 +84,9 @@ fn collect_params(expr: &Expr, sig_names: &HashSet<String>, params: &mut BTreeSe
             collect_params(right, sig_names, params);
         }
         Expr::Not(inner) | Expr::Cardinality(inner) | Expr::TransitiveClosure(inner) => {
+            collect_params(inner, sig_names, params);
+        }
+        Expr::MultFormula { expr: inner, .. } => {
             collect_params(inner, sig_names, params);
         }
         Expr::FieldAccess { base, .. } => collect_params(base, sig_names, params),
@@ -184,6 +188,15 @@ fn translate_inner(
             let l = ti(left, false);
             let r = ti(right, false);
             format!("({l}, {r})")
+        }
+
+        Expr::MultFormula { kind, expr } => {
+            let inner = ti(expr, false);
+            match kind {
+                QuantKind::Some => format!("{inner} != nil"),
+                QuantKind::No => format!("{inner} == nil"),
+                _ => inner,
+            }
         }
     };
 

--- a/src/backend/swift/mod.rs
+++ b/src/backend/swift/mod.rs
@@ -739,6 +739,7 @@ fn expr_uses_tc(expr: &crate::parser::ast::Expr) -> bool {
         Expr::TransitiveClosure(_) => true,
         Expr::FieldAccess { base, .. } => expr_uses_tc(base),
         Expr::Cardinality(inner) | Expr::Not(inner) => expr_uses_tc(inner),
+        Expr::MultFormula { expr: inner, .. } => expr_uses_tc(inner),
         Expr::Comparison { left, right, .. } | Expr::BinaryLogic { left, right, .. }
         | Expr::SetOp { left, right, .. } | Expr::Product { left, right } => {
             expr_uses_tc(left) || expr_uses_tc(right)

--- a/src/backend/typescript/expr_translator.rs
+++ b/src/backend/typescript/expr_translator.rs
@@ -57,6 +57,9 @@ fn collect_params(expr: &Expr, sig_names: &HashSet<String>, params: &mut BTreeSe
         Expr::Not(inner) | Expr::Cardinality(inner) | Expr::TransitiveClosure(inner) => {
             collect_params(inner, sig_names, params);
         }
+        Expr::MultFormula { expr: inner, .. } => {
+            collect_params(inner, sig_names, params);
+        }
         Expr::FieldAccess { base, .. } => collect_params(base, sig_names, params),
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
@@ -86,6 +89,7 @@ fn collect_tc_fields(expr: &Expr, ir: &OxidtrIR, out: &mut Vec<TCField>) {
             collect_tc_fields(right, ir, out);
         }
         Expr::Not(inner) | Expr::Cardinality(inner) => collect_tc_fields(inner, ir, out),
+        Expr::MultFormula { expr: inner, .. } => collect_tc_fields(inner, ir, out),
         Expr::Quantifier { bindings, body, .. } => {
             for b in bindings { collect_tc_fields(&b.domain, ir, out); }
             collect_tc_fields(body, ir, out);
@@ -210,6 +214,15 @@ fn translate_inner(
             let l = ti(left, false);
             let r = ti(right, false);
             format!("[{l}, {r}]")
+        }
+
+        Expr::MultFormula { kind, expr } => {
+            let inner = ti(expr, false);
+            match kind {
+                QuantKind::Some => format!("{inner} != null"),
+                QuantKind::No => format!("{inner} == null"),
+                _ => inner,
+            }
         }
     };
 

--- a/src/backend/typescript/mod.rs
+++ b/src/backend/typescript/mod.rs
@@ -955,6 +955,13 @@ pub fn generate_validators(ir: &OxidtrIR) -> String {
                     let desc = analyze::describe_expr(condition);
                     writeln!(out, "  if ({cond}) errors.push(\"prohibited: {}\");", desc.replace('"', "\\\"")).unwrap();
                 }
+                analyze::ConstraintInfo::Disjoint { left, right, .. } => {
+                    writeln!(out, "  // Disjoint: {left} and {right} must not overlap").unwrap();
+                }
+                analyze::ConstraintInfo::Exhaustive { categories, .. } => {
+                    let cats = categories.join(", ");
+                    writeln!(out, "  // Exhaustive: must belong to one of [{cats}]").unwrap();
+                }
                 _ => {} // Named, Membership — not directly translatable to simple validators
             }
         }

--- a/src/backend/typescript/mod.rs
+++ b/src/backend/typescript/mod.rs
@@ -938,14 +938,22 @@ pub fn generate_validators(ir: &OxidtrIR) -> String {
                     };
                     writeln!(out, "  if ({param_name}.{left_field} {negated_op} {param_name}.{right_field}) errors.push(\"{left_field} must be {ts_op} {right_field}\");").unwrap();
                 }
+                analyze::ConstraintInfo::Implication { condition, consequent, .. } => {
+                    let cond = translate_validator_expr(condition, &s.name, &param_name);
+                    let cons = translate_validator_expr(consequent, &s.name, &param_name);
+                    let desc = format!("{} implies {}", analyze::describe_expr(condition), analyze::describe_expr(consequent));
+                    writeln!(out, "  if ({cond} && !({cons})) errors.push(\"{}\");", desc.replace('"', "\\\"")).unwrap();
+                }
                 analyze::ConstraintInfo::Iff { left, right, .. } => {
-                    let desc_l = analyze::describe_expr(left);
-                    let desc_r = analyze::describe_expr(right);
-                    writeln!(out, "  // TODO: iff constraint — {desc_l} iff {desc_r}").unwrap();
+                    let l = translate_validator_expr(left, &s.name, &param_name);
+                    let r = translate_validator_expr(right, &s.name, &param_name);
+                    let desc = format!("{} iff {}", analyze::describe_expr(left), analyze::describe_expr(right));
+                    writeln!(out, "  if (({l}) !== ({r})) errors.push(\"{}\");", desc.replace('"', "\\\"")).unwrap();
                 }
                 analyze::ConstraintInfo::Prohibition { condition, .. } => {
+                    let cond = translate_validator_expr(condition, &s.name, &param_name);
                     let desc = analyze::describe_expr(condition);
-                    writeln!(out, "  // TODO: prohibition — no instance where {desc}").unwrap();
+                    writeln!(out, "  if ({cond}) errors.push(\"prohibited: {}\");", desc.replace('"', "\\\"")).unwrap();
                 }
                 _ => {} // Named, Membership — not directly translatable to simple validators
             }
@@ -969,4 +977,56 @@ pub fn generate_validators(ir: &OxidtrIR) -> String {
     }
 
     out
+}
+
+/// Translate an Alloy expression to TypeScript for single-instance validator context.
+/// `sig_name` is the sig name used by substitute_var, `param` is the TS parameter name.
+fn translate_validator_expr(expr: &crate::parser::ast::Expr, sig_name: &str, param: &str) -> String {
+    use crate::parser::ast::{Expr, LogicOp, QuantKind};
+    match expr {
+        Expr::VarRef(name) => {
+            if name == sig_name { param.to_string() } else { name.clone() }
+        }
+        Expr::IntLiteral(n) => n.to_string(),
+        Expr::FieldAccess { base, field } => {
+            format!("{}.{}", translate_validator_expr(base, sig_name, param), field)
+        }
+        Expr::Comparison { op, left, right } => {
+            let l = translate_validator_expr(left, sig_name, param);
+            let r = translate_validator_expr(right, sig_name, param);
+            let o = match op {
+                CompareOp::Eq => "===",
+                CompareOp::NotEq => "!==",
+                CompareOp::In => return format!("{r}.includes({l})"),
+                CompareOp::Lt => "<",
+                CompareOp::Gt => ">",
+                CompareOp::Lte => "<=",
+                CompareOp::Gte => ">=",
+            };
+            format!("{l} {o} {r}")
+        }
+        Expr::BinaryLogic { op, left, right } => {
+            let l = translate_validator_expr(left, sig_name, param);
+            let r = translate_validator_expr(right, sig_name, param);
+            match op {
+                LogicOp::And => format!("{l} && {r}"),
+                LogicOp::Or => format!("{l} || {r}"),
+                LogicOp::Implies => format!("!({l}) || {r}"),
+                LogicOp::Iff => format!("({l}) === ({r})"),
+            }
+        }
+        Expr::Not(inner) => format!("!({})", translate_validator_expr(inner, sig_name, param)),
+        Expr::MultFormula { kind, expr: inner } => {
+            let e = translate_validator_expr(inner, sig_name, param);
+            match kind {
+                QuantKind::Some => format!("{e} != null"),
+                QuantKind::No => format!("{e} == null"),
+                _ => e,
+            }
+        }
+        Expr::Cardinality(inner) => {
+            format!("{}.length", translate_validator_expr(inner, sig_name, param))
+        }
+        _ => analyze::describe_expr(expr), // fallback: human-readable
+    }
 }

--- a/src/backend/typescript/mod.rs
+++ b/src/backend/typescript/mod.rs
@@ -2,7 +2,7 @@ pub mod expr_translator;
 
 use super::GeneratedFile;
 use crate::ir::nodes::*;
-use crate::parser::ast::{Multiplicity, SigMultiplicity};
+use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity};
 use crate::analyze;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
@@ -919,6 +919,32 @@ pub fn generate_validators(ir: &OxidtrIR) -> String {
                 }
                 analyze::ConstraintInfo::Acyclic { field_name, .. } => {
                     writeln!(out, "  {{ const seen = new Set<unknown>(); let cur: unknown = {param_name}; while (cur != null) {{ if (seen.has(cur)) {{ errors.push(\"{field_name} must not form a cycle\"); break; }} seen.add(cur); cur = (cur as Record<string, unknown>).{field_name}; }} }}").unwrap();
+                }
+                analyze::ConstraintInfo::FieldOrdering { left_field, op, right_field, .. } => {
+                    let ts_op = match op {
+                        CompareOp::Lt => "<",
+                        CompareOp::Gt => ">",
+                        CompareOp::Lte => "<=",
+                        CompareOp::Gte => ">=",
+                        _ => continue,
+                    };
+                    let negated_op = match op {
+                        CompareOp::Lt => ">=",
+                        CompareOp::Gt => "<=",
+                        CompareOp::Lte => ">",
+                        CompareOp::Gte => "<",
+                        _ => continue,
+                    };
+                    writeln!(out, "  if ({param_name}.{left_field} {negated_op} {param_name}.{right_field}) errors.push(\"{left_field} must be {ts_op} {right_field}\");").unwrap();
+                }
+                analyze::ConstraintInfo::Iff { left, right, .. } => {
+                    let desc_l = analyze::describe_expr(left);
+                    let desc_r = analyze::describe_expr(right);
+                    writeln!(out, "  // TODO: iff constraint — {desc_l} iff {desc_r}").unwrap();
+                }
+                analyze::ConstraintInfo::Prohibition { condition, .. } => {
+                    let desc = analyze::describe_expr(condition);
+                    writeln!(out, "  // TODO: prohibition — no instance where {desc}").unwrap();
                 }
                 _ => {} // Named, Membership — not directly translatable to simple validators
             }

--- a/src/backend/typescript/mod.rs
+++ b/src/backend/typescript/mod.rs
@@ -924,6 +924,18 @@ pub fn generate_validators(ir: &OxidtrIR) -> String {
             }
         }
 
+        // Disj uniqueness checks for seq fields
+        let disj = analyze::disj_fields(ir);
+        for (dsig, dfield) in &disj {
+            if dsig == &s.name {
+                if let Some(f) = s.fields.iter().find(|f| f.name == *dfield) {
+                    if f.mult == Multiplicity::Seq {
+                        writeln!(out, "  if (new Set({param_name}.{dfield}).size !== {param_name}.{dfield}.length) errors.push(\"{dfield} must not contain duplicates (disj constraint)\");").unwrap();
+                    }
+                }
+            }
+        }
+
         writeln!(out, "  return errors;").unwrap();
         writeln!(out, "}}").unwrap();
         writeln!(out).unwrap();

--- a/src/backend/typescript/mod.rs
+++ b/src/backend/typescript/mod.rs
@@ -917,7 +917,10 @@ pub fn generate_validators(ir: &OxidtrIR) -> String {
                 analyze::ConstraintInfo::NoSelfRef { field_name, .. } => {
                     writeln!(out, "  if ({param_name}.{field_name} === {param_name}) errors.push(\"{field_name} must not reference self\");").unwrap();
                 }
-                _ => {} // Named, Membership, Acyclic — too complex for simple validators
+                analyze::ConstraintInfo::Acyclic { field_name, .. } => {
+                    writeln!(out, "  {{ const seen = new Set<unknown>(); let cur: unknown = {param_name}; while (cur != null) {{ if (seen.has(cur)) {{ errors.push(\"{field_name} must not form a cycle\"); break; }} seen.add(cur); cur = (cur as Record<string, unknown>).{field_name}; }} }}").unwrap();
+                }
+                _ => {} // Named, Membership — not directly translatable to simple validators
             }
         }
 

--- a/src/backend/typescript/mod.rs
+++ b/src/backend/typescript/mod.rs
@@ -573,6 +573,7 @@ fn expr_uses_tc(expr: &crate::parser::ast::Expr) -> bool {
         Expr::TransitiveClosure(_) => true,
         Expr::FieldAccess { base, .. } => expr_uses_tc(base),
         Expr::Cardinality(inner) | Expr::Not(inner) => expr_uses_tc(inner),
+        Expr::MultFormula { expr: inner, .. } => expr_uses_tc(inner),
         Expr::Comparison { left, right, .. } | Expr::BinaryLogic { left, right, .. }
         | Expr::SetOp { left, right, .. } | Expr::Product { left, right } => {
             expr_uses_tc(left) || expr_uses_tc(right)

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -420,6 +420,7 @@ fn expr_references_sig_name(expr: &crate::parser::ast::Expr, sig_name: &str) -> 
         Expr::Not(inner) | Expr::Cardinality(inner) | Expr::TransitiveClosure(inner) => {
             expr_references_sig_name(inner, sig_name)
         }
+        Expr::MultFormula { expr: inner, .. } => expr_references_sig_name(inner, sig_name),
         Expr::FieldAccess { base, .. } => expr_references_sig_name(base, sig_name),
         Expr::IntLiteral(_) => false,
     }
@@ -447,6 +448,7 @@ fn constraint_references_field(expr: &crate::parser::ast::Expr, _sig: &str, fiel
         }
         Expr::Cardinality(inner) => constraint_references_field(inner, _sig, field),
         Expr::TransitiveClosure(inner) => constraint_references_field(inner, _sig, field),
+        Expr::MultFormula { expr: inner, .. } => constraint_references_field(inner, _sig, field),
         Expr::SetOp { left, right, .. } | Expr::Product { left, right } => {
             constraint_references_field(left, _sig, field)
                 || constraint_references_field(right, _sig, field)
@@ -492,6 +494,7 @@ fn collect_tc_fields(expr: &crate::parser::ast::Expr, out: &mut std::collections
             collect_tc_fields(left, out); collect_tc_fields(right, out);
         }
         Expr::Not(inner) | Expr::Cardinality(inner) => collect_tc_fields(inner, out),
+        Expr::MultFormula { expr: inner, .. } => collect_tc_fields(inner, out),
         Expr::Quantifier { bindings, body, .. } => {
             for b in bindings { collect_tc_fields(&b.domain, out); }
             collect_tc_fields(body, out);
@@ -535,6 +538,7 @@ fn constraint_references_field_non_tc(expr: &crate::parser::ast::Expr, field: &s
         Expr::Not(inner) | Expr::Cardinality(inner) => {
             constraint_references_field_non_tc(inner, field)
         }
+        Expr::MultFormula { expr: inner, .. } => constraint_references_field_non_tc(inner, field),
         Expr::Quantifier { bindings, body, .. } => {
             bindings.iter().any(|b| constraint_references_field_non_tc(&b.domain, field))
                 || constraint_references_field_non_tc(body, field)

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -95,6 +95,12 @@ pub enum Expr {
         right: Box<Expr>,
     },
     Not(Box<Expr>),
+    /// Multiplicity formula: `some expr` (non-empty) or `no expr` (empty).
+    /// Distinct from Quantifier which has bindings and a body.
+    MultFormula {
+        kind: QuantKind, // Some or No
+        expr: Box<Expr>,
+    },
     Quantifier {
         kind: QuantKind,
         bindings: Vec<QuantBinding>,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -459,11 +459,36 @@ impl<'a> Parser<'a> {
                 let inner = self.parse_field_access()?;
                 Ok(Expr::Cardinality(Box::new(inner)))
             }
-            Token::All | Token::Some_ | Token::No => {
+            Token::All => {
                 self.parse_quantifier()
+            }
+            Token::Some_ | Token::No => {
+                // Try quantifier first (some/no x: S | body), fall back to formula (some/no expr)
+                let saved = self.lexer.pos();
+                match self.parse_quantifier() {
+                    Ok(expr) => Ok(expr),
+                    Err(_) => {
+                        self.lexer.set_pos(saved);
+                        self.parse_mult_formula()
+                    }
+                }
             }
             _ => self.parse_field_access(),
         }
+    }
+
+    /// Parse `some expr` or `no expr` as a multiplicity formula.
+    fn parse_mult_formula(&mut self) -> Result<Expr, ParseError> {
+        let kind = match self.next() {
+            Token::Some_ => QuantKind::Some,
+            Token::No => QuantKind::No,
+            _ => unreachable!(),
+        };
+        let inner = self.parse_field_access()?;
+        Ok(Expr::MultFormula {
+            kind,
+            expr: Box::new(inner),
+        })
     }
 
     fn parse_quantifier(&mut self) -> Result<Expr, ParseError> {


### PR DESCRIPTION
## Summary

This PR significantly expands the constraint analysis system by introducing six new `ConstraintInfo` variants to capture additional Alloy constraint patterns, along with corresponding code generation and validation logic across all backend targets (Rust, TypeScript, Java, Kotlin, Swift).

## Key Changes

### Constraint Analysis (`src/analyze/mod.rs`)
- **New ConstraintInfo variants:**
  - `Iff`: Biconditional constraints (`A iff B`)
  - `FieldOrdering`: Direct field-to-field comparisons (`s.x <= s.y`)
  - `Disjoint`: Set disjointness constraints (`no (A & B)`)
  - `Exhaustive`: Exhaustive classification (`x in A or x in B or ...`)
  - `Implication`: Conditional constraints (`condition implies consequent`)
  - `Prohibition`: Negated existential constraints (`no condition`)

- **New helper functions:**
  - `collect_exhaustive_categories()`: Extracts categories from disjunctive patterns
  - `infer_sig_from_expr()`: Infers signature name from field access expressions
  - `substitute_var()`: Normalizes expressions by replacing quantifier variables with signature names

- **Enhanced pattern matching:**
  - `analyze_expr()` now detects `Prohibition` patterns in `no` quantifiers
  - `analyze_expr()` now detects `Disjoint` patterns in `no (A & B)` formulas
  - `analyze_body_for_sig()` now detects `FieldOrdering`, `Exhaustive`, `Iff`, and `Implication` patterns
  - Updated `constraints_for_sig()` filter to include all new variants

### Parser (`src/parser/mod.rs`)
- Added `MultFormula` expression variant for multiplicity formulas (`some expr`, `no expr`)
- Enhanced parser to distinguish between quantifiers with bindings and multiplicity formulas
- Added `parse_mult_formula()` method with fallback logic

### Code Generation

**Rust backend (`src/backend/rust/mod.rs`):**
- NoSelfRef field validation in `TryFrom` implementations
- Acyclic field cycle detection with chain traversal
- Disj uniqueness checks for seq fields using HashSet
- FieldOrdering validation with comparison operators

**TypeScript backend (`src/backend/typescript/mod.rs`):**
- Added `translate_validator_expr()` function for expression translation in validator context
- Comprehensive validator generation for all new constraint types
- Cycle detection for acyclic fields using Set-based tracking
- Disjoint and Exhaustive constraints emitted as comments (extensible for future switch/match generation)

**Java backend (`src/backend/jvm/java.rs`):**
- NoSelfRef and Acyclic constraint annotations in record generation
- FieldOrdering validation in compact constructor with IllegalArgumentException
- Implication constraints as documentation comments

**Kotlin backend (`src/backend/jvm/kotlin.rs`):**
- NoSelfRef and Acyclic constraint annotations
- FieldOrdering validation in init block with require() expressions
- Implication constraints as documentation comments

**Swift backend (`src/backend/swift/mod.rs`):**
- Updated expression traversal to handle MultFormula variant

### Expression Translation
- Updated all backend expression translators to handle `MultFormula` variant
- Enhanced `describe_expr()` and `alloy_repr()` to format multiplicity formulas
- Updated `expr_references_sig()` and related traversal functions across all backends

### Documentation (`CLAUDE.md`)
- Added comprehensive section on constraint analysis implementation status
- Documented which constraints have runtime validation vs. comment-only output
- Identified opportunities for future code generation (Disjoint/Exhaustive switch patterns)
- Noted parser extensions and remaining work (derived fields, Lean backend)

### Alloy Models
- Added `MultFormula` signature to both `oxidtr.als` and `oxidtr-domain.als`
- Added constraint analysis signatures: `FieldOrdering`, `Implication`, `Prohibition`, `Disjoint`, `Exhaustive`

## Notable Implementation Details

- **Variable substitution**:

https://claude.ai/code/session_019MGqkV7B2vy8ASVWgWotvS