### PR TITLE
Fix callback type parsing and intra-language sig dedup

### DIFF
--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -290,9 +290,35 @@ fn mine_directory(dir: &Path, lang: &str) -> Result<MinedModel, String> {
         let content = std::fs::read_to_string(file)
             .map_err(|e| format!("cannot read {}: {e}", file.display()))?;
         let mined = extract_with_lang(&content, lang)?;
-        merged.sigs.extend(mined.sigs);
+        // Dedup: merge same-name sigs (supplement missing fields, prefer more complete)
+        for sig in mined.sigs {
+            if let Some(existing) = merged.sigs.iter_mut().find(|s| s.name == sig.name) {
+                // Supplement missing fields from the new source
+                for f in &sig.fields {
+                    if !existing.fields.iter().any(|ef| ef.name == f.name) {
+                        existing.fields.push(f.clone());
+                    }
+                }
+                // Prefer abstract if either says abstract
+                if sig.is_abstract { existing.is_abstract = true; }
+                // Prefer parent if either provides one
+                if existing.parent.is_none() && sig.parent.is_some() {
+                    existing.parent = sig.parent.clone();
+                }
+                // Prefer intersection_of if either provides one
+                if existing.intersection_of.is_empty() && !sig.intersection_of.is_empty() {
+                    existing.intersection_of = sig.intersection_of.clone();
+                }
+            } else {
+                merged.sigs.push(sig);
+            }
+        }
         merged.fact_candidates.extend(mined.fact_candidates);
     }
+
+    // Dedup fact candidates
+    merged.fact_candidates.sort_by(|a, b| a.alloy_text.cmp(&b.alloy_text));
+    merged.fact_candidates.dedup_by(|a, b| a.alloy_text == b.alloy_text);
 
     Ok(merged)
 }

--- a/src/extract/ts_extractor.rs
+++ b/src/extract/ts_extractor.rs
@@ -320,6 +320,12 @@ fn parse_ts_field(line: &str) -> Option<MinedField> {
         });
     }
 
+    // Skip callback/function types: `(args) => ReturnType`
+    // These are not data fields — they are method signatures embedded as properties
+    if is_callback_type(type_str) {
+        return None;
+    }
+
     let raw_union = detect_union_type(type_str);
     let (mult, target) = ts_type_to_mult(type_str, optional);
     Some(MinedField { name, mult, target, raw_union_type: raw_union })
@@ -372,7 +378,25 @@ fn detect_union_type(ts_type: &str) -> Option<String> {
     // Must contain " | " but not be a null-union (already handled as lone)
     if !t.contains(" | ") { return None; }
     if t.contains("null") { return None; }
+    // Skip callback types that happen to contain "|" inside parameter lists
+    if is_callback_type(t) { return None; }
     Some(t.to_string())
+}
+
+/// Detect callback/function type signatures: `(args) => ReturnType`
+/// Also handles union of callback + other: `string | (item: S) => T`
+fn is_callback_type(ts_type: &str) -> bool {
+    let t = ts_type.trim();
+    // Direct callback: starts with ( and contains =>
+    if t.starts_with('(') && t.contains("=>") { return true; }
+    // Union containing a callback: any variant starts with (
+    if t.contains(" | ") {
+        for part in t.split(" | ") {
+            let p = part.trim();
+            if p.starts_with('(') && p.contains("=>") { return true; }
+        }
+    }
+    false
 }
 
 fn strip_wrapper_ts<'a>(s: &'a str, prefix: &str, suffix: &str) -> Option<&'a str> {


### PR DESCRIPTION
## Summary
Two fixes discovered from analyzing Solidion with oxidtr extract.

## Fix 1: Callback type parsing
Fields with callback types like `getPosition: (item: S | T) => { x: number; y: number }` caused the parser to cut at `(` inside the callback parameter list, producing garbage union annotations.

Now:
- `is_callback_type()` detects `(args) => ReturnType` patterns
- Callback fields are skipped (they are method signatures, not data fields)
- Unions containing callbacks (`string | (item: S) => T`) are also excluded from union detection

## Fix 2: Intra-language sig dedup
When extracting multiple files of the same language (e.g., `types.ts` + `types.generated.ts`), the same sig could appear twice with identical annotations.

Now:
- Same-name sigs are merged within a single language extraction
- Missing fields are supplemented from later files
- Fact candidates are deduplicated by `alloy_text`

## Note
Phaser/SolidJS-specific types in union annotations (e.g., `string | Accessor<string>`) are kept as-is — they have value as annotations even though Alloy cannot express them.

## Test plan
- [x] 608 tests pass, zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)