### PR TITLE
Alloy 6: binary temporal operators + temporal check/extract

### DIFF
--- a/models/oxidtr-domain.als
+++ b/models/oxidtr-domain.als
@@ -62,6 +62,18 @@ one sig Historically extends TemporalUnaryOp {}
 one sig Once         extends TemporalUnaryOp {}
 one sig Before       extends TemporalUnaryOp {}
 
+sig TemporalBinary extends Expr {
+  tbOp: one TemporalBinaryOp,
+  tbLeft: one Expr,
+  tbRight: one Expr
+}
+
+abstract sig TemporalBinaryOp {}
+one sig Until     extends TemporalBinaryOp {}
+one sig Since     extends TemporalBinaryOp {}
+one sig Release   extends TemporalBinaryOp {}
+one sig Triggered extends TemporalBinaryOp {}
+
 abstract sig CompareOp {}
 one sig In    extends CompareOp {}
 one sig Eq    extends CompareOp {}

--- a/models/oxidtr-internal.als
+++ b/models/oxidtr-internal.als
@@ -173,6 +173,7 @@ sig MissingFn              extends DiffItem {}
 sig ExtraFn                extends DiffItem {}
 sig MissingValidation      extends DiffItem {}
 sig ExtraValidation        extends DiffItem {}
+sig MissingTemporalTest    extends DiffItem {}
 
 sig CheckResult {
   diffs: set DiffItem

--- a/models/oxidtr.als
+++ b/models/oxidtr.als
@@ -63,6 +63,18 @@ one sig Historically extends TemporalUnaryOp {}
 one sig Once         extends TemporalUnaryOp {}
 one sig Before       extends TemporalUnaryOp {}
 
+sig TemporalBinary extends Expr {
+  tbOp: one TemporalBinaryOp,
+  tbLeft: one Expr,
+  tbRight: one Expr
+}
+
+abstract sig TemporalBinaryOp {}
+one sig Until     extends TemporalBinaryOp {}
+one sig Since     extends TemporalBinaryOp {}
+one sig Release   extends TemporalBinaryOp {}
+one sig Triggered extends TemporalBinaryOp {}
+
 abstract sig CompareOp {}
 one sig In    extends CompareOp {}
 one sig Eq    extends CompareOp {}

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -117,13 +117,16 @@ pub fn expr_contains_prime(expr: &Expr) -> bool {
             expr_contains_prime(left) || expr_contains_prime(right)
         }
         Expr::MultFormula { expr: inner, .. } => expr_contains_prime(inner),
+        Expr::TemporalBinary { left, right, .. } => {
+            expr_contains_prime(left) || expr_contains_prime(right)
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => false,
     }
 }
 
 /// Returns true if the expression is wrapped in a temporal operator.
 pub fn expr_is_temporal(expr: &Expr) -> bool {
-    matches!(expr, Expr::TemporalUnary { .. })
+    matches!(expr, Expr::TemporalUnary { .. } | Expr::TemporalBinary { .. })
 }
 
 /// Analyze all constraints in the IR and return structured info.
@@ -238,6 +241,15 @@ pub fn describe_expr(expr: &Expr) -> String {
             };
             format!("{op_name} {}", describe_expr(inner))
         }
+        Expr::TemporalBinary { op, left, right } => {
+            let op_name = match op {
+                TemporalBinaryOp::Until => "until",
+                TemporalBinaryOp::Since => "since",
+                TemporalBinaryOp::Release => "release",
+                TemporalBinaryOp::Triggered => "triggered",
+            };
+            format!("{} {op_name} {}", describe_expr(left), describe_expr(right))
+        }
     }
 }
 
@@ -307,6 +319,11 @@ fn analyze_expr(expr: &Expr, fact_name: &str) -> Vec<ConstraintInfo> {
         // Alloy 6: temporal operators — unwrap and analyze inner expression
         Expr::TemporalUnary { expr: inner, .. } => {
             results.extend(analyze_expr(inner, ""));
+        }
+        // Alloy 6: binary temporal operators — analyze both sides
+        Expr::TemporalBinary { left, right, .. } => {
+            results.extend(analyze_expr(left, ""));
+            results.extend(analyze_expr(right, ""));
         }
         _ => {}
     }
@@ -613,6 +630,11 @@ fn substitute_var(expr: &Expr, var: &str, sig_name: &str) -> Expr {
         Expr::IntLiteral(_) => expr.clone(),
         Expr::Prime(inner) => Expr::Prime(Box::new(substitute_var(inner, var, sig_name))),
         Expr::TemporalUnary { expr: inner, .. } => substitute_var(inner, var, sig_name),
+        Expr::TemporalBinary { op, left, right } => Expr::TemporalBinary {
+            op: *op,
+            left: Box::new(substitute_var(left, var, sig_name)),
+            right: Box::new(substitute_var(right, var, sig_name)),
+        },
     }
 }
 
@@ -670,6 +692,10 @@ fn collect_disj_fields(expr: &Expr, results: &mut Vec<(String, String)>) {
         Expr::FieldAccess { base, .. } => collect_disj_fields(base, results),
         Expr::Prime(inner) => collect_disj_fields(inner, results),
         Expr::TemporalUnary { expr: inner, .. } => collect_disj_fields(inner, results),
+        Expr::TemporalBinary { left, right, .. } => {
+            collect_disj_fields(left, results);
+            collect_disj_fields(right, results);
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
 }
@@ -728,6 +754,9 @@ fn expr_only_refs_params(expr: &Expr, param_names: &[String]) -> bool {
         }
         Expr::Prime(inner) => expr_only_refs_params(inner, param_names),
         Expr::TemporalUnary { expr: inner, .. } => expr_only_refs_params(inner, param_names),
+        Expr::TemporalBinary { left, right, .. } => {
+            expr_only_refs_params(left, param_names) && expr_only_refs_params(right, param_names)
+        }
     }
 }
 
