### PR TITLE
feat: propagate abstract sig fields to enum variants

### DIFF
--- a/src/backend/go/mod.rs
+++ b/src/backend/go/mod.rs
@@ -206,11 +206,15 @@ fn generate_struct(out: &mut String, s: &StructureNode, ir: &OxidtrIR, ctx: &GoC
     }
 }
 
+
 fn generate_enum(out: &mut String, s: &StructureNode, ctx: &GoContext) {
     let variants = ctx.children.get(&s.name);
 
-    // Check if all variants are unit (no fields)
-    let all_unit = variants.map_or(true, |vs| {
+    // Parent abstract sig may have fields that should be inherited by all variants
+    let parent_fields = &s.fields;
+
+    // Check if all variants are unit (no fields, including inherited)
+    let all_unit = parent_fields.is_empty() && variants.map_or(true, |vs| {
         vs.iter().all(|v| ctx.struct_map.get(v).map_or(true, |st| st.fields.is_empty()))
     });
 
@@ -237,11 +241,13 @@ fn generate_enum(out: &mut String, s: &StructureNode, ctx: &GoContext) {
         if let Some(variants) = variants {
             for v in variants {
                 let child = ctx.struct_map.get(v.as_str());
-                let fields = child.map(|c| &c.fields).filter(|f| !f.is_empty());
+                let child_fields: Vec<&IRField> = child.map(|c| c.fields.iter().collect()).unwrap_or_default();
+                // Combine parent fields + child fields
+                let all_fields: Vec<&IRField> = parent_fields.iter().chain(child_fields.iter().copied()).collect();
                 writeln!(out).unwrap();
-                if let Some(fields) = fields {
+                if !all_fields.is_empty() {
                     writeln!(out, "type {} struct {{", v).unwrap();
-                    for f in fields {
+                    for f in &all_fields {
                         let type_str = if let Some(vt) = &f.value_type {
                             format!("map[{}]{}", f.target, vt)
                         } else {

--- a/src/backend/jvm/java.rs
+++ b/src/backend/jvm/java.rs
@@ -309,10 +309,14 @@ fn generate_record(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_fiel
     }
 }
 
+
 fn generate_sealed_interface(out: &mut String, s: &StructureNode, ctx: &JvmContext) {
     let variants = ctx.children.get(&s.name);
 
-    let all_unit = variants.map_or(true, |vs| {
+    // Parent abstract sig may have fields that should be inherited by all variants
+    let parent_fields = &s.fields;
+
+    let all_unit = parent_fields.is_empty() && variants.map_or(true, |vs| {
         vs.iter().all(|v| ctx.struct_map.get(v).map_or(true, |st| st.fields.is_empty()))
     });
 
@@ -337,9 +341,11 @@ fn generate_sealed_interface(out: &mut String, s: &StructureNode, ctx: &JvmConte
         if let Some(variants) = variants {
             for v in variants {
                 let child = ctx.struct_map.get(v.as_str());
-                let fields = child.map(|c| &c.fields).filter(|f| !f.is_empty());
-                if let Some(fields) = fields {
-                    let params: Vec<String> = fields.iter()
+                let child_fields: Vec<&IRField> = child.map(|c| c.fields.iter().collect()).unwrap_or_default();
+                // Combine parent fields + child fields
+                let all_fields: Vec<&IRField> = parent_fields.iter().chain(child_fields.iter().copied()).collect();
+                if !all_fields.is_empty() {
+                    let params: Vec<String> = all_fields.iter()
                         .map(|f| {
                             let t = if let Some(vt) = &f.value_type {
                                 format!("Map<{}, {}>", f.target, vt)

--- a/src/backend/jvm/kotlin.rs
+++ b/src/backend/jvm/kotlin.rs
@@ -268,11 +268,15 @@ fn generate_data_class(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_
     }
 }
 
+
 fn generate_sealed_class(out: &mut String, s: &StructureNode, ctx: &JvmContext) {
     let variants = ctx.children.get(&s.name);
 
-    // Check if all variants are unit (no fields, singleton)
-    let all_unit = variants.map_or(true, |vs| {
+    // Parent abstract sig may have fields that should be inherited by all variants
+    let parent_fields = &s.fields;
+
+    // Check if all variants are unit (no fields, including inherited, singleton)
+    let all_unit = parent_fields.is_empty() && variants.map_or(true, |vs| {
         vs.iter().all(|v| ctx.struct_map.get(v).map_or(true, |st| st.fields.is_empty()))
     });
 
@@ -291,16 +295,18 @@ fn generate_sealed_class(out: &mut String, s: &StructureNode, ctx: &JvmContext) 
         if let Some(variants) = variants {
             for v in variants {
                 let child = ctx.struct_map.get(v.as_str());
-                let fields = child.map(|c| &c.fields).filter(|f| !f.is_empty());
-                if let Some(fields) = fields {
+                let child_fields: Vec<&IRField> = child.map(|c| c.fields.iter().collect()).unwrap_or_default();
+                // Combine parent fields + child fields
+                let all_fields: Vec<&IRField> = parent_fields.iter().chain(child_fields.iter().copied()).collect();
+                if !all_fields.is_empty() {
                     writeln!(out, "data class {}(", v).unwrap();
-                    for (i, f) in fields.iter().enumerate() {
+                    for (i, f) in all_fields.iter().enumerate() {
                         let type_str = if let Some(vt) = &f.value_type {
                             format!("Map<{}, {}>", f.target, vt)
                         } else {
                             mult_to_kt_type(&f.target, &f.mult)
                         };
-                        let comma = if i < fields.len() - 1 { "," } else { "" };
+                        let comma = if i < all_fields.len() - 1 { "," } else { "" };
                         writeln!(out, "    val {}: {type_str}{comma}", f.name).unwrap();
                     }
                     writeln!(out, ") : {}()", s.name).unwrap();

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -199,10 +199,13 @@ fn generate_enum(
         .map(|st| (st.name.as_str(), st))
         .collect();
 
+    // Parent abstract sig may have fields that should be inherited by all variants
+    let parent_fields = &s.fields;
+
     if use_serde {
         writeln!(out, "#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]").unwrap();
-        // Check if any variant has fields — if so, use tagged representation
-        let has_data_variants = children.map_or(false, |vs| {
+        // Check if any variant has fields (including inherited parent fields) — if so, use tagged representation
+        let has_data_variants = !parent_fields.is_empty() || children.map_or(false, |vs| {
             vs.iter().any(|v| struct_map.get(v.as_str()).map_or(false, |st| !st.fields.is_empty()))
         });
         if has_data_variants {
@@ -215,10 +218,12 @@ fn generate_enum(
     if let Some(variants) = children {
         for v in variants {
             let child = struct_map.get(v.as_str());
-            let fields = child.map(|c| &c.fields).filter(|f| !f.is_empty());
-            if let Some(fields) = fields {
+            let child_fields: Vec<&IRField> = child.map(|c| c.fields.iter().collect()).unwrap_or_default();
+            // Combine parent fields + child fields
+            let all_fields: Vec<&IRField> = parent_fields.iter().chain(child_fields.iter().copied()).collect();
+            if !all_fields.is_empty() {
                 writeln!(out, "    {v} {{").unwrap();
-                for f in fields {
+                for f in &all_fields {
                     // Fields referencing the parent enum type need Box to break recursion
                     let needs_box = f.target == s.name;
                     let is_self_ref = needs_box

--- a/src/backend/swift/mod.rs
+++ b/src/backend/swift/mod.rs
@@ -204,11 +204,15 @@ fn generate_struct(out: &mut String, s: &StructureNode, ir: &OxidtrIR, ctx: &Swi
     }
 }
 
+
 fn generate_enum(out: &mut String, s: &StructureNode, ctx: &SwiftContext) {
     let variants = ctx.children.get(&s.name);
 
-    // Check if all variants are unit (no fields)
-    let all_unit = variants.map_or(true, |vs| {
+    // Parent abstract sig may have fields that should be inherited by all variants
+    let parent_fields = &s.fields;
+
+    // Check if all variants are unit (no fields, including inherited)
+    let all_unit = parent_fields.is_empty() && variants.map_or(true, |vs| {
         vs.iter().all(|v| ctx.struct_map.get(v).map_or(true, |st| st.fields.is_empty()))
     });
 
@@ -227,9 +231,11 @@ fn generate_enum(out: &mut String, s: &StructureNode, ctx: &SwiftContext) {
         if let Some(variants) = variants {
             for v in variants {
                 let child = ctx.struct_map.get(v.as_str());
-                let fields = child.map(|c| &c.fields).filter(|f| !f.is_empty());
-                if let Some(fields) = fields {
-                    let params: Vec<String> = fields.iter().map(|f| {
+                let child_fields: Vec<&IRField> = child.map(|c| c.fields.iter().collect()).unwrap_or_default();
+                // Combine parent fields + child fields
+                let all_fields: Vec<&IRField> = parent_fields.iter().chain(child_fields.iter().copied()).collect();
+                if !all_fields.is_empty() {
+                    let params: Vec<String> = all_fields.iter().map(|f| {
                         let type_str = if let Some(vt) = &f.value_type {
                             format!("[{}: {}]", f.target, vt)
                         } else {

--- a/src/backend/typescript/mod.rs
+++ b/src/backend/typescript/mod.rs
@@ -234,8 +234,11 @@ fn generate_union_type(
         return;
     };
 
-    // Check if all variants are unit (no fields) — use string literal union
-    let all_unit = variants.iter().all(|v| {
+    // Parent abstract sig may have fields that should be inherited by all variants
+    let parent_fields = &s.fields;
+
+    // Check if all variants are unit (no fields, including inherited) — use string literal union
+    let all_unit = parent_fields.is_empty() && variants.iter().all(|v| {
         struct_map.get(v.as_str()).map_or(true, |st| st.fields.is_empty())
     });
 
@@ -249,25 +252,25 @@ fn generate_union_type(
         // Discriminated union with kind field
         for v in variants {
             let child = struct_map.get(v.as_str());
-            let fields = child.map(|c| &c.fields).filter(|f| !f.is_empty());
+            let child_fields: Vec<&IRField> = child.map(|c| c.fields.iter().collect()).unwrap_or_default();
+            // Combine parent fields + child fields
+            let all_fields: Vec<&IRField> = parent_fields.iter().chain(child_fields.iter().copied()).collect();
             writeln!(out, "export interface {} {{", v).unwrap();
             writeln!(out, "  readonly kind: \"{}\";", v).unwrap();
-            if let Some(fields) = fields {
-                for f in fields {
-                    let type_str = if let Some(vt) = &f.value_type {
-                        format!("Map<{}, {}>", f.target, vt)
-                    } else if let Some(raw) = &f.raw_union_type {
-                        if f.mult == Multiplicity::Lone {
-                            format!("{} | null", raw)
-                        } else {
-                            raw.clone()
-                        }
+            for f in &all_fields {
+                let type_str = if let Some(vt) = &f.value_type {
+                    format!("Map<{}, {}>", f.target, vt)
+                } else if let Some(raw) = &f.raw_union_type {
+                    if f.mult == Multiplicity::Lone {
+                        format!("{} | null", raw)
                     } else {
-                        mult_to_ts_type(&f.target, &f.mult)
-                    };
-                    let readonly = if f.is_var { "" } else { "readonly " };
-                    writeln!(out, "  {readonly}{}: {};", f.name, type_str).unwrap();
-                }
+                        raw.clone()
+                    }
+                } else {
+                    mult_to_ts_type(&f.target, &f.mult)
+                };
+                let readonly = if f.is_var { "" } else { "readonly " };
+                writeln!(out, "  {readonly}{}: {};", f.name, type_str).unwrap();
             }
             writeln!(out, "}}").unwrap();
             writeln!(out).unwrap();

--- a/tests/backend_rust.rs
+++ b/tests/backend_rust.rs
@@ -601,3 +601,22 @@ fn rust_newtypes_enum_variant_fully_qualified_in_validator() {
         "unqualified PortKindInput found in validator:\n{newtypes}");
 }
 
+
+#[test]
+fn abstract_sig_fields_propagated_to_enum_variants() {
+    let files = generate_from(r#"
+        sig Tick {}
+        abstract sig Event { tick: one Tick }
+        sig Started extends Event { source: one Tick }
+        sig Stopped extends Event {}
+    "#);
+    let content = find_file(&files, "models.rs");
+    // Parent field `tick` must appear in variant Started (alongside its own `source`)
+    assert!(content.contains("Started {"),
+        "Started should be a data variant:\n{content}");
+    assert!(content.contains("tick: Tick"),
+        "parent field `tick` should appear in enum variant:\n{content}");
+    // Stopped has no own fields, but inherits `tick` — must still be a data variant
+    assert!(content.contains("Stopped {"),
+        "Stopped should be a data variant (inherited field):\n{content}");
+}

--- a/tests/backend_ts.rs
+++ b/tests/backend_ts.rs
@@ -355,3 +355,22 @@ fn ts_validator_generates_disjoint_check() {
     assert!(validators.contains("must not overlap"),
         "validator should check disjoint constraint:\n{validators}");
 }
+
+#[test]
+fn ts_abstract_sig_fields_propagated_to_union_variants() {
+    let files = generate_from(r#"
+        sig Tick {}
+        abstract sig Event { tick: one Tick }
+        sig Started extends Event { source: one Tick }
+        sig Stopped extends Event {}
+    "#);
+    let models = find_file(&files, "models.ts");
+    // Parent field `tick` must appear in each variant interface
+    assert!(models.contains("export interface Started {"),
+        "Started should be a discriminated union variant:\n{models}");
+    assert!(models.contains("tick: Tick"),
+        "parent field `tick` should appear in variant:\n{models}");
+    // Stopped has no own fields, but inherits `tick` — must be interface, not string literal
+    assert!(models.contains("export interface Stopped {"),
+        "Stopped should be interface (inherited field), not string literal:\n{models}");
+}


### PR DESCRIPTION
## Summary
- Abstract signatures with fields now correctly propagate those fields to all extending variants across all 6 backends (Rust, TypeScript, Kotlin, Java, Swift, Go)
- Unit type detection (`all_unit`) accounts for inherited parent fields — variants with only inherited fields are no longer treated as unit types
- Added tests for Rust (`abstract_sig_fields_propagated_to_enum_variants`) and TypeScript (`ts_abstract_sig_fields_propagated_to_union_variants`)

## Test plan
- [x] `cargo test` — all tests pass, zero warnings
- [x] Verify generated output for models with abstract sigs that have fields (e.g. `abstract sig Event { tick: one Tick }`)

https://claude.ai/code/session_01X15E8oZ1pTgLK6ARDmNYFL