### PR TITLE
fix: trace checker variable scope — explicit quantifier binding

### DIFF
--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -230,6 +230,22 @@ pub fn find_temporal_binary(expr: &Expr) -> Option<(&TemporalBinaryOp, &Expr, &E
     }
 }
 
+/// Strip the outermost temporal unary wrapper and universal quantifier from an expression.
+/// Returns `(quantifier_kind, bindings, inner_body)` if the expression has the pattern
+/// `TemporalUnary(_, Quantifier(kind, bindings, body))` or just `Quantifier(kind, bindings, body)`.
+/// Used by trace checker generation to avoid relying on naming coincidence between
+/// trace parameters and quantifier domain names.
+pub fn strip_outer_quantifier(expr: &Expr) -> Option<(&QuantKind, &[QuantBinding], &Expr)> {
+    let inner = match expr {
+        Expr::TemporalUnary { expr, .. } => expr.as_ref(),
+        _ => expr,
+    };
+    match inner {
+        Expr::Quantifier { kind, bindings, body } => Some((kind, bindings, body)),
+        _ => None,
+    }
+}
+
 /// Analyze all constraints in the IR and return structured info.
 pub fn analyze(ir: &OxidtrIR) -> Vec<ConstraintInfo> {
     let mut results = Vec::new();

--- a/src/backend/typescript/expr_translator.rs
+++ b/src/backend/typescript/expr_translator.rs
@@ -8,6 +8,24 @@ pub fn translate_with_ir(expr: &Expr, ir: &OxidtrIR) -> String {
     translate_inner(expr, false, &sig_names, ir)
 }
 
+/// Translate a temporal constraint expression for trace checker bodies.
+/// Strips the temporal unary wrapper and translates the outermost quantifier
+/// without spreading the domain (trace elements are already arrays).
+pub fn translate_trace_body(expr: &Expr, ir: &OxidtrIR) -> String {
+    let sig_names = collect_sig_names(ir);
+    let inner = match expr {
+        Expr::TemporalUnary { expr, .. } => expr.as_ref(),
+        _ => expr,
+    };
+    match inner {
+        Expr::Quantifier { kind, bindings, body } => {
+            let body_str = translate_inner(body, false, &sig_names, ir);
+            build_trace_quantifier_ts(kind, bindings, &body_str, &sig_names, ir)
+        }
+        _ => translate_inner(inner, false, &sig_names, ir),
+    }
+}
+
 /// Extract the collection parameters needed by an expression.
 pub fn extract_params(expr: &Expr, sig_names: &HashSet<String>) -> Vec<(String, String)> {
     let mut params = BTreeSet::new();
@@ -285,6 +303,29 @@ fn build_nested_quantifier_ts(
     sig_names: &HashSet<String>,
     ir: &OxidtrIR,
 ) -> String {
+    build_quantifier_ts_common(kind, bindings, body_str, sig_names, ir, true)
+}
+
+/// Build quantifier iteration for trace checker bodies.
+/// Uses direct domain access (no spread) since trace elements are already arrays.
+fn build_trace_quantifier_ts(
+    kind: &QuantKind,
+    bindings: &[QuantBinding],
+    body_str: &str,
+    sig_names: &HashSet<String>,
+    ir: &OxidtrIR,
+) -> String {
+    build_quantifier_ts_common(kind, bindings, body_str, sig_names, ir, false)
+}
+
+fn build_quantifier_ts_common(
+    kind: &QuantKind,
+    bindings: &[QuantBinding],
+    body_str: &str,
+    sig_names: &HashSet<String>,
+    ir: &OxidtrIR,
+    spread_domain: bool,
+) -> String {
     // Collect all (var, domain_str, is_disj) expanding multi-var bindings
     let mut vars: Vec<(String, String, bool)> = Vec::new();
     for b in bindings {
@@ -326,19 +367,20 @@ fn build_nested_quantifier_ts(
     };
 
     // Build from inside-out.
-    // Wrap domain in [...domain] to handle both Set and Array uniformly.
+    // When spread_domain is true, wrap in [...domain] to handle both Set and Array.
+    // When false (trace mode), use domain directly since trace elements are arrays.
     let mut result = guarded_body;
     for idx in (0..vars.len()).rev() {
         let (ref var, ref domain, _) = vars[idx];
-        let arr = format!("[...{domain}]");
+        let arr = if spread_domain { format!("[...{domain}]") } else { domain.clone() };
         result = match kind {
-            QuantKind::All => format!("{arr}.every(({var}) => {result})"),
-            QuantKind::Some => format!("{arr}.some(({var}) => {result})"),
+            QuantKind::All => format!("{arr}.every({var} => {result})"),
+            QuantKind::Some => format!("{arr}.some({var} => {result})"),
             QuantKind::No => {
                 if idx == 0 {
-                    format!("!{arr}.some(({var}) => {result})")
+                    format!("!{arr}.some({var} => {result})")
                 } else {
-                    format!("{arr}.some(({var}) => {result})")
+                    format!("{arr}.some({var} => {result})")
                 }
             }
         };

--- a/src/backend/typescript/mod.rs
+++ b/src/backend/typescript/mod.rs
@@ -589,26 +589,25 @@ fn generate_tests(ir: &OxidtrIR, test_runner: TsTestRunner) -> String {
                     } else {
                         "property held in at least one past state"
                     };
+                    let trace_body = expr_translator::translate_trace_body(&constraint.expr, ir);
                     writeln!(out, "  /** Trace checker for {kind_label}: {semantics}. */").unwrap();
                     if params.len() == 1 {
                         let (pname, tname) = &params[0];
                         writeln!(out, "  function check_{kind_label}_{camel_name}(trace: M.{tname}[][]): boolean {{").unwrap();
-                        writeln!(out, "    return trace.some(({pname}) => {{").unwrap();
+                        writeln!(out, "    return trace.some({pname} => {trace_body});").unwrap();
                     } else {
                         let tuple_types: Vec<_> = params.iter().map(|(_, t)| format!("M.{t}[]")).collect();
                         let tuple_names: Vec<_> = params.iter().map(|(p, _)| p.as_str()).collect();
                         writeln!(out, "  function check_{kind_label}_{camel_name}(trace: [{}][]): boolean {{", tuple_types.join(", ")).unwrap();
-                        writeln!(out, "    return trace.some(([{}]) => {{", tuple_names.join(", ")).unwrap();
+                        writeln!(out, "    return trace.some(([{}]) => {trace_body});", tuple_names.join(", ")).unwrap();
                     }
-                    writeln!(out, "      return {body};").unwrap();
-                    writeln!(out, "    }});").unwrap();
                     writeln!(out, "  }}").unwrap();
                     writeln!(out).unwrap();
                 }
                 analyze::TemporalKind::Binary => {
                     if let Some((op, left, right)) = analyze::find_temporal_binary(&constraint.expr) {
-                        let left_body = expr_translator::translate_with_ir(left, ir);
-                        let right_body = expr_translator::translate_with_ir(right, ir);
+                        let left_body = expr_translator::translate_trace_body(left, ir);
+                        let right_body = expr_translator::translate_trace_body(right, ir);
                         let op_name = match op {
                             TemporalBinaryOp::Until => "until",
                             TemporalBinaryOp::Since => "since",

--- a/tests/test_generation.rs
+++ b/tests/test_generation.rs
@@ -257,6 +257,59 @@ fn ts_binary_temporal_test_uses_temporal_prefix() {
     );
 }
 
+// ── ④d Trace checker variable scope: quantifier vars properly bound ─────────
+
+#[test]
+fn ts_trace_checker_binds_quantifier_variable_explicitly() {
+    let files = generate_ts_from(r#"
+        sig State { x: one Int }
+        fact WillConverge { eventually all s: State | s.x > 10 }
+    "#);
+    let content = find_file(&files, "tests.ts");
+    // Trace checker should use direct iteration without spread
+    assert!(
+        content.contains("states.every(s =>") || content.contains("states.every((s) =>"),
+        "trace checker should iterate with quantifier variable bound to trace element:\n{content}"
+    );
+    // Should NOT have [...states] spread — trace elements are already arrays
+    assert!(
+        !content.contains("[...states]"),
+        "trace checker should not spread trace elements (already arrays):\n{content}"
+    );
+}
+
+#[test]
+fn rust_trace_checker_binds_quantifier_variable_explicitly() {
+    let files = generate_from(r#"
+        sig Counter { value: one Int }
+        fact WillConverge { eventually all c: Counter | c.value > 0 }
+    "#);
+    let content = find_file(&files, "tests.rs");
+    // Should use counters.iter().all(|c| ...) directly, not nested quantifier expansion
+    assert!(
+        content.contains("counters.iter().all(|c|"),
+        "trace checker should iterate trace element with quantifier variable:\n{content}"
+    );
+}
+
+#[test]
+fn ts_binary_trace_checker_binds_quantifier_variable() {
+    let files = generate_ts_from(r#"
+        sig S { x: one Int }
+        fact WaitDone { (all s: S | s.x > 0) until (all s: S | s.x > 10) }
+    "#);
+    let content = find_file(&files, "tests.ts");
+    // Binary temporal trace checker should iterate with quantifier variable
+    assert!(
+        content.contains("ss.every(s =>") || content.contains("ss.every((s) =>"),
+        "binary trace checker should bind quantifier variable via iteration:\n{content}"
+    );
+    assert!(
+        !content.contains("[...ss]"),
+        "binary trace checker should not spread trace elements:\n{content}"
+    );
+}
+
 // ── ③ Integer arithmetic translation ────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- TS trace checkers now strip the outermost temporal + quantifier and generate explicit iteration (`states.every(s => s.x > 10)`) instead of relying on naming coincidence with the full quantifier expansion (`[...states].every((s) => s.x > 10)`)
- Removes unnecessary `[...]` spread on trace elements (already arrays, not Sets)
- Adds `strip_outer_quantifier` utility and `translate_trace_body` for trace-aware translation

## Test plan

- [x] 3 new tests: `ts_trace_checker_binds_quantifier_variable_explicitly`, `rust_trace_checker_binds_quantifier_variable_explicitly`, `ts_binary_trace_checker_binds_quantifier_variable`
- [x] Full `cargo test` passes (0 failures, 0 warnings)
- [x] Self-hosting round-trip tests pass

https://claude.ai/code/session_01Qumm34vGz22RfBV2YGPTve