@@ -800,6 +829,15 @@ pub fn alloy_repr(expr: &Expr) -> String {
         }
         Expr::Prime(inner) => format!("{}'", alloy_repr(inner)),
         Expr::TemporalUnary { expr: inner, .. } => format!("{}'", alloy_repr(inner)),
+        Expr::TemporalBinary { op, left, right } => {
+            let op_name = match op {
+                TemporalBinaryOp::Until => "until",
+                TemporalBinaryOp::Since => "since",
+                TemporalBinaryOp::Release => "release",
+                TemporalBinaryOp::Triggered => "triggered",
+            };
+            format!("{} {op_name} {}", alloy_repr(left), alloy_repr(right))
+        }
     }
 }
 
@@ -935,5 +973,8 @@ fn expr_references_sig(expr: &Expr, sig_name: &str) -> bool {
         Expr::FieldAccess { base, .. } => expr_references_sig(base, sig_name),
         Expr::Prime(inner) => expr_references_sig(inner, sig_name),
         Expr::TemporalUnary { expr: inner, .. } => expr_references_sig(inner, sig_name),
+        Expr::TemporalBinary { left, right, .. } => {
+            expr_references_sig(left, sig_name) || expr_references_sig(right, sig_name)
+        }
     }
 }

--- a/src/backend/go/expr_translator.rs
+++ b/src/backend/go/expr_translator.rs
@@ -53,6 +53,10 @@ fn collect_tc_fields(expr: &Expr, ir: &OxidtrIR, out: &mut Vec<TCField>) {
         Expr::MultFormula { expr: inner, .. } => collect_tc_fields(inner, ir, out),
         Expr::Prime(inner) => collect_tc_fields(inner, ir, out),
         Expr::TemporalUnary { expr: inner, .. } => collect_tc_fields(inner, ir, out),
+        Expr::TemporalBinary { left, right, .. } => {
+            collect_tc_fields(left, ir, out);
+            collect_tc_fields(right, ir, out);
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
 }
@@ -92,6 +96,10 @@ fn collect_params(expr: &Expr, sig_names: &HashSet<String>, params: &mut BTreeSe
         Expr::MultFormula { expr: inner, .. } => collect_params(inner, sig_names, params),
         Expr::Prime(inner) => collect_params(inner, sig_names, params),
         Expr::TemporalUnary { expr: inner, .. } => collect_params(inner, sig_names, params),
+        Expr::TemporalBinary { left, right, .. } => {
+            collect_params(left, sig_names, params);
+            collect_params(right, sig_names, params);
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
 }
@@ -214,6 +222,12 @@ fn translate_inner(
         }
         // Alloy 6: temporal unary operators — translate inner expression
         Expr::TemporalUnary { expr: inner, .. } => ti(inner, false),
+        // Alloy 6: temporal binary operators — translate both sides
+        Expr::TemporalBinary { left, right, .. } => {
+            let l = ti(left, false);
+            let r = ti(right, false);
+            format!("{l} && {r}")
+        }
     };
 
     if parens_if_complex && needs_parens(expr) {

--- a/src/backend/go/mod.rs
+++ b/src/backend/go/mod.rs
@@ -755,6 +755,9 @@ fn expr_uses_tc(expr: &crate::parser::ast::Expr) -> bool {
         Expr::MultFormula { expr: inner, .. } => expr_uses_tc(inner),
         Expr::Prime(inner) => expr_uses_tc(inner),
         Expr::TemporalUnary { expr: inner, .. } => expr_uses_tc(inner),
+        Expr::TemporalBinary { left, right, .. } => {
+            expr_uses_tc(left) || expr_uses_tc(right)
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => false,
     }
 }

--- a/src/backend/jvm/expr_translator.rs
+++ b/src/backend/jvm/expr_translator.rs
@@ -85,6 +85,10 @@ fn collect_tc_fields(expr: &Expr, ir: &OxidtrIR, out: &mut Vec<TCField>) {
         }
         Expr::Prime(inner) => collect_tc_fields(inner, ir, out),
         Expr::TemporalUnary { expr: inner, .. } => collect_tc_fields(inner, ir, out),
+        Expr::TemporalBinary { left, right, .. } => {
+            collect_tc_fields(left, ir, out);
+            collect_tc_fields(right, ir, out);
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
 }
@@ -116,6 +120,10 @@ fn collect_params(expr: &Expr, sig_names: &HashSet<String>, params: &mut BTreeSe
         Expr::FieldAccess { base, .. } => collect_params(base, sig_names, params),
         Expr::Prime(inner) => collect_params(inner, sig_names, params),
         Expr::TemporalUnary { expr: inner, .. } => collect_params(inner, sig_names, params),
+        Expr::TemporalBinary { left, right, .. } => {
+            collect_params(left, sig_names, params);
+            collect_params(right, sig_names, params);
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
 }
@@ -235,6 +243,12 @@ fn translate_inner(
         // Alloy 6: temporal unary operators — translate inner expression
         Expr::TemporalUnary { expr: inner, .. } => {
             ti(inner, false)
+        }
+        // Alloy 6: temporal binary operators — translate both sides
+        Expr::TemporalBinary { left, right, .. } => {
+            let l = ti(left, false);
+            let r = ti(right, false);
+            format!("{l} && {r}")
         }
     };
 

--- a/src/backend/jvm/java.rs
+++ b/src/backend/jvm/java.rs
@@ -609,6 +609,9 @@ fn expr_uses_tc(expr: &crate::parser::ast::Expr) -> bool {
         }
         Expr::Prime(inner) => expr_uses_tc(inner),
         Expr::TemporalUnary { expr: inner, .. } => expr_uses_tc(inner),
+        Expr::TemporalBinary { left, right, .. } => {
+            expr_uses_tc(left) || expr_uses_tc(right)
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => false,
     }
 }

--- a/src/backend/jvm/kotlin.rs
+++ b/src/backend/jvm/kotlin.rs
@@ -612,6 +612,9 @@ fn expr_uses_tc(expr: &crate::parser::ast::Expr) -> bool {
         }
         Expr::Prime(inner) => expr_uses_tc(inner),
         Expr::TemporalUnary { expr: inner, .. } => expr_uses_tc(inner),
+        Expr::TemporalBinary { left, right, .. } => {
+            expr_uses_tc(left) || expr_uses_tc(right)
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => false,
     }
 }

--- a/src/backend/rust/expr_translator.rs
+++ b/src/backend/rust/expr_translator.rs
@@ -75,6 +75,10 @@ fn collect_tc_fields(expr: &Expr, ir: &OxidtrIR, out: &mut Vec<TCField>) {
         }
         Expr::Prime(inner) => collect_tc_fields(inner, ir, out),
         Expr::TemporalUnary { expr: inner, .. } => collect_tc_fields(inner, ir, out),
+        Expr::TemporalBinary { left, right, .. } => {
+            collect_tc_fields(left, ir, out);
+            collect_tc_fields(right, ir, out);
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
 }
@@ -112,6 +116,10 @@ fn collect_params(expr: &Expr, sig_names: &HashSet<String>, params: &mut BTreeSe
         }
         Expr::Prime(inner) => collect_params(inner, sig_names, params),
         Expr::TemporalUnary { expr: inner, .. } => collect_params(inner, sig_names, params),
+        Expr::TemporalBinary { left, right, .. } => {
+            collect_params(left, sig_names, params);
+            collect_params(right, sig_names, params);
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
 }
@@ -230,6 +238,12 @@ fn translate_inner(expr: &Expr, parens_if_complex: bool, sig_names: &HashSet<Str
         // Alloy 6: temporal unary operators — translate inner expression
         Expr::TemporalUnary { expr: inner, .. } => {
             translate_inner(inner, false, sig_names)
+        }
+        // Alloy 6: temporal binary operators — translate both sides
+        Expr::TemporalBinary { left, right, .. } => {
+            let l = translate_inner(left, false, sig_names);
+            let r = translate_inner(right, false, sig_names);
+            format!("{l} && {r}")
         }
     };
 
@@ -530,6 +544,12 @@ fn translate_inner_ir(
         // Alloy 6: temporal unary operators — translate inner expression
         Expr::TemporalUnary { expr: inner, .. } => {
             ti(inner, false)
+        }
+        // Alloy 6: temporal binary operators — translate both sides
+        Expr::TemporalBinary { left, right, .. } => {
+            let l = ti(left, false);
+            let r = ti(right, false);
+            format!("{l} && {r}")
         }
     };
 

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -460,6 +460,9 @@ fn expr_uses_tc(expr: &crate::parser::ast::Expr) -> bool {
         }
         Expr::Prime(inner) => expr_uses_tc(inner),
         Expr::TemporalUnary { expr: inner, .. } => expr_uses_tc(inner),
+        Expr::TemporalBinary { left, right, .. } => {
+            expr_uses_tc(left) || expr_uses_tc(right)
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => false,
     }
 }
