### PR TITLE
feat: temporal binary bindings tracking and snapshot-aware TS trace checkers

### DIFF
--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -230,6 +230,43 @@ pub fn find_temporal_binary(expr: &Expr) -> Option<(&TemporalBinaryOp, &Expr, &E
     }
 }
 
+/// Like `find_temporal_binary` but also returns the bindings of the nearest enclosing quantifier.
+/// Returns `(op, left, right, bindings)` where `bindings` contains the quantifier variable names.
+pub fn find_temporal_binary_with_bindings<'a>(
+    expr: &'a Expr,
+) -> Option<(&'a TemporalBinaryOp, &'a Expr, &'a Expr, Vec<String>)> {
+    find_temporal_binary_inner(expr, &[])
+}
+
+fn find_temporal_binary_inner<'a>(
+    expr: &'a Expr,
+    enclosing_vars: &[String],
+) -> Option<(&'a TemporalBinaryOp, &'a Expr, &'a Expr, Vec<String>)> {
+    match expr {
+        Expr::TemporalBinary { op, left, right } => {
+            Some((op, left, right, enclosing_vars.to_vec()))
+        }
+        Expr::TemporalUnary { expr: inner, .. } => {
+            find_temporal_binary_inner(inner, enclosing_vars)
+        }
+        Expr::Quantifier { bindings, body, .. } => {
+            let mut vars = enclosing_vars.to_vec();
+            for b in bindings {
+                vars.extend(b.vars.clone());
+            }
+            find_temporal_binary_inner(body, &vars)
+        }
+        Expr::BinaryLogic { left, right, .. } => {
+            find_temporal_binary_inner(left, enclosing_vars)
+                .or_else(|| find_temporal_binary_inner(right, enclosing_vars))
+        }
+        Expr::Not(inner) | Expr::MultFormula { expr: inner, .. } => {
+            find_temporal_binary_inner(inner, enclosing_vars)
+        }
+        _ => None,
+    }
+}
+
 /// Strip the outermost temporal unary wrapper and universal quantifier from an expression.
 /// Returns `(quantifier_kind, bindings, inner_body)` if the expression has the pattern
 /// `TemporalUnary(_, Quantifier(kind, bindings, body))` or just `Quantifier(kind, bindings, body)`.

--- a/src/backend/typescript/expr_translator.rs
+++ b/src/backend/typescript/expr_translator.rs
@@ -26,6 +26,67 @@ pub fn translate_trace_body(expr: &Expr, ir: &OxidtrIR) -> String {
     }
 }
 
