### PR TITLE
fix: ghost field refs, Java record+var, idiomatic var comments

### DIFF
--- a/src/backend/go/mod.rs
+++ b/src/backend/go/mod.rs
@@ -162,7 +162,7 @@ fn generate_struct(out: &mut String, s: &StructureNode, ir: &OxidtrIR, ctx: &GoC
     // Singleton: one sig → package-level var
     if s.sig_multiplicity == SigMultiplicity::One && s.fields.is_empty() {
         if s.is_var {
-            writeln!(out, "// @alloy: var sig").unwrap();
+            writeln!(out, "// Alloy var sig: instances change across state transitions (Go fields are mutable by default)").unwrap();
         }
         writeln!(out, "type {} struct{{}}", s.name).unwrap();
         writeln!(out).unwrap();
@@ -172,7 +172,7 @@ fn generate_struct(out: &mut String, s: &StructureNode, ir: &OxidtrIR, ctx: &GoC
     }
 
     if s.is_var {
-        writeln!(out, "// @alloy: var sig").unwrap();
+        writeln!(out, "// Alloy var sig: instances change across state transitions (Go fields are mutable by default)").unwrap();
     }
     if s.fields.is_empty() {
         writeln!(out, "type {} struct{{}}", s.name).unwrap();
@@ -196,9 +196,7 @@ fn generate_struct(out: &mut String, s: &StructureNode, ir: &OxidtrIR, ctx: &GoC
                 }
             }
 
-            if f.is_var {
-                writeln!(out, "\t// @alloy: var").unwrap();
-            }
+            // Go fields are mutable by default; no annotation needed for var fields
             if f.mult == Multiplicity::Seq {
                 writeln!(out, "\t// @alloy: seq").unwrap();
             }
@@ -442,20 +440,21 @@ fn generate_tests(ir: &OxidtrIR) -> String {
             None => continue,
         };
 
-        // Alloy 6: temporal facts with prime → generate transition test
+        // Alloy 6: temporal facts with prime → generate scaffold test
+        // Prime references (x') require before/after state capture; emit scaffold.
         if analyze::expr_contains_prime(&constraint.expr) {
             let params = expr_translator::extract_params(&constraint.expr, &sig_names);
-            let body = expr_translator::translate_with_ir(&constraint.expr, ir);
+            let desc = analyze::describe_expr(&constraint.expr);
 
             writeln!(out, "// @temporal Transition constraint: {fact_name}").unwrap();
-            writeln!(out, "// Verifies state-transition invariant (prime = next-state).").unwrap();
+            writeln!(out, "// Scaffold: prime (next-state) references require a before/after transition mechanism.").unwrap();
             writeln!(out, "func Test_transition_{}(t *testing.T) {{", fact_name).unwrap();
+            writeln!(out, "\t// TODO: apply transition, then assert post-condition").unwrap();
+            writeln!(out, "\t// Alloy constraint: {desc}").unwrap();
             for (pname, tname) in &params {
-                writeln!(out, "\t{pname} := []{tname}{{}}").unwrap();
+                writeln!(out, "\t// pre: capture {pname}: []{tname} before transition").unwrap();
+                writeln!(out, "\t// post: assert condition on {pname} after transition").unwrap();
             }
-            writeln!(out, "\tif !({body}) {{").unwrap();
-            writeln!(out, "\t\tt.Error(\"transition {} violated\")", fact_name).unwrap();
-            writeln!(out, "\t}}").unwrap();
             writeln!(out, "}}").unwrap();
             writeln!(out).unwrap();
             continue;
@@ -499,7 +498,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
         if let Some(ref kind) = temporal_kind {
             let note = match kind {
                 analyze::TemporalKind::Liveness | analyze::TemporalKind::PastLiveness =>
-                    " — cannot be fully tested statically; use trace checker for dynamic verification",
+                    " — liveness property: cannot be fully verified at runtime; static test approximates via implies",
                 analyze::TemporalKind::Binary =>
                     " — binary temporal: requires trace-based verification",
                 _ => "",

--- a/src/backend/jvm/java.rs
+++ b/src/backend/jvm/java.rs
@@ -143,7 +143,12 @@ fn generate_record(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_fiel
     if s.fields.is_empty() {
         writeln!(out, "record {}() {{}}", s.name).unwrap();
     } else {
-        let params: Vec<String> = s.fields.iter()
+        // Java records are immutable (fields are final). If any field is var
+        // (mutable across state transitions), generate a class instead.
+        let has_var_field = s.fields.iter().any(|f| f.is_var);
+
+        // Collect field annotations (shared between record and class generation)
+        let field_infos: Vec<(String, String, bool)> = s.fields.iter()
             .map(|f| {
                 let mut annotations = Vec::new();
                 let target_mult = analyze::sig_multiplicity_for(ir, &f.target);
@@ -202,9 +207,6 @@ fn generate_record(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_fiel
                         annotations.push("/* Consider using Set<T> for uniqueness (disj constraint) */".to_string());
                     }
                 }
-                if f.is_var {
-                    annotations.push("/* @alloy: var */".to_string());
-                }
                 let annotation_str = if annotations.is_empty() {
                     String::new()
                 } else {
@@ -223,11 +225,11 @@ fn generate_record(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_fiel
                 } else {
                     mult_to_java_type(&f.target, &f.mult)
                 };
-                format!("{annotation_str}{} {}", java_type, f.name)
+                (annotation_str, java_type, f.is_var)
             })
             .collect();
 
-        // FieldOrdering → compact constructor with validation
+        // FieldOrdering → constructor/compact-constructor validation
         let sig_constraints = analyze::constraints_for_sig(ir, &s.name);
         let mut constructor_checks: Vec<String> = Vec::new();
         for c in &sig_constraints {
@@ -258,16 +260,51 @@ fn generate_record(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_fiel
                 _ => {}
             }
         }
-        if constructor_checks.is_empty() {
-            writeln!(out, "record {}({}) {{}}", s.name, params.join(", ")).unwrap();
-        } else {
-            writeln!(out, "record {}({}) {{", s.name, params.join(", ")).unwrap();
-            writeln!(out, "    {} {{", s.name).unwrap();
+
+        if has_var_field {
+            // Generate a mutable class instead of record for var fields
+            writeln!(out, "/* var fields require mutable state — using class instead of record */").unwrap();
+            writeln!(out, "class {} {{", s.name).unwrap();
+            for (i, f) in s.fields.iter().enumerate() {
+                let (ref ann, ref jtype, is_var) = field_infos[i];
+                let final_kw = if is_var { "/* MUTABLE: changes across state transitions */ " } else { "final " };
+                writeln!(out, "    {ann}{final_kw}{jtype} {};", f.name).unwrap();
+            }
+            // Generate constructor
+            let ctor_params: Vec<String> = s.fields.iter().enumerate()
+                .map(|(i, f)| {
+                    let (_, ref jtype, _) = field_infos[i];
+                    format!("{jtype} {}", f.name)
+                })
+                .collect();
+            writeln!(out, "    {}({}) {{", s.name, ctor_params.join(", ")).unwrap();
             for check in &constructor_checks {
                 writeln!(out, "        {check}").unwrap();
             }
+            for f in &s.fields {
+                writeln!(out, "        this.{} = {};", f.name, f.name).unwrap();
+            }
             writeln!(out, "    }}").unwrap();
             writeln!(out, "}}").unwrap();
+        } else {
+            // Standard record generation (all fields immutable)
+            let params: Vec<String> = s.fields.iter().enumerate()
+                .map(|(i, f)| {
+                    let (ref ann, ref jtype, _) = field_infos[i];
+                    format!("{ann}{jtype} {}", f.name)
+                })
+                .collect();
+            if constructor_checks.is_empty() {
+                writeln!(out, "record {}({}) {{}}", s.name, params.join(", ")).unwrap();
+            } else {
+                writeln!(out, "record {}({}) {{", s.name, params.join(", ")).unwrap();
+                writeln!(out, "    {} {{", s.name).unwrap();
+                for check in &constructor_checks {
+                    writeln!(out, "        {check}").unwrap();
+                }
+                writeln!(out, "    }}").unwrap();
+                writeln!(out, "}}").unwrap();
+            }
         }
     }
 }
@@ -491,19 +528,22 @@ fn generate_tests(ir: &OxidtrIR) -> String {
     for constraint in &ir.constraints {
         let fact_name = match &constraint.name { Some(n) => n.clone(), None => continue };
 
-        // Alloy 6: temporal facts with prime → generate transition test
+        // Alloy 6: temporal facts with prime → generate scaffold test
+        // Prime references (x') require before/after state capture; emit scaffold.
         if analyze::expr_contains_prime(&constraint.expr) {
             let params = expr_translator::extract_params(&constraint.expr, &sig_names);
-            let body = expr_translator::translate_with_ir(&constraint.expr, ir, &lang);
+            let desc = analyze::describe_expr(&constraint.expr);
 
             writeln!(out, "    /** @temporal Transition constraint: {fact_name} */").unwrap();
-            writeln!(out, "    /** Verifies state-transition invariant (prime = next-state). */").unwrap();
+            writeln!(out, "    /** Scaffold: prime (next-state) references require a before/after transition mechanism. */").unwrap();
             writeln!(out, "    @Test").unwrap();
             writeln!(out, "    void transition_{}() {{", fact_name).unwrap();
+            writeln!(out, "        // TODO: apply transition, then assert post-condition").unwrap();
+            writeln!(out, "        // Alloy constraint: {desc}").unwrap();
             for (pname, tname) in &params {
-                writeln!(out, "        List<{tname}> {pname} = List.of();").unwrap();
+                writeln!(out, "        // pre: capture {pname}: List<{tname}> before transition").unwrap();
+                writeln!(out, "        // post: assert condition on {pname} after transition").unwrap();
             }
-            writeln!(out, "        assertTrue({body});").unwrap();
             writeln!(out, "    }}").unwrap();
             writeln!(out).unwrap();
             continue;
@@ -525,7 +565,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
         if let Some(ref kind) = temporal_kind {
             let note = match kind {
                 analyze::TemporalKind::Liveness | analyze::TemporalKind::PastLiveness =>
-                    " — cannot be fully tested statically; use trace checker for dynamic verification",
+                    " — liveness property: cannot be fully verified at runtime; static test approximates via implies",
                 analyze::TemporalKind::Binary =>
                     " — binary temporal: requires trace-based verification",
                 _ => "",

--- a/src/backend/jvm/kotlin.rs
+++ b/src/backend/jvm/kotlin.rs
@@ -474,19 +474,22 @@ fn generate_tests(ir: &OxidtrIR) -> String {
             None => continue,
         };
 
-        // Alloy 6: temporal facts with prime → generate transition test
+        // Alloy 6: temporal facts with prime → generate scaffold test
+        // Prime references (x') require before/after state capture; emit scaffold.
         if analyze::expr_contains_prime(&constraint.expr) {
             let params = expr_translator::extract_params(&constraint.expr, &sig_names);
-            let body = expr_translator::translate_with_ir(&constraint.expr, ir, &lang);
+            let desc = analyze::describe_expr(&constraint.expr);
 
             writeln!(out, "    /** @temporal Transition constraint: {fact_name} */").unwrap();
-            writeln!(out, "    /** Verifies state-transition invariant (prime = next-state). */").unwrap();
+            writeln!(out, "    /** Scaffold: prime (next-state) references require a before/after transition mechanism. */").unwrap();
             writeln!(out, "    @Test").unwrap();
             writeln!(out, "    fun `transition {fact_name}`() {{").unwrap();
+            writeln!(out, "        // TODO: apply transition, then assert post-condition").unwrap();
+            writeln!(out, "        // Alloy constraint: {desc}").unwrap();
             for (pname, tname) in &params {
-                writeln!(out, "        val {pname}: List<{tname}> = emptyList()").unwrap();
+                writeln!(out, "        // pre: capture {pname}: List<{tname}> before transition").unwrap();
+                writeln!(out, "        // post: assert condition on {pname} after transition").unwrap();
             }
-            writeln!(out, "        assertTrue({body})").unwrap();
             writeln!(out, "    }}").unwrap();
             writeln!(out).unwrap();
             continue;
@@ -530,7 +533,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
         if let Some(ref kind) = temporal_kind {
             let note = match kind {
                 analyze::TemporalKind::Liveness | analyze::TemporalKind::PastLiveness =>
-                    " — cannot be fully tested statically; use trace checker for dynamic verification",
+                    " — liveness property: cannot be fully verified at runtime; static test approximates via implies",
                 analyze::TemporalKind::Binary =>
                     " — binary temporal: requires trace-based verification",
                 _ => "",

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -252,7 +252,7 @@ fn generate_struct(
     // Singleton: one sig → unit struct + INSTANCE constant
     if s.sig_multiplicity == SigMultiplicity::One && s.fields.is_empty() {
         if s.is_var {
-            writeln!(out, "/// @alloy: var sig").unwrap();
+            writeln!(out, "/// MUTABLE SIG: instances of this sig change across state transitions").unwrap();
         }
         if use_serde {
             writeln!(out, "#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]").unwrap();
@@ -265,7 +265,7 @@ fn generate_struct(
     }
 
     if s.is_var {
-        writeln!(out, "/// @alloy: var sig").unwrap();
+        writeln!(out, "/// MUTABLE SIG: instances of this sig change across state transitions").unwrap();
     }
     if use_serde {
         writeln!(out, "#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]").unwrap();
@@ -288,7 +288,7 @@ fn generate_struct(
                 multiplicity_to_type(&f.target, &f.mult, is_self_ref)
             };
             if f.is_var {
-                writeln!(out, "    /// @alloy: var").unwrap();
+                writeln!(out, "    /// MUTABLE: this field changes across state transitions").unwrap();
             }
             writeln!(out, "    pub {}: {type_str},", f.name).unwrap();
         }
@@ -540,28 +540,27 @@ fn generate_tests(ir: &OxidtrIR) -> String {
             None => continue,
         };
 
-        // Alloy 6: temporal facts with prime → generate transition test
+        // Alloy 6: temporal facts with prime → generate scaffold test
+        // Prime references (x') require before/after state capture which cannot be
+        // expressed as a simple field access; emit a scaffold with TODO comments.
         if analyze::expr_contains_prime(&constraint.expr) {
             let test_name = format!("transition_{}", to_snake_case(&fact_name));
             let params = expr_translator::extract_params(&constraint.expr, &sig_names);
             if params.iter().any(|(_, tname)| variant_names_set.contains(tname) || enum_parents.contains(tname)) {
                 continue;
             }
-            let body = expr_translator::translate_with_ir(&constraint.expr, ir);
+            let desc = analyze::describe_expr(&constraint.expr);
 
             writeln!(out, "    /// @temporal Transition constraint: {fact_name}").unwrap();
-            writeln!(out, "    /// Verifies state-transition invariant (prime = next-state).").unwrap();
+            writeln!(out, "    /// Scaffold: prime (next-state) references require a before/after transition mechanism.").unwrap();
             writeln!(out, "    #[test]").unwrap();
             writeln!(out, "    fn {test_name}() {{").unwrap();
+            writeln!(out, "        // TODO: apply transition, then assert post-condition").unwrap();
+            writeln!(out, "        // Alloy constraint: {desc}").unwrap();
             for (pname, tname) in &params {
-                if has_fixture.contains(tname) {
-                    let snake = to_snake_case(tname);
-                    writeln!(out, "        let {pname}: Vec<{tname}> = vec![default_{snake}()];").unwrap();
-                } else {
-                    writeln!(out, "        let {pname}: Vec<{tname}> = Vec::new();").unwrap();
-                }
+                writeln!(out, "        // pre: capture {pname}: Vec<{tname}> before transition").unwrap();
+                writeln!(out, "        // post: assert condition on {pname} after transition").unwrap();
             }
-            writeln!(out, "        assert!({body});").unwrap();
             writeln!(out, "    }}").unwrap();
             writeln!(out).unwrap();
             continue;
@@ -624,9 +623,9 @@ fn generate_tests(ir: &OxidtrIR) -> String {
         if let Some(kind) = temporal_kind {
             let annotation = match kind {
                 analyze::TemporalKind::Invariant => "@temporal Invariant: property must hold in all states",
-                analyze::TemporalKind::Liveness => "@temporal Liveness: cannot be fully tested statically; use trace checker for dynamic verification",
+                analyze::TemporalKind::Liveness => "@temporal Liveness property — cannot be fully verified at runtime; static test approximates via implies",
                 analyze::TemporalKind::PastInvariant => "@temporal PastInvariant: property must have held in all past states",
-                analyze::TemporalKind::PastLiveness => "@temporal PastLiveness: cannot be fully tested statically; use trace checker for dynamic verification",
+                analyze::TemporalKind::PastLiveness => "@temporal PastLiveness property — cannot be fully verified at runtime; static test approximates via implies",
                 analyze::TemporalKind::Step => "@temporal Step: relates adjacent states",
                 analyze::TemporalKind::Binary => "@temporal Binary: temporal binary constraint",
             };

--- a/src/backend/swift/mod.rs
+++ b/src/backend/swift/mod.rs
@@ -413,18 +413,21 @@ fn generate_tests(ir: &OxidtrIR) -> String {
             None => continue,
         };
 
-        // Alloy 6: temporal facts with prime → generate transition test
+        // Alloy 6: temporal facts with prime → generate scaffold test
+        // Prime references (x') require before/after state capture; emit scaffold.
         if analyze::expr_contains_prime(&constraint.expr) {
             let params = expr_translator::extract_params(&constraint.expr, &sig_names);
-            let body = expr_translator::translate_with_ir(&constraint.expr, ir);
+            let desc = analyze::describe_expr(&constraint.expr);
 
             writeln!(out, "    /// @temporal Transition constraint: {fact_name}").unwrap();
-            writeln!(out, "    /// Verifies state-transition invariant (prime = next-state).").unwrap();
+            writeln!(out, "    /// Scaffold: prime (next-state) references require a before/after transition mechanism.").unwrap();
             writeln!(out, "    func test_transition_{}() {{", fact_name).unwrap();
+            writeln!(out, "        // TODO: apply transition, then assert post-condition").unwrap();
+            writeln!(out, "        // Alloy constraint: {desc}").unwrap();
             for (pname, tname) in &params {
-                writeln!(out, "        let {pname}: [{tname}] = []").unwrap();
+                writeln!(out, "        // pre: capture {pname}: [{tname}] before transition").unwrap();
+                writeln!(out, "        // post: assert condition on {pname} after transition").unwrap();
             }
-            writeln!(out, "        XCTAssertTrue({body})").unwrap();
             writeln!(out, "    }}").unwrap();
             writeln!(out).unwrap();
             continue;
@@ -468,7 +471,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
         if let Some(ref kind) = temporal_kind {
             let note = match kind {
                 analyze::TemporalKind::Liveness | analyze::TemporalKind::PastLiveness =>
-                    " — cannot be fully tested statically; use trace checker for dynamic verification",
+                    " — liveness property: cannot be fully verified at runtime; static test approximates via implies",
                 analyze::TemporalKind::Binary =>
                     " — binary temporal: requires trace-based verification",
                 _ => "",

--- a/src/backend/typescript/mod.rs
+++ b/src/backend/typescript/mod.rs
@@ -185,6 +185,9 @@ fn generate_interface(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_f
                 mult_to_ts_type(&f.target, &f.mult)
             };
             let readonly = if f.is_var { "" } else { "readonly " };
+            if f.is_var {
+                writeln!(out, "  /** @mutable changes across state transitions */").unwrap();
+            }
             writeln!(out, "  {readonly}{}: {};", f.name, type_str).unwrap();
         }
         writeln!(out, "}}").unwrap();
@@ -468,23 +471,22 @@ fn generate_tests(ir: &OxidtrIR, test_runner: TsTestRunner) -> String {
             Some(name) => name.clone(),
             None => continue,
         };
-        // Alloy 6: temporal facts with prime → generate transition test
+        // Alloy 6: temporal facts with prime → generate scaffold test
+        // Prime references (x') require before/after state capture; emit scaffold.
         if analyze::expr_contains_prime(&constraint.expr) {
             let test_name = format!("transition {fact_name}");
             let params = expr_translator::extract_params(&constraint.expr, &sig_names);
-            let body = expr_translator::translate_with_ir(&constraint.expr, ir);
+            let desc = analyze::describe_expr(&constraint.expr);
 
             writeln!(out, "  /** @temporal Transition constraint: {fact_name} */").unwrap();
-            writeln!(out, "  /** Verifies state-transition invariant (prime = next-state). */").unwrap();
+            writeln!(out, "  /** Scaffold: prime (next-state) references require a before/after transition mechanism. */").unwrap();
             writeln!(out, "  it('{}', () => {{", test_name).unwrap();
+            writeln!(out, "    // TODO: apply transition, then assert post-condition").unwrap();
+            writeln!(out, "    // Alloy constraint: {desc}").unwrap();
             for (pname, tname) in &params {
-                if has_fixture.contains(tname) {
-                    writeln!(out, "    const {pname}: M.{tname}[] = [fix.default{tname}()];").unwrap();
-                } else {
-                    writeln!(out, "    const {pname}: M.{tname}[] = [];").unwrap();
-                }
+                writeln!(out, "    // pre: capture {pname}: M.{tname}[] before transition").unwrap();
+                writeln!(out, "    // post: assert condition on {pname} after transition").unwrap();
             }
-            writeln!(out, "    expect({body}).toBe(true);").unwrap();
             writeln!(out, "  }});").unwrap();
             writeln!(out).unwrap();
             continue;
@@ -509,7 +511,7 @@ fn generate_tests(ir: &OxidtrIR, test_runner: TsTestRunner) -> String {
         if let Some(ref kind) = temporal_kind {
             let note = match kind {
                 analyze::TemporalKind::Liveness | analyze::TemporalKind::PastLiveness =>
-                    " — cannot be fully tested statically; use trace checker for dynamic verification",
+                    " — liveness property: cannot be fully verified at runtime; static test approximates via implies",
                 analyze::TemporalKind::Binary =>
                     " — binary temporal: requires trace-based verification",
                 _ => "",

--- a/tests/backend_go.rs
+++ b/tests/backend_go.rs
@@ -186,12 +186,16 @@ fn go_tests_import_testing() {
 
 #[test]
 fn go_var_field_annotated() {
+    // Go fields are mutable by default, so no @alloy: var annotation is needed.
+    // The field should still be present without any var-specific comment.
     let files = generate_go(r#"
         sig Account { var balance: one Int }
     "#);
     let m = find_file(&files, "models.go");
-    assert!(m.contains("@alloy: var"),
-        "var field should have @alloy: var annotation in Go:\n{m}");
+    assert!(!m.contains("@alloy: var"),
+        "Go var field should not have @alloy: var annotation (fields are mutable by default):\n{m}");
+    assert!(m.contains("Balance"),
+        "var field should still be present in struct:\n{m}");
 }
 
 // ── Binary temporal static test ──────────────────────────────────────────────

--- a/tests/backend_jvm.rs
+++ b/tests/backend_jvm.rs
@@ -462,12 +462,17 @@ fn kt_var_field_uses_var_keyword() {
 
 #[test]
 fn java_var_field_annotated() {
+    // Java records are immutable. Sigs with var fields should generate a class instead.
     let files = generate_java(r#"
         sig Account { var balance: one Int }
     "#);
     let models = find_file(&files, "Models.java");
-    assert!(models.contains("@alloy: var"),
-        "var field should have @alloy: var annotation in Java:\n{models}");
+    assert!(models.contains("class Account"),
+        "var field sig should generate class (not record) in Java:\n{models}");
+    assert!(models.contains("MUTABLE"),
+        "var field should be annotated as MUTABLE in Java:\n{models}");
+    assert!(!models.contains("record Account"),
+        "var field sig should NOT generate record in Java:\n{models}");
 }
 
 // ── Alloy 6: var field extraction ───────────────────────────────────────────

--- a/tests/backend_rust.rs
+++ b/tests/backend_rust.rs
@@ -461,8 +461,8 @@ fn rust_var_field_annotated() {
         sig Account { var balance: one Int }
     "#);
     let models = find_file(&files, "models.rs");
-    assert!(models.contains("@alloy: var"),
-        "var field should have @alloy: var annotation:\n{models}");
+    assert!(models.contains("MUTABLE"),
+        "var field should have MUTABLE annotation:\n{models}");
 }
 
 #[test]
@@ -485,8 +485,10 @@ fn rust_temporal_prime_fact_generates_transition_test() {
     let tests = find_file(&files, "tests.rs");
     assert!(tests.contains("transition_monotonically_increasing"),
         "should generate transition test for prime-containing fact:\n{tests}");
-    assert!(tests.contains("next_value"),
-        "transition test should reference next-state field:\n{tests}");
+    assert!(tests.contains("TODO: apply transition"),
+        "transition test should be a scaffold with TODO:\n{tests}");
+    assert!(!tests.contains("next_value"),
+        "transition test should NOT reference ghost field next_value:\n{tests}");
 }
 
 // ── Binary temporal static test ──────────────────────────────────────────────

--- a/tests/backend_ts.rs
+++ b/tests/backend_ts.rs
@@ -316,8 +316,10 @@ fn ts_temporal_prime_fact_generates_transition_test() {
     let tests = find_file(&files, "tests.ts");
     assert!(tests.contains("transition"),
         "should generate transition test for prime-containing fact:\n{tests}");
-    assert!(tests.contains("next_value"),
-        "transition test should reference next-state field:\n{tests}");
+    assert!(tests.contains("TODO: apply transition"),
+        "transition test should be a scaffold with TODO:\n{tests}");
+    assert!(!tests.contains("next_value"),
+        "transition test should NOT reference ghost field next_value:\n{tests}");
 }
 
 // ── Binary temporal static test ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **A. Transition tests (prime/next-state)**: Replace uncompilable `next_field` ghost references with scaffold + TODO comments across all 6 backends. Prime expressions require a before/after transition mechanism; scaffolds document the Alloy constraint and pre/post capture needed.
- **B. until/since (binary temporal)**: Verified already correctly handled as comment-only scaffolds — no change needed.
- **C. Java record + var field**: Records are immutable (fields are final). Sigs with var fields now generate a mutable `class` instead of `record`, with MUTABLE annotation and proper constructor.
- **D. Rust var comment**: `/// @alloy: var` → `/// MUTABLE: this field changes across state transitions`
- **E. Go var comment**: Removed — Go fields are mutable by default, annotation was misleading.
- **F. TS var fields**: Added `/** @mutable changes across state transitions */` JSDoc.
- **G. Liveness annotations**: Updated to explicit "liveness property — cannot be fully verified at runtime; static test approximates via implies" across all backends.

## Test plan

- [x] `cargo build` — zero warnings
- [x] `cargo test` — all 490+ tests pass, zero failures
- [x] Verify generated output for a model with var fields (e.g. `models/oxidtr.als`)
- [x] Confirm Java output uses `class` instead of `record` for var-field sigs
- [x] Confirm transition tests are scaffolds (no `next_` ghost fields)

https://claude.ai/code/session_01BPAHkydc1Qoeo8hRdVusWr