@@ -1040,6 +1043,9 @@ fn expr_has_comparison(expr: &crate::parser::ast::Expr) -> bool {
         Expr::FieldAccess { base, .. } => expr_has_comparison(base),
         Expr::Prime(inner) => expr_has_comparison(inner),
         Expr::TemporalUnary { expr: inner, .. } => expr_has_comparison(inner),
+        Expr::TemporalBinary { left, right, .. } => {
+            expr_has_comparison(left) || expr_has_comparison(right)
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => false,
     }
 }

--- a/src/backend/swift/expr_translator.rs
+++ b/src/backend/swift/expr_translator.rs
@@ -53,6 +53,10 @@ fn collect_tc_fields(expr: &Expr, ir: &OxidtrIR, out: &mut Vec<TCField>) {
         }
         Expr::Prime(inner) => collect_tc_fields(inner, ir, out),
         Expr::TemporalUnary { expr: inner, .. } => collect_tc_fields(inner, ir, out),
+        Expr::TemporalBinary { left, right, .. } => {
+            collect_tc_fields(left, ir, out);
+            collect_tc_fields(right, ir, out);
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
 }
@@ -94,6 +98,10 @@ fn collect_params(expr: &Expr, sig_names: &HashSet<String>, params: &mut BTreeSe
         Expr::FieldAccess { base, .. } => collect_params(base, sig_names, params),
         Expr::Prime(inner) => collect_params(inner, sig_names, params),
         Expr::TemporalUnary { expr: inner, .. } => collect_params(inner, sig_names, params),
+        Expr::TemporalBinary { left, right, .. } => {
+            collect_params(left, sig_names, params);
+            collect_params(right, sig_names, params);
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
 }
@@ -217,6 +225,12 @@ fn translate_inner(
         // Alloy 6: temporal unary operators — translate inner expression
         Expr::TemporalUnary { expr: inner, .. } => {
             ti(inner, false)
+        }
+        // Alloy 6: temporal binary operators — translate both sides
+        Expr::TemporalBinary { left, right, .. } => {
+            let l = ti(left, false);
+            let r = ti(right, false);
+            format!("{l} && {r}")
         }
     };
 

--- a/src/backend/swift/mod.rs
+++ b/src/backend/swift/mod.rs
@@ -768,6 +768,9 @@ fn expr_uses_tc(expr: &crate::parser::ast::Expr) -> bool {
         }
         Expr::Prime(inner) => expr_uses_tc(inner),
         Expr::TemporalUnary { expr: inner, .. } => expr_uses_tc(inner),
+        Expr::TemporalBinary { left, right, .. } => {
+            expr_uses_tc(left) || expr_uses_tc(right)
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => false,
     }
 }