+/// Translate a binary temporal operand (left or right side of until/since/etc.)
+/// in the context of specific bound variable names.
+/// Used in trace checker generation where lambdas must explicitly bind the quantifier vars.
+///
+/// Returns `(lambda_params, body_expr)` where `lambda_params` is the lambda argument
+/// list (e.g. `"s"` or `"s, t"`) and `body_expr` is the translated condition string.
+pub fn translate_trace_binary_side(
+    side: &Expr,
+    bound_vars: &[String],
+    ir: &OxidtrIR,
+) -> (String, String) {
+    let sig_names = collect_sig_names(ir);
+    let body_str = translate_inner(side, false, &sig_names, ir);
+
+    if bound_vars.is_empty() {
+        // No quantifier context — return as-is
+        ("_".to_string(), body_str)
+    } else {
+        // The lambda receives one snapshot per bound variable.
+        // For a single var, the trace element is M.Sig[]; for multiple, it's a tuple.
+        if bound_vars.len() == 1 {
+            (bound_vars[0].clone(), body_str)
+        } else {
+            (format!("[{}]", bound_vars.join(", ")), body_str)
+        }
+    }
+}
+
+/// Translate a binary temporal side expression into a one-step predicate string.
+/// For a trace of `M.T[][]`, each element is `M.T[]` (a snapshot).
+/// The returned string is a lambda body that takes a snapshot as its argument.
+pub fn translate_trace_binary_snapshot(
+    side: &Expr,
+    snapshot_var: &str,
+    bound_vars: &[String],
+    ir: &OxidtrIR,
+) -> String {
+    let sig_names = collect_sig_names(ir);
+    if bound_vars.len() == 1 {
+        // Strip enclosing quantifier if present and translate body without spread
+        let var = &bound_vars[0];
+        let body_str = match side {
+            Expr::Quantifier { body, .. } => translate_inner(body, false, &sig_names, ir),
+            _ => translate_inner(side, false, &sig_names, ir),
+        };
+        format!("{snapshot_var}.every({var} => {body_str})")
+    } else if bound_vars.len() > 1 {
+        let body_str = match side {
+            Expr::Quantifier { body, .. } => translate_inner(body, false, &sig_names, ir),
+            _ => translate_inner(side, false, &sig_names, ir),
+        };
+        let checks: Vec<String> = bound_vars.iter().enumerate()
+            .map(|(i, v)| format!("const {v} = {snapshot_var}[{i}];"))
+            .collect();
+        format!("(() => {{ {}; return {}; }})()", checks.join(" "), body_str)
+    } else {
+        // No bound vars — side might still contain a quantifier; use trace-style translation
+        translate_trace_body(side, ir)
+    }
+}
+
 /// Extract the collection parameters needed by an expression.
 pub fn extract_params(expr: &Expr, sig_names: &HashSet<String>) -> Vec<(String, String)> {
     let mut params = BTreeSet::new();

--- a/src/backend/typescript/mod.rs
+++ b/src/backend/typescript/mod.rs
@@ -608,9 +608,9 @@ fn generate_tests(ir: &OxidtrIR, test_runner: TsTestRunner) -> String {
                     writeln!(out).unwrap();
                 }
                 analyze::TemporalKind::Binary => {
-                    if let Some((op, left, right)) = analyze::find_temporal_binary(&constraint.expr) {
-                        let left_body = expr_translator::translate_trace_body(left, ir);
-                        let right_body = expr_translator::translate_trace_body(right, ir);
+                    if let Some((op, left, right, bound_vars)) =
+                        analyze::find_temporal_binary_with_bindings(&constraint.expr)
+                    {
                         let op_name = match op {
                             TemporalBinaryOp::Until => "until",
                             TemporalBinaryOp::Since => "since",
@@ -627,23 +627,27 @@ fn generate_tests(ir: &OxidtrIR, test_runner: TsTestRunner) -> String {
                         if params.len() == 1 {
                             let (pname, tname) = &params[0];
                             writeln!(out, "  function check_{op_name}_{camel_name}(trace: M.{tname}[][]): boolean {{").unwrap();
+                            // Use snapshot-aware translation: each trace element is M.T[]
+                            let snap = pname.as_str();
+                            let left_pred = expr_translator::translate_trace_binary_snapshot(left, snap, &bound_vars, ir);
+                            let right_pred = expr_translator::translate_trace_binary_snapshot(right, snap, &bound_vars, ir);
                             match op {
                                 TemporalBinaryOp::Until => {
-                                    writeln!(out, "    const pos = trace.findIndex(({pname}) => {{ return {right_body}; }});").unwrap();
-                                    writeln!(out, "    return pos >= 0 && trace.slice(0, pos).every(({pname}) => {{ return {left_body}; }});").unwrap();
+                                    writeln!(out, "    const pos = trace.findIndex({snap} => {right_pred});").unwrap();
+                                    writeln!(out, "    return pos >= 0 && trace.slice(0, pos).every({snap} => {left_pred});").unwrap();
                                 }
                                 TemporalBinaryOp::Since => {
                                     writeln!(out, "    let pos = -1;").unwrap();
-                                    writeln!(out, "    for (let i = trace.length - 1; i >= 0; i--) {{ const {pname} = trace[i]; if ({right_body}) {{ pos = i; break; }} }}").unwrap();
-                                    writeln!(out, "    return pos >= 0 && trace.slice(pos).every(({pname}) => {{ return {left_body}; }});").unwrap();
+                                    writeln!(out, "    for (let i = trace.length - 1; i >= 0; i--) {{ if ({}) {{ pos = i; break; }} }}", right_pred.replace(snap, &format!("trace[i]"))).unwrap();
+                                    writeln!(out, "    return pos >= 0 && trace.slice(pos).every({snap} => {left_pred});").unwrap();
                                 }
                                 TemporalBinaryOp::Release => {
-                                    writeln!(out, "    const pos = trace.findIndex(({pname}) => {{ return {left_body}; }});").unwrap();
-                                    writeln!(out, "    return pos >= 0 ? trace.slice(0, pos + 1).every(({pname}) => {{ return {right_body}; }}) : trace.every(({pname}) => {{ return {right_body}; }});").unwrap();
+                                    writeln!(out, "    const pos = trace.findIndex({snap} => {left_pred});").unwrap();
+                                    writeln!(out, "    return pos >= 0 ? trace.slice(0, pos + 1).every({snap} => {right_pred}) : trace.every({snap} => {right_pred});").unwrap();
                                 }
                                 TemporalBinaryOp::Triggered => {
-                                    writeln!(out, "    return trace.every(({pname}, i) => {{").unwrap();
-                                    writeln!(out, "      if ({right_body}) {{ return trace.slice(0, i + 1).some(({pname}) => {{ return {left_body}; }}); }} else {{ return true; }}").unwrap();
+                                    writeln!(out, "    return trace.every(({snap}, i) => {{").unwrap();
+                                    writeln!(out, "      if ({right_pred}) {{ return trace.slice(0, i + 1).some({snap} => {left_pred}); }} else {{ return true; }}").unwrap();
                                     writeln!(out, "    }});").unwrap();
                                 }
                             }
@@ -652,23 +656,26 @@ fn generate_tests(ir: &OxidtrIR, test_runner: TsTestRunner) -> String {
                             let tuple_names: Vec<_> = params.iter().map(|(p, _)| p.as_str()).collect();
                             let pnames = tuple_names.join(", ");
                             writeln!(out, "  function check_{op_name}_{camel_name}(trace: [{}][]): boolean {{", tuple_types.join(", ")).unwrap();
+                            let snap = format!("[{pnames}]");
+                            let left_pred = expr_translator::translate_trace_binary_snapshot(left, &snap, &bound_vars, ir);
+                            let right_pred = expr_translator::translate_trace_binary_snapshot(right, &snap, &bound_vars, ir);
                             match op {
                                 TemporalBinaryOp::Until => {
-                                    writeln!(out, "    const pos = trace.findIndex(([{pnames}]) => {{ return {right_body}; }});").unwrap();
-                                    writeln!(out, "    return pos >= 0 && trace.slice(0, pos).every(([{pnames}]) => {{ return {left_body}; }});").unwrap();
+                                    writeln!(out, "    const pos = trace.findIndex({snap} => {right_pred});").unwrap();
+                                    writeln!(out, "    return pos >= 0 && trace.slice(0, pos).every({snap} => {left_pred});").unwrap();
                                 }
                                 TemporalBinaryOp::Since => {
                                     writeln!(out, "    let pos = -1;").unwrap();
-                                    writeln!(out, "    for (let i = trace.length - 1; i >= 0; i--) {{ const [{pnames}] = trace[i]; if ({right_body}) {{ pos = i; break; }} }}").unwrap();
-                                    writeln!(out, "    return pos >= 0 && trace.slice(pos).every(([{pnames}]) => {{ return {left_body}; }});").unwrap();
+                                    writeln!(out, "    for (let i = trace.length - 1; i >= 0; i--) {{ if ({}) {{ pos = i; break; }} }}", right_pred.replace(snap.as_str(), "trace[i]")).unwrap();
+                                    writeln!(out, "    return pos >= 0 && trace.slice(pos).every({snap} => {left_pred});").unwrap();
                                 }
                                 TemporalBinaryOp::Release => {
-                                    writeln!(out, "    const pos = trace.findIndex(([{pnames}]) => {{ return {left_body}; }});").unwrap();
-                                    writeln!(out, "    return pos >= 0 ? trace.slice(0, pos + 1).every(([{pnames}]) => {{ return {right_body}; }}) : trace.every(([{pnames}]) => {{ return {right_body}; }});").unwrap();
+                                    writeln!(out, "    const pos = trace.findIndex({snap} => {left_pred});").unwrap();
+                                    writeln!(out, "    return pos >= 0 ? trace.slice(0, pos + 1).every({snap} => {right_pred}) : trace.every({snap} => {right_pred});").unwrap();
                                 }
                                 TemporalBinaryOp::Triggered => {
-                                    writeln!(out, "    return trace.every(([{pnames}], i) => {{").unwrap();
-                                    writeln!(out, "      if ({right_body}) {{ return trace.slice(0, i + 1).some(([{pnames}]) => {{ return {left_body}; }}); }} else {{ return true; }}").unwrap();
+                                    writeln!(out, "    return trace.every(({snap}, i) => {{").unwrap();
+                                    writeln!(out, "      if ({right_pred}) {{ return trace.slice(0, i + 1).some({snap} => {left_pred}); }} else {{ return true; }}").unwrap();
                                     writeln!(out, "    }});").unwrap();
                                 }
                             }


### PR DESCRIPTION
## Summary

- `find_temporal_binary_with_bindings` を追加し、量化子の束縛変数名を追跡しながら時相二項演算子を探索できるようにした
- `translate_trace_binary_side` / `translate_trace_binary_snapshot` を追加し、TSトレースチェッカー生成でスナップショット対応の変換を実現
- Binary temporal trace checker生成を新APIに切り替え、不要な `[...ss]` スプレッドを回避

## Test plan

- [x] `cargo test` 全テスト通過（746テスト）
- [x] `cargo build` warning ゼロ
- [x] `ts_binary_trace_checker_binds_quantifier_variable` テストが正しく `ss.every(s =>` パターンを生成することを確認

https://claude.ai/code/session_01VaYjQQQL7jh6rt29JTFXsH