### PR TITLE
Add true/false as Boolean subtypes to language primitives

### DIFF
--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -404,6 +404,8 @@ pub fn is_language_primitive(name: &str) -> bool {
         | "uint" | "uint8" | "uint16" | "uint32" | "uint64"
         | "float32" | "float64" | "rune" | "error"
         | "complex64" | "complex128"
+        // Boolean literal types (subtypes of Boolean, shared across all languages)
+        | "true" | "false"
         // Go/TS shared (already covered above: any, bool, string, int, byte)
     )
 }

--- a/tests/extract_rust.rs
+++ b/tests/extract_rust.rs
@@ -312,6 +312,10 @@ fn is_language_primitive_covers_all_languages() {
     assert!(is_language_primitive("complex64"));
     assert!(is_language_primitive("complex128"));
 
+    // Boolean literal types (subtypes of Boolean)
+    assert!(is_language_primitive("true"));
+    assert!(is_language_primitive("false"));
+
     // User-defined types should NOT be primitives
     assert!(!is_language_primitive("User"));
     assert!(!is_language_primitive("AppConfig"));


### PR DESCRIPTION
## Summary
- `is_language_primitive()` に `"true"` / `"false"` を追加（全言語共通のBoolean literal types）
- extract時にこれらがユーザー定義sigとして誤認されるのを防止
- テストも追加済み

## Test plan
- [x] `is_language_primitive_covers_all_languages` テストに `true`/`false` のアサーション追加
- [x] `cargo test` 全テストパス、warning ゼロ確認済み

https://claude.ai/code/session_01VmoyKuNu28Q8xjtvDQ9hER