### PR TITLE
fix: unit struct parsing in impl_parser no longer consumes following structs

### DIFF
--- a/src/check/impl_parser.rs
+++ b/src/check/impl_parser.rs
@@ -48,7 +48,14 @@ fn parse_structs(src: &str) -> Vec<ExtractedStruct> {
             continue;
         }
         if let Some(name) = parse_type_decl(trimmed, "pub struct ") {
-            let fields = collect_fields(&mut lines);
+            // Unit struct (`pub struct Foo;`) has no brace block.
+            // Calling collect_fields on a unit struct would set depth=1 and
+            // consume all subsequent lines until the next `}` — eating other structs.
+            let fields = if trimmed.ends_with(';') {
+                vec![]
+            } else {
+                collect_fields(&mut lines)
+            };
             result.push(ExtractedStruct { name, fields, is_enum: false, is_var: pending_var_sig });
             pending_var_sig = false;
             continue;

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -641,6 +641,80 @@ fn missing_assert_detected() {
     )), "should detect missing assert test: {diffs:?}");
 }
 
+/// Regression test: unit struct (e.g. `pub struct Foo;`) must be parsed correctly
+/// and must NOT consume subsequent struct definitions.
+/// Previously, `parse_structs` called `collect_fields` even for unit structs,
+/// which caused the depth counter to never reset and ate all following lines.
+#[test]
+fn parse_impl_unit_struct_does_not_consume_following_structs() {
+    let models_src = r#"
+pub struct Tag;
+
+pub struct Node {
+    pub tag: Tag,
+}
+
+pub struct Edge {
+    pub source: Node,
+    pub target: Node,
+}
+"#;
+    let result = impl_parser::parse_impl(models_src, "");
+    let names: Vec<&str> = result.structs.iter().map(|s| s.name.as_str()).collect();
+    assert!(names.contains(&"Tag"),  "Tag should be parsed as unit struct; got: {names:?}");
+    assert!(names.contains(&"Node"), "Node should be parsed; got: {names:?}");
+    assert!(names.contains(&"Edge"), "Edge should be parsed; got: {names:?}");
+    assert_eq!(result.structs.len(), 3, "exactly 3 structs; got: {names:?}");
+
+    let node = result.structs.iter().find(|s| s.name == "Node").unwrap();
+    assert_eq!(node.fields.len(), 1, "Node should have 1 field; got: {:?}", node.fields);
+    assert_eq!(node.fields[0].name, "tag");
+
+    let edge = result.structs.iter().find(|s| s.name == "Edge").unwrap();
+    assert_eq!(edge.fields.len(), 2, "Edge should have 2 fields; got: {:?}", edge.fields);
+}
+
+/// Unit struct followed immediately by another unit struct — both must be captured.
+#[test]
+fn parse_impl_consecutive_unit_structs() {
+    let models_src = r#"
+pub struct Alpha;
+pub struct Beta;
+pub struct Gamma;
+"#;
+    let result = impl_parser::parse_impl(models_src, "");
+    let names: Vec<&str> = result.structs.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(result.structs.len(), 3, "3 unit structs; got: {names:?}");
+    assert!(names.contains(&"Alpha"));
+    assert!(names.contains(&"Beta"));
+    assert!(names.contains(&"Gamma"));
+}
+
+/// Unit struct mixed with enums and regular structs — none should eat another.
+#[test]
+fn parse_impl_unit_struct_mixed_with_enum_and_struct() {
+    let models_src = r#"
+pub enum Color {
+    Red,
+    Blue,
+}
+
+pub struct Token;
+
+pub struct Edge {
+    pub weight: Token,
+}
+"#;
+    let result = impl_parser::parse_impl(models_src, "");
+    let names: Vec<&str> = result.structs.iter().map(|s| s.name.as_str()).collect();
+    // Color (enum) + Red + Blue (variants) + Token (unit) + Edge = 5 entries
+    assert!(names.contains(&"Token"), "Token unit struct; got: {names:?}");
+    assert!(names.contains(&"Edge"),  "Edge struct; got: {names:?}");
+    assert!(names.contains(&"Color"), "Color enum; got: {names:?}");
+    let edge = result.structs.iter().find(|s| s.name == "Edge").unwrap();
+    assert_eq!(edge.fields.len(), 1, "Edge has 1 field; got: {:?}", edge.fields);
+}
+
 #[test]
 fn present_assert_not_flagged() {
     use oxidtr::ir::nodes::PropertyNode;


### PR DESCRIPTION
## Summary

- `parse_structs` previously called `collect_fields` unconditionally for unit structs (`pub struct Foo;`), which set depth=1 and consumed all subsequent lines until a closing `}` — eating other struct definitions.
- Now detects the trailing `;` of unit structs and skips brace-block collection entirely.
- Added 3 regression tests covering: unit struct followed by regular structs, consecutive unit structs, and unit structs mixed with enums.

## Test plan

- [x] `cargo test` — all tests pass, zero warnings
- [x] CI passes on all checks

https://claude.ai/code/session_01GBi1hPEV3wUoDrjFVud9sX