### PR TITLE
fix: collect_block depth underflow guard & TS extractor improvements

### DIFF
--- a/src/extract/java_extractor.rs
+++ b/src/extract/java_extractor.rs
@@ -313,11 +313,13 @@ fn collect_block(
     lines: &mut std::iter::Peekable<std::iter::Enumerate<std::str::Lines<'_>>>,
 ) -> Vec<(usize, String)> {
     let mut body = Vec::new();
+    // The opening '{' is on the trigger line (already consumed by the caller's loop),
+    // so we start at depth=1.
     let mut depth = 1usize;
     for (ln, line) in lines.by_ref() {
         let trimmed = line.trim();
         for ch in trimmed.chars() {
-            match ch { '{' => depth += 1, '}' => depth -= 1, _ => {} }
+            match ch { '{' => depth += 1, '}' => { if depth > 0 { depth -= 1; } } _ => {} }
         }
         if depth == 0 { break; }
         body.push((ln, trimmed.to_string()));

--- a/src/extract/kotlin_extractor.rs
+++ b/src/extract/kotlin_extractor.rs
@@ -347,11 +347,13 @@ fn collect_block(
     lines: &mut std::iter::Peekable<std::iter::Enumerate<std::str::Lines<'_>>>,
 ) -> Vec<(usize, String)> {
     let mut body = Vec::new();
+    // The opening '{' is on the trigger line (already consumed by the caller's loop),
+    // so we start at depth=1.
     let mut depth = 1usize;
     for (ln, line) in lines.by_ref() {
         let trimmed = line.trim();
         for ch in trimmed.chars() {
-            match ch { '{' => depth += 1, '}' => depth -= 1, _ => {} }
+            match ch { '{' => depth += 1, '}' => { if depth > 0 { depth -= 1; } } _ => {} }
         }
         if depth == 0 { break; }
         body.push((ln, trimmed.to_string()));

--- a/src/extract/swift_extractor.rs
+++ b/src/extract/swift_extractor.rs
@@ -220,11 +220,13 @@ fn collect_block(
     lines: &mut std::iter::Peekable<std::iter::Enumerate<std::str::Lines<'_>>>,
 ) -> Vec<(usize, String)> {
     let mut body = Vec::new();
+    // The opening '{' is on the trigger line (already consumed by the caller's loop),
+    // so we start at depth=1.
     let mut depth = 1usize;
     for (ln, line) in lines.by_ref() {
         let trimmed = line.trim();
         for ch in trimmed.chars() {
-            match ch { '{' => depth += 1, '}' => depth -= 1, _ => {} }
+            match ch { '{' => depth += 1, '}' => { if depth > 0 { depth -= 1; } } _ => {} }
         }
         if depth == 0 { break; }
         body.push((ln, trimmed.to_string()));

--- a/src/extract/ts_extractor.rs
+++ b/src/extract/ts_extractor.rs
@@ -13,7 +13,7 @@ pub fn extract(source: &str) -> MinedModel {
         let trimmed = line.trim();
 
         // export interface Foo { ... } → sig
-        if let Some(name) = parse_interface_decl(trimmed) {
+        if let Some((name, iface_parent)) = parse_interface_decl(trimmed) {
             // Self-closing interface on one line: "export interface Foo {}"
             let fields = if trimmed.contains('{') && trimmed.contains('}') {
                 vec![]
@@ -29,7 +29,7 @@ pub fn extract(source: &str) -> MinedModel {
                 name,
                 fields: real_fields,
                 is_abstract: false,
-                parent: None,
+                parent: iface_parent,
                 source_location: format!("line {}", line_num + 1),
             });
         }
@@ -85,13 +85,44 @@ pub fn extract(source: &str) -> MinedModel {
     MinedModel { sigs, fact_candidates }
 }
 
-fn parse_interface_decl(line: &str) -> Option<String> {
+/// Returns (name, first_parent) for an interface declaration.
+/// Handles `interface Foo`, `interface Foo<T>`, `interface Foo extends Bar`,
+/// and `interface Foo extends Bar, Baz` (takes first parent only).
+fn parse_interface_decl(line: &str) -> Option<(String, Option<String>)> {
     let rest = line.strip_prefix("export interface ")
         .or_else(|| line.strip_prefix("interface "))?;
+
+    // Extract name (up to '<', ' ', or '{')
     let name: String = rest.chars()
         .take_while(|c| c.is_alphanumeric() || *c == '_')
         .collect();
-    if name.is_empty() { None } else { Some(name) }
+    if name.is_empty() { return None; }
+
+    // Look for `extends` keyword after the name (skip generics <...>)
+    let after_name = &rest[name.len()..];
+    let after_generics = if after_name.starts_with('<') {
+        // Skip generic params: find matching '>'
+        let mut depth = 0usize;
+        let mut end = 0;
+        for (i, ch) in after_name.chars().enumerate() {
+            match ch { '<' => depth += 1, '>' => { depth -= 1; if depth == 0 { end = i + 1; break; } } _ => {} }
+        }
+        &after_name[end..]
+    } else {
+        after_name
+    };
+
+    let parent = if let Some(ext) = after_generics.trim_start().strip_prefix("extends ") {
+        // Take first parent (before ',', '<', or '{')
+        let first: String = ext.chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        if first.is_empty() { None } else { Some(first) }
+    } else {
+        None
+    };
+
+    Some((name, parent))
 }
 
 fn parse_type_union(line: &str) -> Option<(String, Vec<String>)> {
@@ -116,19 +147,87 @@ fn collect_interface_fields(
 ) -> Vec<MinedField> {
     let mut fields = Vec::new();
     let mut depth = 1usize;
+    // Track inline object depth separately to avoid mis-counting type annotations.
+    // When depth==1 and we encounter a field line whose type part has unbalanced
+    // braces, we accumulate them here and skip those lines for field parsing.
+    let mut inline_depth: isize = 0;
 
     for (_ln, line) in lines.by_ref() {
         let trimmed = line.trim();
-        // Capture depth BEFORE processing this line's braces.
-        // Only parse fields at the top level of the interface (depth == 1).
         let depth_before = depth;
-        for ch in trimmed.chars() {
-            match ch { '{' => depth += 1, '}' => depth -= 1, _ => {} }
+
+        // Single-line JSDoc /** ... */ or block comment content: skip brace counting entirely.
+        // These lines cannot be field declarations and their braces (e.g. `{ y: 10 }`)
+        // must not affect the interface depth.
+        if (trimmed.starts_with("/**") && trimmed.ends_with("*/"))
+            || trimmed.starts_with("* ")
+            || trimmed == "*"
+            || trimmed.starts_with("*/")
+        {
+            continue;
         }
+
+        if inline_depth > 0 {
+            // Consuming lines inside a multi-line inline object type.
+            for ch in trimmed.chars() {
+                match ch {
+                    '{' => inline_depth += 1,
+                    '}' => inline_depth -= 1,
+                    _ => {}
+                }
+            }
+            if inline_depth <= 0 {
+                inline_depth = 0;
+                // The closing '}' of the inline object is consumed.
+                // Depth of the outer interface is unchanged.
+            }
+            continue;
+        }
+
+        // Count braces, but be careful about inline object types.
+        // For a field line at depth==1 (e.g. `bounds?: { x?: number; };`),
+        // braces in the type annotation are balanced on the same line.
+        // For a multi-line inline object (open brace not closed on same line),
+        // we enter inline_depth mode.
+        if depth_before == 1 {
+            let colon_pos = trimmed.find(':');
+            if let Some(cp) = colon_pos {
+                if !trimmed.starts_with('}') {
+                    let before = &trimmed[..cp];
+                    let type_part = &trimmed[cp..];
+                    // Count pre-colon braces (e.g., the outer `}` only)
+                    for ch in before.chars() {
+                        match ch { '{' => depth += 1, '}' => { if depth > 0 { depth -= 1; } } _ => {} }
+                    }
+                    // Net brace count in the type part
+                    let open_t = type_part.chars().filter(|&c| c == '{').count() as isize;
+                    let close_t = type_part.chars().filter(|&c| c == '}').count() as isize;
+                    let net = open_t - close_t;
+                    if net > 0 {
+                        // Multi-line inline object: enter inline tracking mode
+                        inline_depth = net;
+                    }
+                    // Balanced or over-closed: no depth change for outer interface
+                } else {
+                    // Line starts with '}': closing the interface or a nested block
+                    for ch in trimmed.chars() {
+                        match ch { '{' => depth += 1, '}' => { if depth > 0 { depth -= 1; } } _ => {} }
+                    }
+                }
+            } else {
+                for ch in trimmed.chars() {
+                    match ch { '{' => depth += 1, '}' => { if depth > 0 { depth -= 1; } } _ => {} }
+                }
+            }
+        } else {
+            for ch in trimmed.chars() {
+                match ch { '{' => depth += 1, '}' => { if depth > 0 { depth -= 1; } } _ => {} }
+            }
+        }
+
         if depth == 0 { break; }
 
-        // Skip fields nested inside inline object types (e.g. bounds?: { x: ...; y: ...; })
-        if depth_before == 1 {
+        if depth_before == 1 && inline_depth == 0 {
             if let Some(field) = parse_ts_field(trimmed) {
                 fields.push(field);
             }
@@ -230,14 +329,23 @@ fn collect_block(
     lines: &mut std::iter::Peekable<std::iter::Enumerate<std::str::Lines<'_>>>,
 ) -> Vec<(usize, String)> {
     let mut body = Vec::new();
-    let mut depth = 1usize;
+    // depth starts at 0: we haven't seen the opening '{' yet.
+    // For single-line trigger (e.g. `function f() {`), the caller's line already
+    // contained the '{', so we start at depth=1 only when the trigger line had one.
+    // Here we conservatively start at 0 and increment on the first '{' we see.
+    let mut depth = 0usize;
+    let mut started = false;
 
     for (ln, line) in lines.by_ref() {
         let trimmed = line.trim();
         for ch in trimmed.chars() {
-            match ch { '{' => depth += 1, '}' => depth -= 1, _ => {} }
+            match ch {
+                '{' => { depth += 1; started = true; }
+                '}' => { if depth > 0 { depth -= 1; } }
+                _ => {}
+            }
         }
-        if depth == 0 { break; }
+        if started && depth == 0 { break; }
         body.push((ln, trimmed.to_string()));
     }
     body

--- a/tests/extract_general_patterns.rs
+++ b/tests/extract_general_patterns.rs
@@ -1,7 +1,7 @@
 /// Mine tests for general patterns found in hand-written (non-oxidtr-generated) code.
 /// Organized by pattern category following TDD: tests written first, then implementation.
 
-use oxidtr::extract::{rust_extractor, ts_extractor, kotlin_extractor, java_extractor, Confidence};
+use oxidtr::extract::{rust_extractor, ts_extractor, kotlin_extractor, java_extractor, swift_extractor, Confidence};
 
 // ── Category 1: Validation patterns ──────────────────────────────────────────
 
@@ -587,4 +587,52 @@ fn ts_map_chain() {
         ".map() should produce field mapping candidate: {:?}",
         mined.fact_candidates
     );
+}
+
+// ── collect_block depth underflow protection ────────────────────────────────
+
+#[test]
+fn java_collect_block_extra_closing_brace_no_panic() {
+    // Source with an extra '}' that could cause depth underflow.
+    // The record body has an extra '}' in a string literal.
+    let src = r#"
+public record Foo(String name) {
+    public Foo {
+        if (name.contains("}")) {
+            throw new IllegalArgumentException("bad");
+        }
+    }
+}
+"#;
+    // Should not panic; just extract whatever it can
+    let mined = java_extractor::extract(src);
+    assert!(!mined.sigs.is_empty(), "should extract Foo record");
+}
+
+#[test]
+fn kotlin_collect_block_extra_closing_brace_no_panic() {
+    let src = r#"
+data class Foo(val name: String) {
+    init {
+        require(!name.contains("}")) { "bad" }
+    }
+}
+"#;
+    let mined = kotlin_extractor::extract(src);
+    assert!(!mined.sigs.is_empty(), "should extract Foo data class");
+}
+
+#[test]
+fn swift_collect_block_extra_closing_brace_no_panic() {
+    let src = r#"
+struct Foo {
+    let name: String
+    init(name: String) {
+        precondition(!name.contains("}"))
+        self.name = name
+    }
+}
+"#;
+    let mined = swift_extractor::extract(src);
+    assert!(!mined.sigs.is_empty(), "should extract Foo struct");
 }

--- a/tests/extract_ts.rs
+++ b/tests/extract_ts.rs
@@ -172,3 +172,146 @@ sig Role {}
     assert_eq!(roles_field.mult, MinedMultiplicity::Set);
     assert_eq!(roles_field.target, "Role");
 }
+
+// --- Tests for parse_interface_decl: extends parent extraction ---
+
+#[test]
+fn mine_ts_interface_extends_parent() {
+    let src = r#"
+export interface Child extends Parent {
+  name: string;
+}
+export interface Parent {}
+"#;
+    let mined = ts_extractor::extract(src);
+    let child = mined.sigs.iter().find(|s| s.name == "Child").unwrap();
+    assert_eq!(child.parent.as_deref(), Some("Parent"));
+    assert_eq!(child.fields.len(), 1);
+}
+
+#[test]
+fn mine_ts_interface_extends_with_generics() {
+    let src = r#"
+export interface Container<T> extends Base {
+  items: T[];
+}
+"#;
+    let mined = ts_extractor::extract(src);
+    let container = mined.sigs.iter().find(|s| s.name == "Container").unwrap();
+    assert_eq!(container.parent.as_deref(), Some("Base"));
+}
+
+#[test]
+fn mine_ts_interface_extends_multiple_takes_first() {
+    let src = r#"
+export interface Combo extends Alpha, Beta {
+  value: number;
+}
+"#;
+    let mined = ts_extractor::extract(src);
+    let combo = mined.sigs.iter().find(|s| s.name == "Combo").unwrap();
+    assert_eq!(combo.parent.as_deref(), Some("Alpha"));
+}
+
+#[test]
+fn mine_ts_interface_no_extends_has_no_parent() {
+    let src = r#"
+export interface Plain {
+  x: number;
+}
+"#;
+    let mined = ts_extractor::extract(src);
+    let plain = mined.sigs.iter().find(|s| s.name == "Plain").unwrap();
+    assert!(plain.parent.is_none());
+}
+
+// --- Tests for collect_interface_fields: inline object types ---
+
+#[test]
+fn mine_ts_interface_with_inline_object_field() {
+    // Inline object type on one line: braces should not confuse depth tracking
+    let src = r#"
+export interface Widget {
+  name: string;
+  bounds: { x: number; y: number; };
+  color: string;
+}
+"#;
+    let mined = ts_extractor::extract(src);
+    let widget = mined.sigs.iter().find(|s| s.name == "Widget").unwrap();
+    // Should have 3 fields: name, bounds, color
+    assert_eq!(widget.fields.len(), 3, "fields: {:?}", widget.fields.iter().map(|f| &f.name).collect::<Vec<_>>());
+}
+
+#[test]
+fn mine_ts_interface_with_multiline_inline_object() {
+    // Multi-line inline object: the '{' on the field line is not closed on the same line
+    let src = r#"
+export interface Config {
+  name: string;
+  options: {
+    debug: boolean;
+    verbose: boolean;
+  };
+  version: number;
+}
+"#;
+    let mined = ts_extractor::extract(src);
+    let config = mined.sigs.iter().find(|s| s.name == "Config").unwrap();
+    // Should have 3 fields: name, options, version (inline object lines skipped)
+    let field_names: Vec<&str> = config.fields.iter().map(|f| f.name.as_str()).collect();
+    assert!(field_names.contains(&"name"), "missing 'name' in {field_names:?}");
+    assert!(field_names.contains(&"version"), "missing 'version' in {field_names:?}");
+}
+
+#[test]
+fn mine_ts_interface_with_jsdoc_braces() {
+    // JSDoc comments with braces should not affect depth
+    let src = r#"
+export interface Widget {
+  /** default value is { x: 0, y: 0 } */
+  position: string;
+  name: string;
+}
+"#;
+    let mined = ts_extractor::extract(src);
+    let widget = mined.sigs.iter().find(|s| s.name == "Widget").unwrap();
+    assert_eq!(widget.fields.len(), 2, "fields: {:?}", widget.fields.iter().map(|f| &f.name).collect::<Vec<_>>());
+}
+
+// --- Tests for TS collect_block: depth=0 start with started flag ---
+
+#[test]
+fn mine_ts_function_body_with_nested_braces() {
+    // Function with nested braces should still be collected correctly
+    let src = r#"
+export function validate(x: User): boolean {
+  if (x.name.length === 0) {
+    throw new Error("empty");
+  }
+  return true;
+}
+"#;
+    let mined = ts_extractor::extract(src);
+    // Should extract a fact candidate from the throw
+    assert!(!mined.fact_candidates.is_empty(), "should extract facts from function body");
+}
+
+#[test]
+fn mine_ts_function_with_brace_on_next_line() {
+    // Function where '{' is on the next line (collect_block starts at depth=0)
+    let src = r#"
+export function check(x: User): boolean
+{
+  if (x.name.includes("admin")) {
+    return true;
+  }
+  return false;
+}
+"#;
+    let mined = ts_extractor::extract(src);
+    // Should extract includes fact candidate
+    assert!(mined.fact_candidates.iter().any(|f|
+        f.source_pattern.contains("includes")
+    ), "should extract .includes() fact from function body");
+}


### PR DESCRIPTION
## Summary

- Java/Kotlin/Swift `collect_block`: `depth > 0` ガードを追加し、文字列リテラル内の余分な `}` によるアンダーフロー(パニック)を防止
- TS `parse_interface_decl`: `extends` による親インターフェース抽出に対応（ジェネリクス `Foo<T> extends Bar` も対応、複数継承は先頭のみ取得）
- TS `collect_interface_fields`: インラインオブジェクト型（単一行・複数行）とJSDocコメント内のブレースを正しく処理
- TS `collect_block`: `depth=0` + `started` フラグ方式に変更し、`{` が次行にあるケースも正しく追跡

## Test plan

- [x] 12個の新規テストを追加（全パス確認済み）
  - TS: extends親抽出 (4件)、インラインオブジェクト型 (2件)、JSDocブレース (1件)、collect_block (2件)
  - Java/Kotlin/Swift: depth underflow防止 (各1件)
- [x] 既存テスト全パス、warning ゼロ

https://claude.ai/code/session_01FCVDiTW55mvSj5bbm3BrNS