### PR TITLE
fix: recursive temporal operator classification for nested quantifiers

### DIFF
--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -150,18 +150,82 @@ pub enum TemporalKind {
     Binary,
 }
 
-/// Classify the outermost temporal operator of an expression.
-/// Returns `None` if the expression is not temporal.
-pub fn expr_temporal_kind(expr: &Expr) -> Option<TemporalKind> {
+/// Priority of temporal kind for determining test type.
+/// Higher priority kinds require trace-based verification and override lower ones.
+fn temporal_priority(kind: TemporalKind) -> u8 {
+    match kind {
+        TemporalKind::Binary => 3,
+        TemporalKind::Liveness | TemporalKind::PastLiveness => 2,
+        TemporalKind::Step => 1,
+        TemporalKind::Invariant | TemporalKind::PastInvariant => 0,
+    }
+}
+
+/// Map a temporal unary operator to its TemporalKind.
+fn unary_op_to_kind(op: &TemporalUnaryOp) -> TemporalKind {
+    match op {
+        TemporalUnaryOp::Always => TemporalKind::Invariant,
+        TemporalUnaryOp::Eventually => TemporalKind::Liveness,
+        TemporalUnaryOp::Historically => TemporalKind::PastInvariant,
+        TemporalUnaryOp::Once => TemporalKind::PastLiveness,
+        TemporalUnaryOp::After | TemporalUnaryOp::Before => TemporalKind::Step,
+    }
+}
+
+/// Recursively scan an expression tree for the highest-priority temporal operator.
+/// Walks through quantifiers, logical connectives, and temporal wrappers.
+fn scan_temporal_kind(expr: &Expr) -> Option<TemporalKind> {
     match expr {
-        Expr::TemporalUnary { op, .. } => Some(match op {
-            TemporalUnaryOp::Always => TemporalKind::Invariant,
-            TemporalUnaryOp::Eventually => TemporalKind::Liveness,
-            TemporalUnaryOp::Historically => TemporalKind::PastInvariant,
-            TemporalUnaryOp::Once => TemporalKind::PastLiveness,
-            TemporalUnaryOp::After | TemporalUnaryOp::Before => TemporalKind::Step,
-        }),
         Expr::TemporalBinary { .. } => Some(TemporalKind::Binary),
+        Expr::TemporalUnary { op, expr: inner } => {
+            let this_kind = unary_op_to_kind(op);
+            let nested = scan_temporal_kind(inner);
+            match nested {
+                Some(n) if temporal_priority(n) > temporal_priority(this_kind) => Some(n),
+                _ => Some(this_kind),
+            }
+        }
+        Expr::Quantifier { body, .. } => scan_temporal_kind(body),
+        Expr::BinaryLogic { left, right, .. } => {
+            merge_temporal_kinds(scan_temporal_kind(left), scan_temporal_kind(right))
+        }
+        Expr::Not(inner) => scan_temporal_kind(inner),
+        Expr::MultFormula { expr: inner, .. } => scan_temporal_kind(inner),
+        _ => None,
+    }
+}
+
+/// Merge two optional temporal kinds, returning the higher-priority one.
+fn merge_temporal_kinds(a: Option<TemporalKind>, b: Option<TemporalKind>) -> Option<TemporalKind> {
+    match (a, b) {
+        (Some(ak), Some(bk)) => {
+            if temporal_priority(ak) >= temporal_priority(bk) { Some(ak) } else { Some(bk) }
+        }
+        (Some(ak), None) => Some(ak),
+        (None, bk) => bk,
+    }
+}
+
+/// Classify the temporal operator of an expression, recursing through quantifiers
+/// and logical connectives to find nested temporal operators.
+/// Returns `None` if the expression contains no temporal operators.
+pub fn expr_temporal_kind(expr: &Expr) -> Option<TemporalKind> {
+    scan_temporal_kind(expr)
+}
+
+/// Find the first `TemporalBinary` node nested inside an expression tree,
+/// walking through quantifiers and logical connectives.
+/// Returns the operator, left, and right sub-expressions.
+pub fn find_temporal_binary(expr: &Expr) -> Option<(&TemporalBinaryOp, &Expr, &Expr)> {
+    match expr {
+        Expr::TemporalBinary { op, left, right } => Some((op, left, right)),
+        Expr::TemporalUnary { expr: inner, .. } => find_temporal_binary(inner),
+        Expr::Quantifier { body, .. } => find_temporal_binary(body),
+        Expr::BinaryLogic { left, right, .. } => {
+            find_temporal_binary(left).or_else(|| find_temporal_binary(right))
+        }
+        Expr::Not(inner) => find_temporal_binary(inner),
+        Expr::MultFormula { expr: inner, .. } => find_temporal_binary(inner),
         _ => None,
     }
 }

--- a/src/backend/go/mod.rs
+++ b/src/backend/go/mod.rs
@@ -2,7 +2,7 @@ pub mod expr_translator;
 
 use crate::backend::GeneratedFile;
 use crate::ir::nodes::*;
-use crate::parser::ast::{Expr, Multiplicity, SigMultiplicity, TemporalBinaryOp};
+use crate::parser::ast::{Multiplicity, SigMultiplicity, TemporalBinaryOp};
 use crate::analyze;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
@@ -508,7 +508,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
 
         // Binary temporal: static test cannot meaningfully assert the body
         if temporal_kind == Some(analyze::TemporalKind::Binary) {
-            let op_label = if let Expr::TemporalBinary { op, .. } = &constraint.expr {
+            let op_label = if let Some((op, _, _)) = analyze::find_temporal_binary(&constraint.expr) {
                 match op {
                     TemporalBinaryOp::Until => "until",
                     TemporalBinaryOp::Since => "since",
@@ -581,7 +581,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
                     writeln!(out).unwrap();
                 }
                 analyze::TemporalKind::Binary => {
-                    if let Expr::TemporalBinary { op, left, right } = &constraint.expr {
+                    if let Some((op, left, right)) = analyze::find_temporal_binary(&constraint.expr) {
                         let left_body = expr_translator::translate_with_ir(left, ir);
                         let right_body = expr_translator::translate_with_ir(right, ir);
                         let op_name = match op {

--- a/src/backend/jvm/java.rs
+++ b/src/backend/jvm/java.rs
@@ -2,7 +2,7 @@ use super::{JvmContext, expr_translator};
 use super::expr_translator::JvmLang;
 use crate::backend::GeneratedFile;
 use crate::ir::nodes::*;
-use crate::parser::ast::{CompareOp, Expr, Multiplicity, SigMultiplicity, TemporalBinaryOp};
+use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity, TemporalBinaryOp};
 use crate::analyze;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
@@ -575,7 +575,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
 
         // Binary temporal: static test cannot meaningfully assert the body
         if temporal_kind == Some(analyze::TemporalKind::Binary) {
-            let op_label = if let Expr::TemporalBinary { op, .. } = &constraint.expr {
+            let op_label = if let Some((op, _, _)) = analyze::find_temporal_binary(&constraint.expr) {
                 match op {
                     TemporalBinaryOp::Until => "Until",
                     TemporalBinaryOp::Since => "Since",
@@ -636,7 +636,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
                     writeln!(out).unwrap();
                 }
                 analyze::TemporalKind::Binary => {
-                    if let Expr::TemporalBinary { op, left, right } = &constraint.expr {
+                    if let Some((op, left, right)) = analyze::find_temporal_binary(&constraint.expr) {
                         let left_body = expr_translator::translate_with_ir(left, ir, &lang);
                         let right_body = expr_translator::translate_with_ir(right, ir, &lang);
                         let op_name = match op {

--- a/src/backend/jvm/kotlin.rs
+++ b/src/backend/jvm/kotlin.rs
@@ -2,7 +2,7 @@ use super::{JvmContext, expr_translator};
 use super::expr_translator::JvmLang;
 use crate::backend::GeneratedFile;
 use crate::ir::nodes::*;
-use crate::parser::ast::{CompareOp, Expr, Multiplicity, SigMultiplicity, TemporalBinaryOp};
+use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity, TemporalBinaryOp};
 use crate::analyze;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
@@ -543,7 +543,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
 
         // Binary temporal: static test cannot meaningfully assert the body
         if temporal_kind == Some(analyze::TemporalKind::Binary) {
-            let op_label = if let Expr::TemporalBinary { op, .. } = &constraint.expr {
+            let op_label = if let Some((op, _, _)) = analyze::find_temporal_binary(&constraint.expr) {
                 match op {
                     TemporalBinaryOp::Until => "Until",
                     TemporalBinaryOp::Since => "Since",
@@ -600,7 +600,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
                     writeln!(out).unwrap();
                 }
                 analyze::TemporalKind::Binary => {
-                    if let Expr::TemporalBinary { op, left, right } = &constraint.expr {
+                    if let Some((op, left, right)) = analyze::find_temporal_binary(&constraint.expr) {
                         let left_body = expr_translator::translate_with_ir(left, ir, &lang);
                         let right_body = expr_translator::translate_with_ir(right, ir, &lang);
                         let op_name = match op {

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -635,7 +635,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
         // Binary temporal: static test cannot meaningfully assert the body
         // (e.g. `p until q` requires a trace, not a snapshot)
         if temporal_kind == Some(analyze::TemporalKind::Binary) {
-            let op_label = if let Expr::TemporalBinary { op, .. } = &constraint.expr {
+            let op_label = if let Some((op, _, _)) = analyze::find_temporal_binary(&constraint.expr) {
                 match op {
                     TemporalBinaryOp::Until => "until",
                     TemporalBinaryOp::Since => "since",
@@ -736,7 +736,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
                 }
                 analyze::TemporalKind::Binary => {
                     // Extract left/right sub-expressions for until/since
-                    if let Expr::TemporalBinary { op, left, right } = &constraint.expr {
+                    if let Some((op, left, right)) = analyze::find_temporal_binary(&constraint.expr) {
                         let left_body = expr_translator::translate_with_ir(left, ir);
                         let right_body = expr_translator::translate_with_ir(right, ir);
                         let op_name = match op {

--- a/src/backend/swift/mod.rs
+++ b/src/backend/swift/mod.rs
@@ -2,7 +2,7 @@ pub mod expr_translator;
 
 use crate::backend::GeneratedFile;
 use crate::ir::nodes::*;
-use crate::parser::ast::{Expr, Multiplicity, SigMultiplicity, TemporalBinaryOp};
+use crate::parser::ast::{Multiplicity, SigMultiplicity, TemporalBinaryOp};
 use crate::analyze;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
@@ -481,7 +481,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
 
         // Binary temporal: static test cannot meaningfully assert the body
         if temporal_kind == Some(analyze::TemporalKind::Binary) {
-            let op_label = if let Expr::TemporalBinary { op, .. } = &constraint.expr {
+            let op_label = if let Some((op, _, _)) = analyze::find_temporal_binary(&constraint.expr) {
                 match op {
                     TemporalBinaryOp::Until => "until",
                     TemporalBinaryOp::Since => "since",
@@ -541,7 +541,7 @@ fn generate_tests(ir: &OxidtrIR) -> String {
                     writeln!(out).unwrap();
                 }
                 analyze::TemporalKind::Binary => {
-                    if let Expr::TemporalBinary { op, left, right } = &constraint.expr {
+                    if let Some((op, left, right)) = analyze::find_temporal_binary(&constraint.expr) {
                         let left_body = expr_translator::translate_with_ir(left, ir);
                         let right_body = expr_translator::translate_with_ir(right, ir);
                         let op_name = match op {

--- a/src/backend/typescript/mod.rs
+++ b/src/backend/typescript/mod.rs
@@ -2,7 +2,7 @@ pub mod expr_translator;
 
 use super::GeneratedFile;
 use crate::ir::nodes::*;
-use crate::parser::ast::{CompareOp, Expr, Multiplicity, SigMultiplicity, TemporalBinaryOp};
+use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity, TemporalBinaryOp};
 use crate::analyze;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
@@ -521,7 +521,7 @@ fn generate_tests(ir: &OxidtrIR, test_runner: TsTestRunner) -> String {
 
         // Binary temporal: static test cannot meaningfully assert the body
         if temporal_kind == Some(analyze::TemporalKind::Binary) {
-            let op_label = if let Expr::TemporalBinary { op, .. } = &constraint.expr {
+            let op_label = if let Some((op, _, _)) = analyze::find_temporal_binary(&constraint.expr) {
                 match op {
                     TemporalBinaryOp::Until => "until",
                     TemporalBinaryOp::Since => "since",
@@ -606,7 +606,7 @@ fn generate_tests(ir: &OxidtrIR, test_runner: TsTestRunner) -> String {
                     writeln!(out).unwrap();
                 }
                 analyze::TemporalKind::Binary => {
-                    if let Expr::TemporalBinary { op, left, right } = &constraint.expr {
+                    if let Some((op, left, right)) = analyze::find_temporal_binary(&constraint.expr) {
                         let left_body = expr_translator::translate_with_ir(left, ir);
                         let right_body = expr_translator::translate_with_ir(right, ir);
                         let op_name = match op {

--- a/tests/analyze.rs
+++ b/tests/analyze.rs
@@ -837,3 +837,48 @@ fn temporal_kind_non_temporal_is_none() {
     let kind = analyze::expr_temporal_kind(&ir_data.constraints[0].expr);
     assert_eq!(kind, None);
 }
+
+#[test]
+fn temporal_kind_nested_until_in_quantifier_is_binary() {
+    use oxidtr::analyze::TemporalKind;
+    let model = parser::parse(
+        "sig S { active: one S }\nfact WaitUntil { all s: S | s.active = s.active until s.active = s.active }"
+    ).unwrap();
+    let ir_data = ir::lower(&model).unwrap();
+    let kind = analyze::expr_temporal_kind(&ir_data.constraints[0].expr);
+    assert_eq!(kind, Some(TemporalKind::Binary), "until nested inside quantifier should be classified as Binary");
+}
+
+#[test]
+fn temporal_kind_nested_since_in_quantifier_is_binary() {
+    use oxidtr::analyze::TemporalKind;
+    let model = parser::parse(
+        "sig S { active: one S }\nfact SinceActive { all s: S | s.active = s.active since s.active = s.active }"
+    ).unwrap();
+    let ir_data = ir::lower(&model).unwrap();
+    let kind = analyze::expr_temporal_kind(&ir_data.constraints[0].expr);
+    assert_eq!(kind, Some(TemporalKind::Binary), "since nested inside quantifier should be classified as Binary");
+}
+
+#[test]
+fn temporal_kind_always_implies_eventually_is_liveness() {
+    use oxidtr::analyze::TemporalKind;
+    let model = parser::parse(
+        "sig S { active: one S }\nfact Responsive { always (all s: S | s.active = s.active implies eventually s.active = s.active) }"
+    ).unwrap();
+    let ir_data = ir::lower(&model).unwrap();
+    let kind = analyze::expr_temporal_kind(&ir_data.constraints[0].expr);
+    assert_eq!(kind, Some(TemporalKind::Liveness), "always-implies-eventually should be classified as Liveness, not Invariant");
+}
+
+#[test]
+fn find_temporal_binary_nested_in_quantifier() {
+    let model = parser::parse(
+        "sig S { active: one S }\nfact WaitUntil { all s: S | s.active = s.active until s.active = s.active }"
+    ).unwrap();
+    let ir_data = ir::lower(&model).unwrap();
+    let found = analyze::find_temporal_binary(&ir_data.constraints[0].expr);
+    assert!(found.is_some(), "find_temporal_binary should find until inside quantifier");
+    let (op, _, _) = found.unwrap();
+    assert_eq!(*op, oxidtr::parser::ast::TemporalBinaryOp::Until);
+}


### PR DESCRIPTION
## Summary

- **① ネストした時相演算子の分類不足を修正**: `expr_temporal_kind` を再帰的にクォンティファイア・論理結合子・時相ラッパーを走査するように書き換え。`all s: S | A until B` が `None`（invariant扱い）になる問題を解消し、正しく `Binary` に分類。
- **② `until`/`since` のテスト内容の意味的誤りを修正**: 全6バックエンドで `find_temporal_binary()` を使用してネストされた二項時相演算子を正しく抽出。op_labelとtrace checker生成が量化子内でも動作。
- **③ `eventually` の liveness 近似の不正確さを修正**: `always (P implies eventually Q)` パターンがネスト走査により `Liveness` に正しく分類され、静的アサーションではなくtrace checkerへの参照+スタブテストが生成される。

## Test plan

- [x] `temporal_kind_nested_until_in_quantifier_is_binary` — 量化子内の `until` が `Binary` に分類
- [x] `temporal_kind_nested_since_in_quantifier_is_binary` — 量化子内の `since` が `Binary` に分類
- [x] `temporal_kind_always_implies_eventually_is_liveness` — `always-implies-eventually` が `Liveness` に分類
- [x] `find_temporal_binary_nested_in_quantifier` — ネストされた `TemporalBinary` の抽出
- [x] 全既存テスト通過・warning ゼロ

https://claude.ai/code/session_01R4ELctEj6tAHsKc1poioD9