--- a/src/backend/typescript/expr_translator.rs
+++ b/src/backend/typescript/expr_translator.rs
@@ -63,6 +63,10 @@ fn collect_params(expr: &Expr, sig_names: &HashSet<String>, params: &mut BTreeSe
         Expr::FieldAccess { base, .. } => collect_params(base, sig_names, params),
         Expr::Prime(inner) => collect_params(inner, sig_names, params),
         Expr::TemporalUnary { expr: inner, .. } => collect_params(inner, sig_names, params),
+        Expr::TemporalBinary { left, right, .. } => {
+            collect_params(left, sig_names, params);
+            collect_params(right, sig_names, params);
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
 }
@@ -102,6 +106,10 @@ fn collect_tc_fields(expr: &Expr, ir: &OxidtrIR, out: &mut Vec<TCField>) {
         }
         Expr::Prime(inner) => collect_tc_fields(inner, ir, out),
         Expr::TemporalUnary { expr: inner, .. } => collect_tc_fields(inner, ir, out),
+        Expr::TemporalBinary { left, right, .. } => {
+            collect_tc_fields(left, ir, out);
+            collect_tc_fields(right, ir, out);
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
 }
@@ -243,6 +251,12 @@ fn translate_inner(
         // Alloy 6: temporal unary operators — translate inner expression
         Expr::TemporalUnary { expr: inner, .. } => {
             ti(inner, false)
+        }
+        // Alloy 6: temporal binary operators — translate both sides
+        Expr::TemporalBinary { left, right, .. } => {
+            let l = ti(left, false);
+            let r = ti(right, false);
+            format!("{l} && {r}")
         }
     };
 

--- a/src/backend/typescript/mod.rs
+++ b/src/backend/typescript/mod.rs
@@ -637,6 +637,9 @@ fn expr_uses_tc(expr: &crate::parser::ast::Expr) -> bool {
         }
         Expr::Prime(inner) => expr_uses_tc(inner),
         Expr::TemporalUnary { expr: inner, .. } => expr_uses_tc(inner),
+        Expr::TemporalBinary { left, right, .. } => {
+            expr_uses_tc(left) || expr_uses_tc(right)
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => false,
     }
 }

--- a/src/check/differ.rs
+++ b/src/check/differ.rs
@@ -2,6 +2,7 @@
 
 use crate::ir::nodes::OxidtrIR;
 use crate::parser::ast::Multiplicity;
+use crate::analyze;
 use super::impl_parser::{ExtractedImpl, ExtractedStruct};
 
 fn to_snake_case(s: &str) -> String {
@@ -41,6 +42,10 @@ pub enum DiffItem {
     ExtraFn   { name: String },
     MissingValidation { fact_name: String },
     ExtraValidation   { name: String },
+    MissingTemporalTest {
+        fact_name: String,
+        expected_kind: String, // "transition" or "invariant"
+    },
 }
 
 impl std::fmt::Display for DiffItem {
@@ -71,6 +76,8 @@ impl std::fmt::Display for DiffItem {
                 write!(f, "[MISSING_VALIDATION] {fact_name}: fact in model but no validation in impl"),
             DiffItem::ExtraValidation { name } =>
                 write!(f, "[EXTRA_VALIDATION] {name}: validation in impl but no fact in model"),
+            DiffItem::MissingTemporalTest { fact_name, expected_kind } =>
+                write!(f, "[MISSING_TEMPORAL_TEST] {fact_name}: expected {expected_kind} test in impl"),
         }
     }
 }
@@ -137,7 +144,40 @@ fn diff_validations(ir: &OxidtrIR, sources: &[String], use_snake_case: bool) -> 
 
         let found = combined.contains(&search_name);
         if !found {
-            diffs.push(DiffItem::MissingValidation { fact_name });
+            diffs.push(DiffItem::MissingValidation { fact_name: fact_name.clone() });
+            continue; // no point checking temporal subtype if basic validation is missing
+        }
+
+        // Temporal constraint classification: verify correct test type exists
+        let has_prime = analyze::expr_contains_prime(&constraint.expr);
+        let is_temporal = analyze::expr_is_temporal(&constraint.expr);
+
+        if has_prime {
+            // Facts with prime should have a transition test
+            let transition_name = if use_snake_case {
+                format!("transition_{}", to_snake_case(&fact_name))
+            } else {
+                format!("transition_{fact_name}")
+            };
+            if !combined.contains(&transition_name) {
+                diffs.push(DiffItem::MissingTemporalTest {
+                    fact_name: fact_name.clone(),
+                    expected_kind: "transition".to_string(),
+                });
+            }
+        } else if is_temporal {
+            // Temporal facts without prime should have an invariant test
+            let invariant_name = if use_snake_case {
+                format!("invariant_{}", to_snake_case(&fact_name))
+            } else {
+                format!("invariant_{fact_name}")
+            };
+            if !combined.contains(&invariant_name) {
+                diffs.push(DiffItem::MissingTemporalTest {
+                    fact_name,
+                    expected_kind: "invariant".to_string(),
+                });
+            }
         }
     }
 

