### PR TITLE
fix: unify temporal test name conventions between generate and check

### DIFF
--- a/src/backend/go/mod.rs
+++ b/src/backend/go/mod.rs
@@ -521,6 +521,14 @@ fn generate_tests(ir: &OxidtrIR) -> String {
             writeln!(out, "\t// binary temporal: requires trace-based verification; see check_{op_label}_{snake_name}").unwrap();
             writeln!(out, "}}").unwrap();
             writeln!(out).unwrap();
+        } else if matches!(temporal_kind, Some(analyze::TemporalKind::Liveness) | Some(analyze::TemporalKind::PastLiveness)) {
+            let kind_label = if temporal_kind == Some(analyze::TemporalKind::Liveness) {
+                "liveness" } else { "past_liveness" };
+            let snake_name = to_snake_case(&fact_name);
+            writeln!(out, "func Test_{}_{}(t *testing.T) {{", test_prefix, fact_name).unwrap();
+            writeln!(out, "\t// {kind_label}: requires trace-based verification; see check_{kind_label}_{snake_name}").unwrap();
+            writeln!(out, "}}").unwrap();
+            writeln!(out).unwrap();
         } else {
         writeln!(out, "func Test_{}_{}(t *testing.T) {{", test_prefix, fact_name).unwrap();
         for (pname, tname) in &params {

--- a/src/backend/jvm/java.rs
+++ b/src/backend/jvm/java.rs
@@ -588,6 +588,14 @@ fn generate_tests(ir: &OxidtrIR) -> String {
             writeln!(out, "        // binary temporal: requires trace-based verification; see check{op_label}{fact_name}").unwrap();
             writeln!(out, "    }}").unwrap();
             writeln!(out).unwrap();
+        } else if matches!(temporal_kind, Some(analyze::TemporalKind::Liveness) | Some(analyze::TemporalKind::PastLiveness)) {
+            let kind_label = if temporal_kind == Some(analyze::TemporalKind::Liveness) {
+                "Liveness" } else { "PastLiveness" };
+            writeln!(out, "    @Test").unwrap();
+            writeln!(out, "    void {}_{}() {{", test_prefix, fact_name).unwrap();
+            writeln!(out, "        // {}: requires trace-based verification; see check{kind_label}{fact_name}", test_prefix).unwrap();
+            writeln!(out, "    }}").unwrap();
+            writeln!(out).unwrap();
         } else {
         writeln!(out, "    @Test").unwrap();
         writeln!(out, "    void {}_{}() {{", test_prefix, fact_name).unwrap();

--- a/src/backend/jvm/kotlin.rs
+++ b/src/backend/jvm/kotlin.rs
@@ -556,6 +556,14 @@ fn generate_tests(ir: &OxidtrIR) -> String {
             writeln!(out, "        // binary temporal: requires trace-based verification; see check{op_label}{fact_name}").unwrap();
             writeln!(out, "    }}").unwrap();
             writeln!(out).unwrap();
+        } else if matches!(temporal_kind, Some(analyze::TemporalKind::Liveness) | Some(analyze::TemporalKind::PastLiveness)) {
+            let kind_label = if temporal_kind == Some(analyze::TemporalKind::Liveness) {
+                "Liveness" } else { "PastLiveness" };
+            writeln!(out, "    @Test").unwrap();
+            writeln!(out, "    fun `{test_prefix} {fact_name}`() {{").unwrap();
+            writeln!(out, "        // {}: requires trace-based verification; see check{kind_label}{fact_name}", test_prefix).unwrap();
+            writeln!(out, "    }}").unwrap();
+            writeln!(out).unwrap();
         } else {
         writeln!(out, "    @Test").unwrap();
         writeln!(out, "    fun `{test_prefix} {fact_name}`() {{").unwrap();

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -649,6 +649,16 @@ fn generate_tests(ir: &OxidtrIR) -> String {
             writeln!(out, "        // binary temporal: requires trace-based verification; see check_{op_label}_{snake_name}").unwrap();
             writeln!(out, "    }}").unwrap();
             writeln!(out).unwrap();
+        } else if matches!(temporal_kind, Some(analyze::TemporalKind::Liveness) | Some(analyze::TemporalKind::PastLiveness)) {
+            // Liveness/past_liveness: cannot be verified with single snapshot
+            let kind_label = if temporal_kind == Some(analyze::TemporalKind::Liveness) {
+                "liveness" } else { "past_liveness" };
+            let snake_name = to_snake_case(&fact_name);
+            writeln!(out, "    #[test]").unwrap();
+            writeln!(out, "    fn {test_name}() {{").unwrap();
+            writeln!(out, "        // {kind_label}: requires trace-based verification; see check_{kind_label}_{snake_name}").unwrap();
+            writeln!(out, "    }}").unwrap();
+            writeln!(out).unwrap();
         } else {
         // Detect ownership facts: `all x: A | some y: B | x in y.field`
         // These need linked fixture setup where B.field contains x.

--- a/src/backend/swift/mod.rs
+++ b/src/backend/swift/mod.rs
@@ -494,6 +494,14 @@ fn generate_tests(ir: &OxidtrIR) -> String {
             writeln!(out, "        // binary temporal: requires trace-based verification; see check_{op_label}_{snake_name}").unwrap();
             writeln!(out, "    }}").unwrap();
             writeln!(out).unwrap();
+        } else if matches!(temporal_kind, Some(analyze::TemporalKind::Liveness) | Some(analyze::TemporalKind::PastLiveness)) {
+            let kind_label = if temporal_kind == Some(analyze::TemporalKind::Liveness) {
+                "liveness" } else { "past_liveness" };
+            let snake_name = to_snake_case(&fact_name);
+            writeln!(out, "    func test_{}_{}() {{", test_prefix, fact_name).unwrap();
+            writeln!(out, "        // {kind_label}: requires trace-based verification; see check_{kind_label}_{snake_name}").unwrap();
+            writeln!(out, "    }}").unwrap();
+            writeln!(out).unwrap();
         } else {
         writeln!(out, "    func test_{}_{}() {{", test_prefix, fact_name).unwrap();
         for (pname, tname) in &params {

--- a/src/backend/typescript/mod.rs
+++ b/src/backend/typescript/mod.rs
@@ -534,6 +534,15 @@ fn generate_tests(ir: &OxidtrIR, test_runner: TsTestRunner) -> String {
             writeln!(out, "    // binary temporal: requires trace-based verification; see check_{op_label}_{camel_name}").unwrap();
             writeln!(out, "  }});").unwrap();
             writeln!(out).unwrap();
+        } else if matches!(temporal_kind, Some(analyze::TemporalKind::Liveness) | Some(analyze::TemporalKind::PastLiveness)) {
+            // Liveness/past_liveness: cannot be verified with single snapshot
+            let kind_label = if temporal_kind == Some(analyze::TemporalKind::Liveness) {
+                "liveness" } else { "past_liveness" };
+            let camel_name = to_camel_case(&fact_name);
+            writeln!(out, "  it('{}', () => {{", test_name).unwrap();
+            writeln!(out, "    // {kind_label}: requires trace-based verification; see check_{kind_label}_{camel_name}").unwrap();
+            writeln!(out, "  }});").unwrap();
+            writeln!(out).unwrap();
         } else {
         writeln!(out, "  it('{}', () => {{", test_name).unwrap();
         if let Some((owned_var, owner_var, _owner_type, field_name)) = &ownership {

--- a/src/check/differ.rs
+++ b/src/check/differ.rs
@@ -172,7 +172,10 @@ fn diff_validations(ir: &OxidtrIR, sources: &[String], use_snake_case: bool) -> 
             } else {
                 format!("transition_{fact_name}")
             };
-            if !combined.contains(&transition_name) {
+            // TS/Kotlin use space-separated test names: `transition FlagName`
+            let found_transition = combined.contains(&transition_name)
+                || (!use_snake_case && combined.contains(&format!("transition {fact_name}")));
+            if !found_transition {
                 diffs.push(DiffItem::MissingTemporalTest {
                     fact_name: fact_name.clone(),
                     expected_kind: "transition".to_string(),
@@ -201,14 +204,19 @@ fn diff_validations(ir: &OxidtrIR, sources: &[String], use_snake_case: bool) -> 
             } else {
                 format!("{test_prefix}_{fact_name}")
             };
-            if !combined.contains(&temporal_name) {
+            // TS/Kotlin use space-separated test names: `prefix FactName`
+            let found_temporal = combined.contains(&temporal_name)
+                || (!use_snake_case && combined.contains(&format!("{test_prefix} {fact_name}")));
+            if !found_temporal {
                 // Fall back to invariant_ prefix for backward compatibility
                 let fallback_name = if use_snake_case {
                     format!("invariant_{}", to_snake_case(&fact_name))
                 } else {
                     format!("invariant_{fact_name}")
                 };
-                if !combined.contains(&fallback_name) {
+                let found_fallback = combined.contains(&fallback_name)
+                    || (!use_snake_case && combined.contains(&format!("invariant {fact_name}")));
+                if !found_fallback {
                     diffs.push(DiffItem::MissingTemporalTest {
                         fact_name,
                         expected_kind: expected_kind.to_string(),

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -527,6 +527,99 @@ fn check_detects_missing_invariant_test_for_temporal_without_prime() {
     )), "should detect missing invariant test: {diffs:?}");
 }
 
+// ── Temporal test name: space-separated form (TS/Kotlin) ────────────────────────
+
+#[test]
+fn check_accepts_space_separated_invariant_test_name() {
+    // TS/Kotlin generate `it('invariant FlagImpliesPositive', ...)` (space separator)
+    // check should recognize this as matching the temporal test requirement
+    let ir = OxidtrIR {
+        structures: vec![],
+        constraints: vec![ConstraintNode {
+            name: Some("FlagImpliesPositive".to_string()),
+            expr: Expr::TemporalUnary {
+                op: ast::TemporalUnaryOp::Always,
+                expr: Box::new(Expr::Comparison {
+                    op: ast::CompareOp::Gte,
+                    left: Box::new(Expr::VarRef("x".to_string())),
+                    right: Box::new(Expr::IntLiteral(0)),
+                }),
+            },
+        }],
+        operations: vec![],
+        properties: vec![],
+    };
+    // Source uses space-separated form (as TS/Kotlin backends emit)
+    let sources = vec!["it('invariant FlagImpliesPositive', () => {".to_string()];
+    let diffs = differ::diff_identity_with_validation(&ir, &impl_parser::parse_impl("", ""), &sources);
+    assert!(!diffs.iter().any(|d| matches!(d, DiffItem::MissingTemporalTest { .. })),
+        "should accept space-separated invariant test name: {diffs:?}");
+}
+
+#[test]
+fn check_accepts_space_separated_temporal_binary_test_name() {
+    // TS/Kotlin generate `it('temporal FlagUntilLarge', ...)` for binary temporal
+    use oxidtr::parser::ast::TemporalBinaryOp;
+    let ir = OxidtrIR {
+        structures: vec![],
+        constraints: vec![ConstraintNode {
+            name: Some("FlagUntilLarge".to_string()),
+            expr: Expr::TemporalBinary {
+                op: TemporalBinaryOp::Until,
+                left: Box::new(Expr::VarRef("x".to_string())),
+                right: Box::new(Expr::VarRef("y".to_string())),
+            },
+        }],
+        operations: vec![],
+        properties: vec![],
+    };
+    let sources = vec!["it('temporal FlagUntilLarge', () => {".to_string()];
+    let diffs = differ::diff_identity_with_validation(&ir, &impl_parser::parse_impl("", ""), &sources);
+    assert!(!diffs.iter().any(|d| matches!(d, DiffItem::MissingTemporalTest { .. })),
+        "should accept space-separated temporal binary test name: {diffs:?}");
+}
+
+#[test]
+fn check_accepts_space_separated_liveness_test_name() {
+    let ir = OxidtrIR {
+        structures: vec![],
+        constraints: vec![ConstraintNode {
+            name: Some("WillConverge".to_string()),
+            expr: Expr::TemporalUnary {
+                op: ast::TemporalUnaryOp::Eventually,
+                expr: Box::new(Expr::VarRef("x".to_string())),
+            },
+        }],
+        operations: vec![],
+        properties: vec![],
+    };
+    let sources = vec!["it('liveness WillConverge', () => {".to_string()];
+    let diffs = differ::diff_identity_with_validation(&ir, &impl_parser::parse_impl("", ""), &sources);
+    assert!(!diffs.iter().any(|d| matches!(d, DiffItem::MissingTemporalTest { .. })),
+        "should accept space-separated liveness test name: {diffs:?}");
+}
+
+#[test]
+fn check_accepts_space_separated_transition_test_name() {
+    // TS generates `it('transition StateUpdate', ...)` for prime constraints
+    let ir = OxidtrIR {
+        structures: vec![],
+        constraints: vec![ConstraintNode {
+            name: Some("StateUpdate".to_string()),
+            expr: Expr::TemporalUnary {
+                op: ast::TemporalUnaryOp::Always,
+                expr: Box::new(Expr::Prime(Box::new(Expr::VarRef("x".to_string())))),
+            },
+        }],
+        operations: vec![],
+        properties: vec![],
+    };
+    let sources = vec!["it('transition StateUpdate', () => {".to_string()];
+    let diffs = differ::diff_identity_with_validation(&ir, &impl_parser::parse_impl("", ""), &sources);
+    assert!(!diffs.iter().any(|d| matches!(d, DiffItem::MissingTemporalTest { .. })),
+        "should accept space-separated transition test name: {diffs:?}");
+}
+
 // ── Assert check ────────────────────────────────────────────────────────────────
 
 #[test]

--- a/tests/test_generation.rs
+++ b/tests/test_generation.rs
@@ -1,11 +1,18 @@
 use oxidtr::parser;
 use oxidtr::ir;
 use oxidtr::backend::rust;
+use oxidtr::backend::typescript;
 
 fn generate_from(input: &str) -> Vec<oxidtr::backend::GeneratedFile> {
     let model = parser::parse(input).expect("should parse");
     let ir = ir::lower(&model).expect("should lower");
     rust::generate(&ir)
+}
+
+fn generate_ts_from(input: &str) -> Vec<oxidtr::backend::GeneratedFile> {
+    let model = parser::parse(input).expect("should parse");
+    let ir = ir::lower(&model).expect("should lower");
+    typescript::generate(&ir)
 }
 
 fn find_file<'a>(files: &'a [oxidtr::backend::GeneratedFile], path: &str) -> &'a str {
@@ -177,6 +184,76 @@ fn binary_temporal_since_static_test_does_not_assert_body() {
     assert!(
         content.contains("binary temporal: requires trace-based verification"),
         "since static test should document the limitation:\n{content}"
+    );
+}
+
+// ── ④b Liveness static test should reference trace checker, not assert body ──
+
+#[test]
+fn liveness_static_test_references_trace_checker_rust() {
+    let files = generate_from(r#"
+        sig S { x: one S }
+        fact WillConverge { eventually all s: S | s.x = s.x }
+    "#);
+    let content = find_file(&files, "tests.rs");
+    // Liveness test should exist
+    assert!(content.contains("fn liveness_"), "missing liveness test:\n{content}");
+    // But should NOT assert body — liveness cannot be verified with single snapshot
+    assert!(
+        !content.contains("assert!(s.iter()"),
+        "liveness static test should NOT assert body inline:\n{content}"
+    );
+    // Should reference trace checker
+    assert!(
+        content.contains("liveness: requires trace-based verification; see check_liveness_"),
+        "liveness static test should reference trace checker:\n{content}"
+    );
+}
+
+#[test]
+fn past_liveness_static_test_references_trace_checker_rust() {
+    let files = generate_from(r#"
+        sig S { x: one S }
+        fact WasReached { once all s: S | s.x = s.x }
+    "#);
+    let content = find_file(&files, "tests.rs");
+    assert!(content.contains("fn past_liveness_"), "missing past_liveness test:\n{content}");
+    assert!(
+        content.contains("past_liveness: requires trace-based verification; see check_past_liveness_"),
+        "past_liveness static test should reference trace checker:\n{content}"
+    );
+}
+
+// ── ④c TS: liveness/binary temporal test names and trace checker references ──
+
+#[test]
+fn ts_liveness_static_test_references_trace_checker() {
+    let files = generate_ts_from(r#"
+        sig S { x: one S }
+        fact WillConverge { eventually all s: S | s.x = s.x }
+    "#);
+    let content = find_file(&files, "tests.ts");
+    // TS should generate `it('liveness WillConverge', ...)`
+    assert!(content.contains("it('liveness WillConverge'"), "missing liveness test with correct name:\n{content}");
+    // Should reference trace checker, not assert body
+    assert!(
+        content.contains("liveness: requires trace-based verification; see check_liveness_"),
+        "liveness static test should reference trace checker:\n{content}"
+    );
+}
+
+#[test]
+fn ts_binary_temporal_test_uses_temporal_prefix() {
+    let files = generate_ts_from(r#"
+        sig S { x: one S }
+        fact WaitUntilDone { (all s: S | s.x = s.x) until (all s: S | s.x = s.x) }
+    "#);
+    let content = find_file(&files, "tests.ts");
+    // TS should generate `it('temporal WaitUntilDone', ...)` not `it('invariant WaitUntilDone', ...)`
+    assert!(content.contains("it('temporal WaitUntilDone'"), "missing temporal binary test with correct name:\n{content}");
+    assert!(
+        content.contains("binary temporal: requires trace-based verification; see check_until_"),
+        "binary temporal should reference trace checker:\n{content}"
     );
 }
 


### PR DESCRIPTION
## Summary

- **differ.rs**: Accept space-separated temporal test names for TS/Kotlin backends (`invariant FlagName` was not matched by check which searched for `invariant_FlagName`)
- **All 6 backends**: Liveness/past_liveness static tests now generate stubs referencing trace checkers instead of asserting body inline (liveness properties cannot be verified with a single snapshot)
- **Tests**: 8 new tests covering space-separated name matching and trace checker reference verification

## Test plan

- [x] `cargo test` — all tests pass (including 8 new tests), zero warnings
- [x] Verify generated TS/Kotlin output for temporal constraints no longer triggers `MISSING_TEMPORAL_TEST` in check
- [x] Verify liveness test stubs reference trace checker functions correctly

https://claude.ai/code/session_01WZuqASfWk1kXmGbC41nXV3