### PR TITLE
fix: Rust backend bug fixes — unit struct fixtures, lone field, enum qualification

### DIFF
--- a/src/backend/rust/expr_translator.rs
+++ b/src/backend/rust/expr_translator.rs
@@ -470,7 +470,19 @@ fn translate_inner_ir(
     let result = match expr {
         Expr::IntLiteral(n) => n.to_string(),
 
-        Expr::VarRef(name) => name.clone(),
+        Expr::VarRef(name) => {
+            // Bug 3 fix: enum variants (one sig Foo extends Bar) must be qualified
+            // as `Bar::Foo` in Rust. Detect by checking whether the name has a parent
+            // sig that is itself an enum (abstract sig … {}).
+            if let Some(s) = ir.structures.iter().find(|s| s.name == *name) {
+                if let Some(parent) = &s.parent {
+                    if ir.structures.iter().any(|p| p.name == *parent && p.is_enum) {
+                        return format!("{parent}::{name}");
+                    }
+                }
+            }
+            name.clone()
+        }
 
         Expr::FieldAccess { base, field } => {
             let base_str = ti(base, false);
@@ -505,16 +517,27 @@ fn translate_inner_ir(
                 CompareOp::Lte => format!("{} <= {}", ti(left, false), ti(right, false)),
                 CompareOp::Gte => format!("{} >= {}", ti(left, false), ti(right, false)),
                 CompareOp::In => {
+                    // Bug 2 fix: if the LEFT side is a `lone` field (Option<T>),
+                    // `set.contains(&Option<T>)` is a type error.
+                    // Generate: `base.field.as_ref().map_or(true, |s| set.contains(s))`
+                    // (lone = 0 or 1; None satisfies "activeState in states" vacuously)
+                    if let Expr::FieldAccess { base: l_base, field: l_field } = left.as_ref() {
+                        if let Some((Multiplicity::Lone, _)) = field_mult(l_field, ir) {
+                            let base_str = ti(l_base, false);
+                            let r = ti(right, false);
+                            return format!(
+                                "{base_str}.{l_field}.as_ref().map_or(true, |s| {r}.contains(s))"
+                            );
+                        }
+                    }
                     let l = ti(left, false);
-                    // Check if right side is a field access to a lone field
+                    // Check if RIGHT side is a field access to a lone field
                     if let Expr::FieldAccess { base, field } = right.as_ref() {
                         let r_base = ti(base, false);
                         if let Some((Multiplicity::Lone, is_self_ref)) = field_mult(field, ir) {
                             return if is_self_ref {
-                                // Option<Box<T>> — use as_deref()
                                 format!("{r_base}.{field}.as_deref() == Some(&{l})")
                             } else {
-                                // Option<T> — use as_ref()
                                 format!("{r_base}.{field}.as_ref() == Some(&{l})")
                             };
                         }

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -1453,9 +1453,17 @@ fn generate_fixtures(ir: &OxidtrIR) -> String {
 
     for s in &ir.structures {
         if variant_names.contains(&s.name) || s.is_enum { continue; }
-        if s.fields.is_empty() { continue; }
 
         let struct_snake = to_snake_case(&s.name);
+
+        // Unit struct (no fields): generate a trivial factory.
+        if s.fields.is_empty() {
+            writeln!(out, "/// Factory: default value for unit struct {}", s.name).unwrap();
+            writeln!(out, "#[allow(dead_code)]").unwrap();
+            writeln!(out, "pub fn default_{}() -> {} {{ {} }}", struct_snake, s.name, s.name).unwrap();
+            writeln!(out).unwrap();
+            continue;
+        }
 
         writeln!(out, "/// Factory: create a default valid {}", s.name).unwrap();
         writeln!(out, "#[allow(dead_code)]").unwrap();

--- a/tests/backend_rust.rs
+++ b/tests/backend_rust.rs
@@ -526,3 +526,78 @@ fn rust_try_from_generates_disjoint_check() {
     assert!(newtypes.contains("must not overlap"),
         "TryFrom should check disjoint constraint:\n{newtypes}");
 }
+
+// ── Bug fixes ────────────────────────────────────────────────────────────────
+
+/// Bug: unit struct (no fields) was skipped in fixture generation — no default_foo() produced.
+/// A unit struct in Alloy is a sig with no fields. The fixture should produce
+/// `pub fn default_foo() -> Foo { Foo }`.
+#[test]
+fn rust_unit_struct_fixture_generated() {
+    let files = generate_from(r#"
+        sig Tag {}
+        sig Node { tag: one Tag }
+    "#);
+    let fixtures = find_file(&files, "fixtures.rs");
+    assert!(fixtures.contains("pub fn default_tag() -> Tag"),
+        "fixtures.rs should contain default_tag():\n{fixtures}");
+    assert!(fixtures.contains("Tag"),
+        "default_tag() body should return Tag:\n{fixtures}");
+}
+
+/// Multiple unit structs should all get factory functions.
+#[test]
+fn rust_multiple_unit_structs_all_get_fixtures() {
+    let files = generate_from(r#"
+        sig Alpha {}
+        sig Beta {}
+        sig Gamma {}
+        sig Container { a: one Alpha, b: one Beta, c: one Gamma }
+    "#);
+    let fixtures = find_file(&files, "fixtures.rs");
+    for name in &["alpha", "beta", "gamma"] {
+        assert!(fixtures.contains(&format!("pub fn default_{name}() -> ")),
+            "fixtures.rs should contain default_{name}():\n{fixtures}");
+    }
+}
+
+/// Bug: newtypes validator for a `lone` (Option) field used `contains(&field)`
+/// where field is `Option<T>`, causing a type mismatch.
+/// The generated validator should unwrap the Option before calling contains.
+#[test]
+fn rust_newtypes_lone_field_option_unwrapped_in_validator() {
+    let files = generate_from(r#"
+        sig SM { states: set State, activeState: lone State }
+        sig State {}
+        fact ActiveOwned { all sm: SM | sm.activeState in sm.states }
+    "#);
+    let newtypes = find_file(&files, "newtypes.rs");
+    // Must NOT contain the broken pattern `contains(&sm.active_state)` where active_state: Option
+    assert!(!newtypes.contains("contains(&value.activeState)"),
+        "validator must not pass Option<T> directly to contains:\n{newtypes}");
+    // Must contain the correct pattern: unwrap Option before contains check
+    assert!(
+        newtypes.contains("as_ref()") || newtypes.contains("map(") || newtypes.contains("unwrap_or"),
+        "validator must handle Option with as_ref/map/unwrap_or:\n{newtypes}");
+}
+
+/// Bug: newtypes validator for enum comparison used unqualified variant names
+/// (e.g. `PortKindOutput`) instead of `PortKind::PortKindOutput`.
+#[test]
+fn rust_newtypes_enum_variant_fully_qualified_in_validator() {
+    let files = generate_from(r#"
+        abstract sig PortKind {}
+        one sig PortKindInput  extends PortKind {}
+        one sig PortKindOutput extends PortKind {}
+        sig Port { portKind: one PortKind }
+        sig Conn { src: one Port, tgt: one Port }
+        fact ConnDir { all c: Conn | c.src.portKind = PortKindOutput and c.tgt.portKind = PortKindInput }
+    "#);
+    let newtypes = find_file(&files, "newtypes.rs");
+    // Variants must be qualified as PortKind::PortKindOutput, not bare PortKindOutput
+    assert!(!newtypes.contains("== PortKindOutput"),
+        "unqualified PortKindOutput found in validator:\n{newtypes}");
+    assert!(!newtypes.contains("== PortKindInput"),
+        "unqualified PortKindInput found in validator:\n{newtypes}");
+}
+


### PR DESCRIPTION
## Summary

- **Bug 1 (unit struct fixtures)**: `generate_fixtures` skipped sigs with no fields — unit structs now get a trivial `default_foo() -> Foo { Foo }` factory
- **Bug 2 (lone field in `in` validator)**: LHS of `in` being a `lone` (Option<T>) field caused `contains(&Option<T>)` type error — now generates `as_ref().map_or(true, |s| set.contains(s))`
- **Bug 3 (enum variant qualification)**: `VarRef` for enum variants emitted bare names (`PortKindOutput`) instead of qualified (`PortKind::PortKindOutput`) — now checks IR for parent enum and qualifies

## Test plan

- [x] 4 new tests added in `tests/backend_rust.rs`
- [x] `cargo test` — all tests pass
- [x] `cargo build` — zero warnings

https://claude.ai/code/session_01GgKTFSFGQU1tiuQv5UT6QL