--- a/src/extract/go_extractor.rs
+++ b/src/extract/go_extractor.rs
@@ -128,6 +128,9 @@ pub fn extract(source: &str) -> MinedModel {
         }
     }
 
+    // Extract @temporal annotations from generated tests
+    super::extract_temporal_annotations(source, &mut fact_candidates);
+
     MinedModel { sigs, fact_candidates }
 }
 

--- a/src/extract/java_extractor.rs
+++ b/src/extract/java_extractor.rs
@@ -73,6 +73,9 @@ pub fn extract(source: &str) -> MinedModel {
         }
     }
 
+    // Extract @temporal annotations from generated tests
+    super::extract_temporal_annotations(source, &mut fact_candidates);
+
     MinedModel { sigs, fact_candidates }
 }
 

--- a/src/extract/kotlin_extractor.rs
+++ b/src/extract/kotlin_extractor.rs
@@ -108,6 +108,9 @@ pub fn extract(source: &str) -> MinedModel {
         }
     }
 
+    // Extract @temporal annotations from generated tests
+    super::extract_temporal_annotations(source, &mut fact_candidates);
+
     MinedModel { sigs, fact_candidates }
 }
 

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -455,6 +455,44 @@ pub fn is_type_parameter(name: &str) -> bool {
     }
 }
 
+/// Extract @temporal annotations from generated test code.
+/// Works across all languages by looking for `@temporal` in comment lines.
+pub fn extract_temporal_annotations(source: &str, facts: &mut Vec<MinedFactCandidate>) {
+    for (i, line) in source.lines().enumerate() {
+        let trimmed = line.trim();
+        // Strip common comment prefixes: /// // /** * -- #
+        let content = trimmed
+            .strip_prefix("///")
+            .or_else(|| trimmed.strip_prefix("//"))
+            .or_else(|| trimmed.strip_prefix("/**"))
+            .or_else(|| trimmed.strip_prefix("*"))
+            .or_else(|| trimmed.strip_prefix("--"))
+            .unwrap_or(trimmed)
+            .trim();
+
+        if let Some(rest) = content.strip_prefix("@temporal ") {
+            let loc = format!("line {}", i + 1);
+            if let Some(name) = rest.strip_prefix("Transition constraint: ") {
+                let name = name.trim().trim_end_matches("*/").trim();
+                facts.push(MinedFactCandidate {
+                    alloy_text: format!("always all s | s.field' = ... -- {name}"),
+                    confidence: Confidence::High,
+                    source_location: loc,
+                    source_pattern: format!("@temporal Transition constraint: {name}"),
+                });
+            } else if let Some(name) = rest.strip_prefix("Invariant constraint: ") {
+                let name = name.trim().trim_end_matches("*/").trim();
+                facts.push(MinedFactCandidate {
+                    alloy_text: format!("always all s | ... -- {name}"),
+                    confidence: Confidence::High,
+                    source_location: loc,
+                    source_pattern: format!("@temporal Invariant constraint: {name}"),
+                });
+            }
+        }
+    }
+}
+
 /// Add placeholder sigs for types referenced in fields but not defined as sigs.
 /// This ensures the mined .als output is self-contained valid Alloy.
 /// Filters out language primitives and generic type parameters.

--- a/src/extract/rust_extractor.rs
+++ b/src/extract/rust_extractor.rs
@@ -220,6 +220,9 @@ pub fn extract(source: &str) -> MinedModel {
         }
     }
 
+    // Pass 3: Extract temporal constraint annotations (@temporal markers)
+    extract_temporal_annotations(source, &mut fact_candidates);
+
     MinedModel { sigs, fact_candidates }
 }
 
@@ -896,4 +899,9 @@ fn extract_contains_fact(line: &str) -> String {
     } else {
         "-- contains check (review)".to_string()
     }
+}
+
+/// Extract @temporal annotations — delegates to shared implementation.
+fn extract_temporal_annotations(source: &str, facts: &mut Vec<MinedFactCandidate>) {
+    super::extract_temporal_annotations(source, facts);
 }

--- a/src/extract/swift_extractor.rs
+++ b/src/extract/swift_extractor.rs
@@ -49,6 +49,9 @@ pub fn extract(source: &str) -> MinedModel {
         }
     }
 
+    // Extract @temporal annotations from generated tests
+    super::extract_temporal_annotations(source, &mut fact_candidates);
+
     MinedModel { sigs, fact_candidates }
 }
 

--- a/src/extract/ts_extractor.rs
+++ b/src/extract/ts_extractor.rs
@@ -98,6 +98,9 @@ pub fn extract(source: &str) -> MinedModel {
         }
     }
 
+    // Extract @temporal annotations from generated tests
+    super::extract_temporal_annotations(source, &mut fact_candidates);
+
     MinedModel { sigs, fact_candidates }
 }
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -424,6 +424,10 @@ fn expr_references_sig_name(expr: &crate::parser::ast::Expr, sig_name: &str) -> 
         Expr::FieldAccess { base, .. } => expr_references_sig_name(base, sig_name),
         Expr::Prime(inner) => expr_references_sig_name(inner, sig_name),
         Expr::TemporalUnary { expr: inner, .. } => expr_references_sig_name(inner, sig_name),
+        Expr::TemporalBinary { left, right, .. } => {
+            expr_references_sig_name(left, sig_name)
+                || expr_references_sig_name(right, sig_name)
+        }
         Expr::IntLiteral(_) => false,
     }
 }
@@ -457,6 +461,10 @@ fn constraint_references_field(expr: &crate::parser::ast::Expr, _sig: &str, fiel
         }
         Expr::Prime(inner) => constraint_references_field(inner, _sig, field),
         Expr::TemporalUnary { expr: inner, .. } => constraint_references_field(inner, _sig, field),
+        Expr::TemporalBinary { left, right, .. } => {
+            constraint_references_field(left, _sig, field)
+                || constraint_references_field(right, _sig, field)
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => false,
     }
 }
@@ -509,6 +517,10 @@ fn collect_tc_fields(expr: &crate::parser::ast::Expr, out: &mut std::collections
         Expr::FieldAccess { base, .. } => collect_tc_fields(base, out),
         Expr::Prime(inner) => collect_tc_fields(inner, out),
         Expr::TemporalUnary { expr: inner, .. } => collect_tc_fields(inner, out),
+        Expr::TemporalBinary { left, right, .. } => {
+            collect_tc_fields(left, out);
+            collect_tc_fields(right, out);
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => {}
     }
 }
@@ -555,6 +567,10 @@ fn constraint_references_field_non_tc(expr: &crate::parser::ast::Expr, field: &s
         }
         Expr::Prime(inner) => constraint_references_field_non_tc(inner, field),
         Expr::TemporalUnary { expr: inner, .. } => constraint_references_field_non_tc(inner, field),
+        Expr::TemporalBinary { left, right, .. } => {
+            constraint_references_field_non_tc(left, field)
+                || constraint_references_field_non_tc(right, field)
+        }
         Expr::VarRef(_) | Expr::IntLiteral(_) => false,
     }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -124,6 +124,12 @@ pub enum Expr {
         op: TemporalUnaryOp,
         expr: Box<Expr>,
     },
+    /// Alloy 6: temporal binary operator (until/since/release/triggered)
+    TemporalBinary {
+        op: TemporalBinaryOp,
+        left: Box<Expr>,
+        right: Box<Expr>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -134,6 +140,14 @@ pub enum TemporalUnaryOp {
     Historically,
     Once,
     Before,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TemporalBinaryOp {
+    Until,
+    Since,
+    Release,
+    Triggered,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -34,6 +34,11 @@ pub enum Token {
     Historically,
     Once,
     Before,
+    // Alloy 6: temporal binary keywords
+    Until,
+    Since,
+    Release,
+    Triggered,
     // Symbols
     LBrace,
     RBrace,
@@ -258,6 +263,10 @@ impl<'a> Lexer<'a> {
                 "historically" => Token::Historically,
                 "once" => Token::Once,
                 "before" => Token::Before,
+                "until" => Token::Until,
+                "since" => Token::Since,
+                "release" => Token::Release,
+                "triggered" => Token::Triggered,
                 _ => Token::Ident(ident),
             };
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -400,6 +400,23 @@ impl<'a> Parser<'a> {
                 right: Box::new(right),
             });
         }
+        // Alloy 6: binary temporal operators
+        let temporal_bin_op = match self.peek() {
+            Token::Until => Some(ast::TemporalBinaryOp::Until),
+            Token::Since => Some(ast::TemporalBinaryOp::Since),
+            Token::Release => Some(ast::TemporalBinaryOp::Release),
+            Token::Triggered => Some(ast::TemporalBinaryOp::Triggered),
+            _ => None,
+        };
+        if let Some(op) = temporal_bin_op {
+            self.next();
+            let right = self.parse_not()?;
+            return Ok(Expr::TemporalBinary {
+                op,
+                left: Box::new(left),
+                right: Box::new(right),
+            });
+        }
         Ok(left)
     }
 

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -4,8 +4,8 @@
 use oxidtr::check::{self, CheckConfig};
 use oxidtr::check::impl_parser::{self, ExtractedField};
 use oxidtr::check::differ::{self, DiffItem};
-use oxidtr::ir::nodes::{OxidtrIR, StructureNode, IRField, OperationNode};
-use oxidtr::parser::ast::{Multiplicity, SigMultiplicity};
+use oxidtr::ir::nodes::{OxidtrIR, StructureNode, ConstraintNode, IRField, OperationNode};
+use oxidtr::parser::ast::{self, Multiplicity, SigMultiplicity, Expr};
 
 // ── impl_parser: type_to_mult ─────────────────────────────────────────────────
 
@@ -428,4 +428,94 @@ fn differ_detects_var_mismatch() {
         DiffItem::VarMismatch { struct_name, field_name, .. }
         if struct_name == "Account" && field_name == "balance"
     )), "should detect var mismatch when model has var but impl doesn't: {diffs:?}");
+}
+
+// ── Alloy 6: temporal constraint checking ──────────────────────────────────
+
+#[test]
+fn check_detects_missing_transition_test() {
+    // A fact with prime operator should require a transition_ test
+    let ir = OxidtrIR {
+        structures: vec![],
+        constraints: vec![ConstraintNode {
+            name: Some("StateUpdate".to_string()),
+            expr: Expr::TemporalUnary {
+                op: ast::TemporalUnaryOp::Always,
+                expr: Box::new(Expr::Quantifier {
+                    kind: ast::QuantKind::All,
+                    bindings: vec![ast::QuantBinding {
+                        vars: vec!["s".to_string()],
+                        domain: Expr::VarRef("S".to_string()),
+                        disj: false,
+                    }],
+                    body: Box::new(Expr::Comparison {
+                        op: ast::CompareOp::Eq,
+                        left: Box::new(Expr::Prime(Box::new(Expr::FieldAccess {
+                            base: Box::new(Expr::VarRef("s".to_string())),
+                            field: "x".to_string(),
+                        }))),
+                        right: Box::new(Expr::FieldAccess {
+                            base: Box::new(Expr::VarRef("s".to_string())),
+                            field: "x".to_string(),
+                        }),
+                    }),
+                }),
+            },
+        }],
+        operations: vec![],
+        properties: vec![],
+    };
+    // Source has the fact name but NOT the transition_ prefixed test
+    let sources = vec!["fn test_state_update() { /* StateUpdate */ }".to_string()];
+    let diffs = differ::diff_with_validation(&ir, &impl_parser::parse_impl("", ""), &sources);
+    assert!(diffs.iter().any(|d| matches!(d,
+        DiffItem::MissingTemporalTest { fact_name, expected_kind }
+        if fact_name == "StateUpdate" && expected_kind == "transition"
+    )), "should detect missing transition test: {diffs:?}");
+}
+
+#[test]
+fn check_passes_when_transition_test_present() {
+    let ir = OxidtrIR {
+        structures: vec![],
+        constraints: vec![ConstraintNode {
+            name: Some("StateUpdate".to_string()),
+            expr: Expr::TemporalUnary {
+                op: ast::TemporalUnaryOp::Always,
+                expr: Box::new(Expr::Prime(Box::new(Expr::VarRef("x".to_string())))),
+            },
+        }],
+        operations: vec![],
+        properties: vec![],
+    };
+    let sources = vec!["fn transition_state_update() { /* StateUpdate */ }".to_string()];
+    let diffs = differ::diff_with_validation(&ir, &impl_parser::parse_impl("", ""), &sources);
+    assert!(!diffs.iter().any(|d| matches!(d, DiffItem::MissingTemporalTest { .. })),
+        "should not report missing temporal test: {diffs:?}");
+}
+
+#[test]
+fn check_detects_missing_invariant_test_for_temporal_without_prime() {
+    let ir = OxidtrIR {
+        structures: vec![],
+        constraints: vec![ConstraintNode {
+            name: Some("AlwaysPositive".to_string()),
+            expr: Expr::TemporalUnary {
+                op: ast::TemporalUnaryOp::Always,
+                expr: Box::new(Expr::Comparison {
+                    op: ast::CompareOp::Gte,
+                    left: Box::new(Expr::VarRef("x".to_string())),
+                    right: Box::new(Expr::IntLiteral(0)),
+                }),
+            },
+        }],
+        operations: vec![],
+        properties: vec![],
+    };
+    let sources = vec!["fn test_always_positive() { /* AlwaysPositive */ }".to_string()];
+    let diffs = differ::diff_with_validation(&ir, &impl_parser::parse_impl("", ""), &sources);
+    assert!(diffs.iter().any(|d| matches!(d,
+        DiffItem::MissingTemporalTest { fact_name, expected_kind }
+        if fact_name == "AlwaysPositive" && expected_kind == "invariant"
+    )), "should detect missing invariant test: {diffs:?}");
 }

--- a/tests/expr_translator.rs
+++ b/tests/expr_translator.rs
@@ -540,3 +540,33 @@ fn translate_eventually_unwraps_inner() {
     let result = translate(&expr);
     assert!(!result.contains("/* temporal */"), "should not use comment placeholder, got: {result}");
 }
+
+#[test]
+fn translate_until_translates_both_sides() {
+    use oxidtr::parser::ast::{Expr, TemporalBinaryOp};
+    let left = eq(field(var("s"), "x"), field(var("s"), "y"));
+    let right = eq(field(var("s"), "a"), field(var("s"), "b"));
+    let expr = Expr::TemporalBinary {
+        op: TemporalBinaryOp::Until,
+        left: Box::new(left),
+        right: Box::new(right),
+    };
+    let result = translate(&expr);
+    assert!(result.contains("s.x == s.y"), "should contain left side, got: {result}");
+    assert!(result.contains("s.a == s.b"), "should contain right side, got: {result}");
+    assert!(result.contains("&&"), "should combine with &&, got: {result}");
+}
+
+#[test]
+fn translate_since_translates_both_sides() {
+    use oxidtr::parser::ast::{Expr, TemporalBinaryOp};
+    let left = eq(field(var("s"), "x"), field(var("s"), "y"));
+    let right = eq(field(var("s"), "a"), field(var("s"), "b"));
+    let expr = Expr::TemporalBinary {
+        op: TemporalBinaryOp::Since,
+        left: Box::new(left),
+        right: Box::new(right),
+    };
+    let result = translate(&expr);
+    assert!(result.contains("&&"), "should combine with &&, got: {result}");
+}

--- a/tests/extract_rust.rs
+++ b/tests/extract_rust.rs
@@ -426,3 +426,52 @@ pub struct Account {
     assert!(!rendered.contains("var name:"),
         "name should not have var prefix:\n{rendered}");
 }
+
+// ── Alloy 6: temporal annotation extraction ─────────────────────────────────
+
+#[test]
+fn mine_rust_temporal_transition_annotation() {
+    let src = r#"
+pub struct S {
+    pub x: i32,
+}
+
+#[cfg(test)]
+mod tests {
+    /// @temporal Transition constraint: StateUpdate
+    /// Verifies state-transition invariant (prime = next-state).
+    #[test]
+    fn transition_state_update() {
+        // test body
+    }
+}
+"#;
+    let mined = rust_extractor::extract(src);
+    assert!(mined.fact_candidates.iter().any(|f|
+        f.source_pattern.contains("@temporal Transition constraint: StateUpdate")),
+        "should extract @temporal Transition annotation: {:?}",
+        mined.fact_candidates.iter().map(|f| &f.source_pattern).collect::<Vec<_>>());
+}
+
+#[test]
+fn mine_rust_temporal_invariant_annotation() {
+    let src = r#"
+pub struct S {
+    pub x: i32,
+}
+
+#[cfg(test)]
+mod tests {
+    /// @temporal Invariant constraint: AlwaysPositive
+    #[test]
+    fn invariant_always_positive() {
+        // test body
+    }
+}
+"#;
+    let mined = rust_extractor::extract(src);
+    assert!(mined.fact_candidates.iter().any(|f|
+        f.source_pattern.contains("@temporal Invariant constraint: AlwaysPositive")),
+        "should extract @temporal Invariant annotation: {:?}",
+        mined.fact_candidates.iter().map(|f| &f.source_pattern).collect::<Vec<_>>());
+}

--- a/tests/parser_expr.rs
+++ b/tests/parser_expr.rs
@@ -718,3 +718,80 @@ fn parse_nested_temporal() {
         other => panic!("expected Always(Eventually(...)), got {other:?}"),
     }
 }
+
+// ── Alloy 6: temporal binary operator tests ─────────────────────────────────────
+
+#[test]
+fn parse_until_formula() {
+    let input = r#"
+        sig S { var x: one S }
+        fact { (all s: S | s.x = s.x) until (all s: S | s.x = s.x) }
+    "#;
+    let model = parser::parse(input).expect("should parse");
+    match &model.facts[0].body {
+        Expr::TemporalBinary { op, .. } => {
+            assert_eq!(*op, TemporalBinaryOp::Until);
+        }
+        other => panic!("expected TemporalBinary(Until), got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_since_formula() {
+    let input = r#"
+        sig S { var x: one S }
+        fact { (all s: S | s.x = s.x) since (all s: S | s.x = s.x) }
+    "#;
+    let model = parser::parse(input).expect("should parse");
+    match &model.facts[0].body {
+        Expr::TemporalBinary { op, .. } => {
+            assert_eq!(*op, TemporalBinaryOp::Since);
+        }
+        other => panic!("expected TemporalBinary(Since), got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_release_formula() {
+    let input = r#"
+        sig S { var x: one S }
+        fact { (all s: S | s.x = s.x) release (all s: S | s.x = s.x) }
+    "#;
+    let model = parser::parse(input).expect("should parse");
+    match &model.facts[0].body {
+        Expr::TemporalBinary { op, .. } => {
+            assert_eq!(*op, TemporalBinaryOp::Release);
+        }
+        other => panic!("expected TemporalBinary(Release), got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_triggered_formula() {
+    let input = r#"
+        sig S { var x: one S }
+        fact { (all s: S | s.x = s.x) triggered (all s: S | s.x = s.x) }
+    "#;
+    let model = parser::parse(input).expect("should parse");
+    match &model.facts[0].body {
+        Expr::TemporalBinary { op, .. } => {
+            assert_eq!(*op, TemporalBinaryOp::Triggered);
+        }
+        other => panic!("expected TemporalBinary(Triggered), got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_nested_always_until() {
+    let input = r#"
+        sig S { var x: one S }
+        fact { always ((all s: S | s.x = s.x) until (all s: S | s.x = s.x)) }
+    "#;
+    let model = parser::parse(input).expect("should parse");
+    match &model.facts[0].body {
+        Expr::TemporalUnary { op: TemporalUnaryOp::Always, expr } => {
+            assert!(matches!(expr.as_ref(), Expr::TemporalBinary { op: TemporalBinaryOp::Until, .. }));
+        }
+        other => panic!("expected Always(Until(...)), got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

- **二項時相演算子** (`until`/`since`/`release`/`triggered`) をパーサー、AST、全6バックエンドに追加
- **check強化**: 時相factに対して `transition_`/`invariant_` テストの存在を検証する `MissingTemporalTest` diff追加
- **extract強化**: 生成コード中の `@temporal` アノテーションを全6言語extractorで復元

## 変更内容

### パーサー + AST
- `Token::Until`/`Since`/`Release`/`Triggered` をlexerに追加
- `Expr::TemporalBinary { op, left, right }` と `TemporalBinaryOp` enumをASTに追加
- `parse_logic_implies` で二項時相演算子をパース（implies/iffと同じ優先度）

### 全6バックエンド (Rust/TS/Kotlin/Java/Swift/Go)
- expr_translatorに `TemporalBinary` 対応（左右をtranslateして `&&` で結合）
- `collect_params`/`collect_tc_fields`/`expr_uses_tc` 等の再帰matchに対応追加

### 制約分析 (analyze)
- `expr_contains_prime`/`expr_is_temporal`/`describe_expr`/`substitute_var`/`alloy_repr` 等 ~10箇所に対応追加

### check (differ.rs)
- `DiffItem::MissingTemporalTest { fact_name, expected_kind }` 追加
- prime含むfact → `transition_` テスト存在チェック
- prime無しtemporal fact → `invariant_` テスト存在チェック

### extract
- `extract_temporal_annotations()` 共有ヘルパーをmod.rsに追加
- 全6言語extractorから `@temporal Transition/Invariant constraint:` を検出
- `Confidence::High` で `MinedFactCandidate` 生成

### セルフホストモデル
- `models/oxidtr.als` と `models/oxidtr-domain.als` に `TemporalBinary`/`TemporalBinaryOp` sig追加

## テスト追加 (12件)
- パーサー: 5 (until/since/release/triggered + nested always-until)
- 式変換: 2 (until/since translates both sides)
- check: 3 (missing transition/invariant, passes when present)
- extract: 2 (transition/invariant annotation mining)

## Test plan
- [x] `cargo build` — zero warnings
- [x] `cargo test` — 全テスト通過 (既存 + 新規12件)
- [x] セルフホスト検証 (mine sig coverage 100%)

https://claude.ai/code/session_01N1KWAUnmHcbFJmtXvVGDKa