### PR TITLE
feat: expand constraint validation to all 7 backends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,20 +173,19 @@ cargo run -- extract generated/ -o /tmp/mined.als
 
 現在の実装状況と残課題:
 
-**実装済み（テスト生成 + ランタイム検証コード）:**
-- NoSelfRef: Rust TryFrom / TS validator / Kotlin・Java注釈
-- Acyclic: Rust TryFrom（チェーン走査） / TS validator（Setベース）
-- Disj一意性: Rust TryFrom（HashSet） / TS validator（Set.size）
-- FieldOrdering: Rust TryFrom / TS validator / Kotlin init block / Java compact constructor
-- Implication: TS validator（translate_validator_expr） / Kotlin・Java コメント
-- Iff / Prohibition: TS validator（translate_validator_expr）
-
 **実装済み（全7言語でバリデーションコード生成）:**
+- NoSelfRef: Rust TryFrom / TS validator / Kotlin require / Java constructor / Swift validate() / Go Validate() / C# Validate()
+- Acyclic: Rust TryFrom / TS validator / Kotlin require / Java constructor / Swift validate() / Go Validate() / C# Validate()
+- Disj一意性: Rust TryFrom / TS validator / Kotlin require / Java constructor / Swift validate() / Go Validate() / C# Validate()
+- FieldOrdering: Rust TryFrom / TS validator / Kotlin require / Java constructor / Swift validate() / Go Validate() / C# Validate()
+- Implication: Rust TryFrom / TS validator / Kotlin require / Java constructor / Swift validate() / Go Validate() / C# Validate()
+- Iff: Rust TryFrom / TS validator / Kotlin require / Java constructor / Swift validate() / Go Validate() / C# Validate()
+- Prohibition: Rust TryFrom / TS validator / Kotlin require / Java constructor / Swift validate() / Go Validate() / C# Validate()
 - Disjoint (`no (A & B)`): Rust TryFrom / TS validator / Kotlin require / Java constructor / Swift validate() / Go Validate() / C# Validate()
 - Exhaustive (`all x | x in A or x in B or ...`): Rust validate_exhaustive関数 / TS validator / Kotlin require / Java constructor / Swift validate() / Go Validate() / C# Validate()
 
-**パーサー拡張済み・活用余地あり:**
-- `some expr`/`no expr`フォーミュラ: パーサーとexpr_translatorは対応済み。solidionのドメインモデルでimpliesパターンの記述が可能に
+**パーサー拡張済み:**
+- `some expr`/`no expr`フォーミュラ: パーサーとexpr_translatorは対応済み。各バックエンドのtranslate_validator_exprでnull/nil/None判定に変換
 
 **Alloy 6 時相式（実装済み）:**
 - Prime (`x'`): 全バックエンドで `next_x` パラメータ付き遷移関数として変換

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -431,31 +431,45 @@ fn analyze_expr(expr: &Expr, fact_name: &str) -> Vec<ConstraintInfo> {
                 }
             }
         }
-        // no s: Sig | ... → Acyclic or Prohibition
+        // no s: Sig | ... → Acyclic, NoSelfRef, or Prohibition
         Expr::Quantifier { kind: QuantKind::No, bindings, body } => {
             if bindings.len() == 1 && bindings[0].vars.len() == 1 {
                 let var = &bindings[0].vars[0];
                 let domain = &bindings[0].domain;
                 if let Expr::VarRef(sig_name) = domain {
-                    let mut is_acyclic = false;
-                    // s in s.^field → Acyclic
+                    let mut is_specialized = false;
                     if let Expr::Comparison { op: CompareOp::In, left, right } = body.as_ref() {
                         if let Expr::VarRef(v) = left.as_ref() {
                             if v == var {
+                                // s in s.^field → Acyclic
                                 if let Expr::TransitiveClosure(inner) = right.as_ref() {
                                     if let Expr::FieldAccess { field, .. } = inner.as_ref() {
                                         results.push(ConstraintInfo::Acyclic {
                                             sig_name: sig_name.clone(),
                                             field_name: field.clone(),
                                         });
-                                        is_acyclic = true;
+                                        is_specialized = true;
+                                    }
+                                }
+                                // s in s.field → NoSelfRef
+                                if !is_specialized {
+                                    if let Expr::FieldAccess { base, field } = right.as_ref() {
+                                        if let Expr::VarRef(base_var) = base.as_ref() {
+                                            if base_var == var {
+                                                results.push(ConstraintInfo::NoSelfRef {
+                                                    sig_name: sig_name.clone(),
+                                                    field_name: field.clone(),
+                                                });
+                                                is_specialized = true;
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
                     }
                     // Other no-quantifier patterns → Prohibition
-                    if !is_acyclic {
+                    if !is_specialized {
                         results.push(ConstraintInfo::Prohibition {
                             sig_name: sig_name.clone(),
                             condition: substitute_var(body, var, sig_name),

--- a/src/backend/csharp/mod.rs
+++ b/src/backend/csharp/mod.rs
@@ -2,7 +2,7 @@ pub mod expr_translator;
 
 use crate::backend::GeneratedFile;
 use crate::ir::nodes::*;
-use crate::parser::ast::{Multiplicity, SigMultiplicity};
+use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity};
 use crate::analyze;
 use crate::backend;
 use std::collections::{HashMap, HashSet};
@@ -166,11 +166,16 @@ fn generate_class(out: &mut String, s: &StructureNode, ir: &OxidtrIR, _ctx: &CsC
         writeln!(out, "    public {} {} {{ get; set; }}", type_str, capitalize(&f.name)).unwrap();
     }
 
-    // Generate Validate() method for Disjoint and Exhaustive constraints
+    // Generate Validate() method for constraint validation
     let sig_constraints = analyze::constraints_for_sig(ir, &s.name);
+    let disj = analyze::disj_fields(ir);
     let has_validation = sig_constraints.iter().any(|c| matches!(c,
         analyze::ConstraintInfo::Disjoint { .. } | analyze::ConstraintInfo::Exhaustive { .. }
-    ));
+        | analyze::ConstraintInfo::NoSelfRef { .. } | analyze::ConstraintInfo::Acyclic { .. }
+        | analyze::ConstraintInfo::FieldOrdering { .. }
+        | analyze::ConstraintInfo::Implication { .. } | analyze::ConstraintInfo::Iff { .. }
+        | analyze::ConstraintInfo::Prohibition { .. }
+    )) || disj.iter().any(|(dsig, _)| dsig == &s.name);
     if has_validation {
         writeln!(out).unwrap();
         writeln!(out, "    public List<string> Validate()").unwrap();
@@ -178,6 +183,60 @@ fn generate_class(out: &mut String, s: &StructureNode, ir: &OxidtrIR, _ctx: &CsC
         writeln!(out, "        var errors = new List<string>();").unwrap();
         for c in &sig_constraints {
             match c {
+                analyze::ConstraintInfo::NoSelfRef { field_name, .. } => {
+                    let fname = capitalize(field_name);
+                    writeln!(out, "        if (ReferenceEquals({fname}, this))").unwrap();
+                    writeln!(out, "            errors.Add(\"{fname} must not reference self\");").unwrap();
+                }
+                analyze::ConstraintInfo::Acyclic { field_name, .. } => {
+                    let fname = capitalize(field_name);
+                    writeln!(out, "        {{").unwrap();
+                    writeln!(out, "            var seen = new HashSet<object>(ReferenceEqualityComparer.Instance);").unwrap();
+                    writeln!(out, "            var cur = this;").unwrap();
+                    writeln!(out, "            while (cur != null)").unwrap();
+                    writeln!(out, "            {{").unwrap();
+                    writeln!(out, "                if (!seen.Add(cur))").unwrap();
+                    writeln!(out, "                {{").unwrap();
+                    writeln!(out, "                    errors.Add(\"{fname} must not form a cycle\");").unwrap();
+                    writeln!(out, "                    break;").unwrap();
+                    writeln!(out, "                }}").unwrap();
+                    writeln!(out, "                cur = cur.{fname};").unwrap();
+                    writeln!(out, "            }}").unwrap();
+                    writeln!(out, "        }}").unwrap();
+                }
+                analyze::ConstraintInfo::FieldOrdering { left_field, op, right_field, .. } => {
+                    let lf = capitalize(left_field);
+                    let rf = capitalize(right_field);
+                    let (cs_op, negated_op) = match op {
+                        CompareOp::Lt => ("<", ">="),
+                        CompareOp::Gt => (">", "<="),
+                        CompareOp::Lte => ("<=", ">"),
+                        CompareOp::Gte => (">=", "<"),
+                        _ => continue,
+                    };
+                    writeln!(out, "        if ({lf} {negated_op} {rf})").unwrap();
+                    writeln!(out, "            errors.Add(\"{lf} must be {cs_op} {rf}\");").unwrap();
+                }
+                analyze::ConstraintInfo::Implication { condition, consequent, .. } => {
+                    let cond = translate_validator_expr_cs(condition, &s.name);
+                    let cons = translate_validator_expr_cs(consequent, &s.name);
+                    let desc = format!("{} implies {}", analyze::describe_expr(condition), analyze::describe_expr(consequent));
+                    writeln!(out, "        if ({cond} && !({cons}))").unwrap();
+                    writeln!(out, "            errors.Add(\"{}\");", desc.replace('"', "\\\"")).unwrap();
+                }
+                analyze::ConstraintInfo::Iff { left, right, .. } => {
+                    let l = translate_validator_expr_cs(left, &s.name);
+                    let r = translate_validator_expr_cs(right, &s.name);
+                    let desc = format!("{} iff {}", analyze::describe_expr(left), analyze::describe_expr(right));
+                    writeln!(out, "        if (({l}) != ({r}))").unwrap();
+                    writeln!(out, "            errors.Add(\"{}\");", desc.replace('"', "\\\"")).unwrap();
+                }
+                analyze::ConstraintInfo::Prohibition { condition, .. } => {
+                    let cond = translate_validator_expr_cs(condition, &s.name);
+                    let desc = analyze::describe_expr(condition);
+                    writeln!(out, "        if ({cond})").unwrap();
+                    writeln!(out, "            errors.Add(\"prohibited: {}\");", desc.replace('"', "\\\"")).unwrap();
+                }
                 analyze::ConstraintInfo::Disjoint { left, right, .. } => {
                     let left_field = capitalize(left.rsplit('.').next().unwrap_or(left));
                     let right_field = capitalize(right.rsplit('.').next().unwrap_or(right));
@@ -199,6 +258,18 @@ fn generate_class(out: &mut String, s: &StructureNode, ir: &OxidtrIR, _ctx: &CsC
                     writeln!(out, "            errors.Add(\"must belong to one of [{cats}] (exhaustive constraint)\");").unwrap();
                 }
                 _ => {}
+            }
+        }
+        // Disj uniqueness checks for seq fields
+        for (dsig, dfield) in &disj {
+            if dsig == &s.name {
+                if let Some(f) = s.fields.iter().find(|f| f.name == *dfield) {
+                    if f.mult == Multiplicity::Seq {
+                        let fname = capitalize(dfield);
+                        writeln!(out, "        if ({fname}.Distinct().Count() != {fname}.Count)").unwrap();
+                        writeln!(out, "            errors.Add(\"{fname} must not contain duplicates (disj constraint)\");").unwrap();
+                    }
+                }
             }
         }
         writeln!(out, "        return errors;").unwrap();
@@ -623,5 +694,56 @@ fn cs_default_value(target: &str, mult: &Multiplicity) -> String {
         Multiplicity::Lone => "null".to_string(),
         Multiplicity::Set => format!("new HashSet<{}>()", target),
         Multiplicity::Seq => format!("new List<{}>()", target),
+    }
+}
+
+/// Translate an Alloy expression to C# for single-instance validator context.
+fn translate_validator_expr_cs(expr: &crate::parser::ast::Expr, sig_name: &str) -> String {
+    use crate::parser::ast::{Expr, LogicOp, QuantKind};
+    match expr {
+        Expr::VarRef(name) => {
+            if name == sig_name { "this".to_string() } else { name.clone() }
+        }
+        Expr::IntLiteral(n) => n.to_string(),
+        Expr::FieldAccess { base, field } => {
+            format!("{}.{}", translate_validator_expr_cs(base, sig_name), capitalize(field))
+        }
+        Expr::Comparison { op, left, right } => {
+            let l = translate_validator_expr_cs(left, sig_name);
+            let r = translate_validator_expr_cs(right, sig_name);
+            let o = match op {
+                CompareOp::Eq => "==",
+                CompareOp::NotEq => "!=",
+                CompareOp::In => return format!("{r}.Contains({l})"),
+                CompareOp::Lt => "<",
+                CompareOp::Gt => ">",
+                CompareOp::Lte => "<=",
+                CompareOp::Gte => ">=",
+            };
+            format!("{l} {o} {r}")
+        }
+        Expr::BinaryLogic { op, left, right } => {
+            let l = translate_validator_expr_cs(left, sig_name);
+            let r = translate_validator_expr_cs(right, sig_name);
+            match op {
+                LogicOp::And => format!("{l} && {r}"),
+                LogicOp::Or => format!("{l} || {r}"),
+                LogicOp::Implies => format!("!({l}) || {r}"),
+                LogicOp::Iff => format!("({l}) == ({r})"),
+            }
+        }
+        Expr::Not(inner) => format!("!({})", translate_validator_expr_cs(inner, sig_name)),
+        Expr::MultFormula { kind, expr: inner } => {
+            let e = translate_validator_expr_cs(inner, sig_name);
+            match kind {
+                QuantKind::Some => format!("{e} != null"),
+                QuantKind::No => format!("{e} == null"),
+                _ => e,
+            }
+        }
+        Expr::Cardinality(inner) => {
+            format!("{}.Count", translate_validator_expr_cs(inner, sig_name))
+        }
+        _ => analyze::describe_expr(expr), // fallback: human-readable
     }
 }

--- a/src/backend/go/mod.rs
+++ b/src/backend/go/mod.rs
@@ -2,7 +2,7 @@ pub mod expr_translator;
 
 use crate::backend::GeneratedFile;
 use crate::ir::nodes::*;
-use crate::parser::ast::{Multiplicity, SigMultiplicity, TemporalBinaryOp};
+use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity, TemporalBinaryOp};
 use crate::analyze;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
@@ -229,17 +229,80 @@ fn generate_struct(out: &mut String, s: &StructureNode, ir: &OxidtrIR, ctx: &GoC
         }
         writeln!(out, "}}").unwrap();
 
-        // Generate Validate() method for Disjoint and Exhaustive constraints
+        // Generate Validate() method for constraint validation
         let sig_constraints = analyze::constraints_for_sig(ir, &s.name);
+        let disj = analyze::disj_fields(ir);
         let has_validation = sig_constraints.iter().any(|c| matches!(c,
             analyze::ConstraintInfo::Disjoint { .. } | analyze::ConstraintInfo::Exhaustive { .. }
-        ));
+            | analyze::ConstraintInfo::NoSelfRef { .. } | analyze::ConstraintInfo::Acyclic { .. }
+            | analyze::ConstraintInfo::FieldOrdering { .. }
+            | analyze::ConstraintInfo::Implication { .. } | analyze::ConstraintInfo::Iff { .. }
+            | analyze::ConstraintInfo::Prohibition { .. }
+        )) || disj.iter().any(|(dsig, _)| dsig == &s.name);
         if has_validation {
             writeln!(out).unwrap();
             writeln!(out, "func (s {}) Validate() []string {{", s.name).unwrap();
             writeln!(out, "\tvar errors []string").unwrap();
             for c in &sig_constraints {
                 match c {
+                    analyze::ConstraintInfo::NoSelfRef { field_name, .. } => {
+                        let fname = expr_translator::capitalize(field_name);
+                        writeln!(out, "\tif &s == s.{fname} {{").unwrap();
+                        writeln!(out, "\t\terrors = append(errors, \"{fname} must not reference self\")").unwrap();
+                        writeln!(out, "\t}}").unwrap();
+                    }
+                    analyze::ConstraintInfo::Acyclic { field_name, .. } => {
+                        let fname = expr_translator::capitalize(field_name);
+                        writeln!(out, "\t{{").unwrap();
+                        writeln!(out, "\t\tseen := make(map[*{}]bool)", s.name).unwrap();
+                        writeln!(out, "\t\tcur := &s").unwrap();
+                        writeln!(out, "\t\tfor cur != nil {{").unwrap();
+                        writeln!(out, "\t\t\tif seen[cur] {{").unwrap();
+                        writeln!(out, "\t\t\t\terrors = append(errors, \"{fname} must not form a cycle\")").unwrap();
+                        writeln!(out, "\t\t\t\tbreak").unwrap();
+                        writeln!(out, "\t\t\t}}").unwrap();
+                        writeln!(out, "\t\t\tseen[cur] = true").unwrap();
+                        writeln!(out, "\t\t\tcur = cur.{fname}").unwrap();
+                        writeln!(out, "\t\t}}").unwrap();
+                        writeln!(out, "\t}}").unwrap();
+                    }
+                    analyze::ConstraintInfo::FieldOrdering { left_field, op, right_field, .. } => {
+                        let lf = expr_translator::capitalize(left_field);
+                        let rf = expr_translator::capitalize(right_field);
+                        let (go_op, negated_op) = match op {
+                            CompareOp::Lt => ("<", ">="),
+                            CompareOp::Gt => (">", "<="),
+                            CompareOp::Lte => ("<=", ">"),
+                            CompareOp::Gte => (">=", "<"),
+                            _ => continue,
+                        };
+                        writeln!(out, "\tif s.{lf} {negated_op} s.{rf} {{").unwrap();
+                        writeln!(out, "\t\terrors = append(errors, \"{lf} must be {go_op} {rf}\")").unwrap();
+                        writeln!(out, "\t}}").unwrap();
+                    }
+                    analyze::ConstraintInfo::Implication { condition, consequent, .. } => {
+                        let cond = translate_validator_expr_go(condition, &s.name);
+                        let cons = translate_validator_expr_go(consequent, &s.name);
+                        let desc = format!("{} implies {}", analyze::describe_expr(condition), analyze::describe_expr(consequent));
+                        writeln!(out, "\tif {cond} && !({cons}) {{").unwrap();
+                        writeln!(out, "\t\terrors = append(errors, \"{}\"))", desc.replace('"', "\\\"")).unwrap();
+                        writeln!(out, "\t}}").unwrap();
+                    }
+                    analyze::ConstraintInfo::Iff { left, right, .. } => {
+                        let l = translate_validator_expr_go(left, &s.name);
+                        let r = translate_validator_expr_go(right, &s.name);
+                        let desc = format!("{} iff {}", analyze::describe_expr(left), analyze::describe_expr(right));
+                        writeln!(out, "\tif ({l}) != ({r}) {{").unwrap();
+                        writeln!(out, "\t\terrors = append(errors, \"{}\"))", desc.replace('"', "\\\"")).unwrap();
+                        writeln!(out, "\t}}").unwrap();
+                    }
+                    analyze::ConstraintInfo::Prohibition { condition, .. } => {
+                        let cond = translate_validator_expr_go(condition, &s.name);
+                        let desc = analyze::describe_expr(condition);
+                        writeln!(out, "\tif {cond} {{").unwrap();
+                        writeln!(out, "\t\terrors = append(errors, \"prohibited: {}\"))", desc.replace('"', "\\\"")).unwrap();
+                        writeln!(out, "\t}}").unwrap();
+                    }
                     analyze::ConstraintInfo::Disjoint { left, right, .. } => {
                         let left_field = expr_translator::capitalize(left.rsplit('.').next().unwrap_or(left));
                         let right_field = expr_translator::capitalize(right.rsplit('.').next().unwrap_or(right));
@@ -254,11 +317,40 @@ fn generate_struct(out: &mut String, s: &StructureNode, ir: &OxidtrIR, ctx: &GoC
                     }
                     analyze::ConstraintInfo::Exhaustive { categories, .. } => {
                         let cats = categories.join(", ");
-                        writeln!(out, "\t// exhaustive: must belong to one of [{cats}]").unwrap();
-                        writeln!(out, "\t// Validate at integration level with category collections").unwrap();
-                        writeln!(out, "\t_ = \"must belong to one of [{cats}] (exhaustive constraint)\"").unwrap();
+                        let checks: Vec<String> = categories.iter().map(|cat| {
+                            let parts: Vec<&str> = cat.split('.').collect();
+                            if parts.len() == 2 {
+                                format!("contains{}{}(s)", expr_translator::capitalize(parts[0]), expr_translator::capitalize(parts[1]))
+                            } else {
+                                format!("contains{cat}(s)")
+                            }
+                        }).collect();
+                        let condition = checks.join(" || ");
+                        writeln!(out, "\tif !({condition}) {{").unwrap();
+                        writeln!(out, "\t\terrors = append(errors, \"must belong to one of [{cats}] (exhaustive constraint)\")").unwrap();
+                        writeln!(out, "\t}}").unwrap();
                     }
                     _ => {}
+                }
+            }
+            // Disj uniqueness checks for seq fields
+            for (dsig, dfield) in &disj {
+                if dsig == &s.name {
+                    if let Some(f) = s.fields.iter().find(|f| f.name == *dfield) {
+                        if f.mult == Multiplicity::Seq {
+                            let fname = expr_translator::capitalize(dfield);
+                            writeln!(out, "\t{{").unwrap();
+                            writeln!(out, "\t\tseen := make(map[interface{{}}]bool)").unwrap();
+                            writeln!(out, "\t\tfor _, v := range s.{fname} {{").unwrap();
+                            writeln!(out, "\t\t\tif seen[v] {{").unwrap();
+                            writeln!(out, "\t\t\t\terrors = append(errors, \"{fname} must not contain duplicates (disj constraint)\")").unwrap();
+                            writeln!(out, "\t\t\t\tbreak").unwrap();
+                            writeln!(out, "\t\t\t}}").unwrap();
+                            writeln!(out, "\t\t\tseen[v] = true").unwrap();
+                            writeln!(out, "\t\t}}").unwrap();
+                            writeln!(out, "\t}}").unwrap();
+                        }
+                    }
                 }
             }
             writeln!(out, "\treturn errors").unwrap();
@@ -1237,5 +1329,56 @@ fn expr_uses_tc(expr: &crate::parser::ast::Expr) -> bool {
         }
         Expr::FunApp { receiver, args, .. } => receiver.as_ref().map_or(false, |r| expr_uses_tc(r)) || args.iter().any(|a| expr_uses_tc(a)),
         Expr::VarRef(_) | Expr::IntLiteral(_) => false,
+    }
+}
+
+/// Translate an Alloy expression to Go for single-instance validator context.
+fn translate_validator_expr_go(expr: &crate::parser::ast::Expr, sig_name: &str) -> String {
+    use crate::parser::ast::{Expr, LogicOp, QuantKind};
+    match expr {
+        Expr::VarRef(name) => {
+            if name == sig_name { "s".to_string() } else { name.clone() }
+        }
+        Expr::IntLiteral(n) => n.to_string(),
+        Expr::FieldAccess { base, field } => {
+            format!("{}.{}", translate_validator_expr_go(base, sig_name), expr_translator::capitalize(field))
+        }
+        Expr::Comparison { op, left, right } => {
+            let l = translate_validator_expr_go(left, sig_name);
+            let r = translate_validator_expr_go(right, sig_name);
+            let o = match op {
+                CompareOp::Eq => "==",
+                CompareOp::NotEq => "!=",
+                CompareOp::In => return format!("contains({r}, {l})"),
+                CompareOp::Lt => "<",
+                CompareOp::Gt => ">",
+                CompareOp::Lte => "<=",
+                CompareOp::Gte => ">=",
+            };
+            format!("{l} {o} {r}")
+        }
+        Expr::BinaryLogic { op, left, right } => {
+            let l = translate_validator_expr_go(left, sig_name);
+            let r = translate_validator_expr_go(right, sig_name);
+            match op {
+                LogicOp::And => format!("{l} && {r}"),
+                LogicOp::Or => format!("{l} || {r}"),
+                LogicOp::Implies => format!("!({l}) || {r}"),
+                LogicOp::Iff => format!("({l}) == ({r})"),
+            }
+        }
+        Expr::Not(inner) => format!("!({})", translate_validator_expr_go(inner, sig_name)),
+        Expr::MultFormula { kind, expr: inner } => {
+            let e = translate_validator_expr_go(inner, sig_name);
+            match kind {
+                QuantKind::Some => format!("{e} != nil"),
+                QuantKind::No => format!("{e} == nil"),
+                _ => e,
+            }
+        }
+        Expr::Cardinality(inner) => {
+            format!("len({})", translate_validator_expr_go(inner, sig_name))
+        }
+        _ => analyze::describe_expr(expr), // fallback: human-readable
     }
 }

--- a/src/backend/jvm/java.rs
+++ b/src/backend/jvm/java.rs
@@ -282,9 +282,28 @@ fn generate_record(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_fiel
                     };
                     constructor_checks.push(format!("if ({left_field} {negated} {right_field}) throw new IllegalArgumentException(\"{left_field} must be {op_str} {right_field}\");"));
                 }
+                analyze::ConstraintInfo::NoSelfRef { field_name, .. } => {
+                    constructor_checks.push(format!("if ({field_name} == this) throw new IllegalArgumentException(\"{field_name} must not reference self\");"));
+                }
+                analyze::ConstraintInfo::Acyclic { field_name, .. } => {
+                    constructor_checks.push(format!("{{ var seen = new java.util.HashSet<>(); var cur = ({sig_name}) this; while (cur != null) {{ if (!seen.add(cur)) throw new IllegalArgumentException(\"{field_name} must not form a cycle\"); cur = cur.{field_name}(); }} }}", sig_name = s.name));
+                }
                 analyze::ConstraintInfo::Implication { condition, consequent, .. } => {
+                    let cond = translate_validator_expr_java(condition, &s.name);
+                    let cons = translate_validator_expr_java(consequent, &s.name);
                     let desc = format!("{} implies {}", analyze::describe_expr(condition), analyze::describe_expr(consequent));
-                    constructor_checks.push(format!("// {desc}"));
+                    constructor_checks.push(format!("if ({cond} && !({cons})) throw new IllegalArgumentException(\"{}\");", desc.replace('"', "\\\"")));
+                }
+                analyze::ConstraintInfo::Iff { left, right, .. } => {
+                    let l = translate_validator_expr_java(left, &s.name);
+                    let r = translate_validator_expr_java(right, &s.name);
+                    let desc = format!("{} iff {}", analyze::describe_expr(left), analyze::describe_expr(right));
+                    constructor_checks.push(format!("if (({l}) != ({r})) throw new IllegalArgumentException(\"{}\");", desc.replace('"', "\\\"")));
+                }
+                analyze::ConstraintInfo::Prohibition { condition, .. } => {
+                    let cond = translate_validator_expr_java(condition, &s.name);
+                    let desc = analyze::describe_expr(condition);
+                    constructor_checks.push(format!("if ({cond}) throw new IllegalArgumentException(\"prohibited: {}\");", desc.replace('"', "\\\"")));
                 }
                 analyze::ConstraintInfo::Disjoint { left, right, .. } => {
                     let left_field = left.rsplit('.').next().unwrap_or(left);
@@ -305,6 +324,17 @@ fn generate_record(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_fiel
                     constructor_checks.push(format!("if ({condition}) throw new IllegalArgumentException(\"must belong to one of [{cats}] (exhaustive constraint)\");"));
                 }
                 _ => {}
+            }
+        }
+        // Disj uniqueness checks for seq fields
+        let disj = analyze::disj_fields(ir);
+        for (dsig, dfield) in &disj {
+            if dsig == &s.name {
+                if let Some(f) = s.fields.iter().find(|f| f.name == *dfield) {
+                    if f.mult == Multiplicity::Seq {
+                        constructor_checks.push(format!("if (new java.util.HashSet<>({dfield}).size() != {dfield}.size()) throw new IllegalArgumentException(\"{dfield} must not contain duplicates (disj constraint)\");"));
+                    }
+                }
             }
         }
 
@@ -1053,6 +1083,58 @@ fn capitalize(s: &str) -> String {
     match c.next() {
         None => String::new(),
         Some(f) => f.to_uppercase().to_string() + c.as_str(),
+    }
+}
+
+/// Translate an Alloy expression to Java for single-instance validator context.
+/// Java records use `.field()` accessor methods.
+fn translate_validator_expr_java(expr: &crate::parser::ast::Expr, sig_name: &str) -> String {
+    use crate::parser::ast::{Expr, LogicOp, QuantKind};
+    match expr {
+        Expr::VarRef(name) => {
+            if name == sig_name { "this".to_string() } else { name.clone() }
+        }
+        Expr::IntLiteral(n) => n.to_string(),
+        Expr::FieldAccess { base, field } => {
+            format!("{}.{}()", translate_validator_expr_java(base, sig_name), field)
+        }
+        Expr::Comparison { op, left, right } => {
+            let l = translate_validator_expr_java(left, sig_name);
+            let r = translate_validator_expr_java(right, sig_name);
+            let o = match op {
+                CompareOp::Eq => return format!("{l}.equals({r})"),
+                CompareOp::NotEq => return format!("!{l}.equals({r})"),
+                CompareOp::In => return format!("{r}.contains({l})"),
+                CompareOp::Lt => "<",
+                CompareOp::Gt => ">",
+                CompareOp::Lte => "<=",
+                CompareOp::Gte => ">=",
+            };
+            format!("{l} {o} {r}")
+        }
+        Expr::BinaryLogic { op, left, right } => {
+            let l = translate_validator_expr_java(left, sig_name);
+            let r = translate_validator_expr_java(right, sig_name);
+            match op {
+                LogicOp::And => format!("{l} && {r}"),
+                LogicOp::Or => format!("{l} || {r}"),
+                LogicOp::Implies => format!("!({l}) || {r}"),
+                LogicOp::Iff => format!("({l}) == ({r})"),
+            }
+        }
+        Expr::Not(inner) => format!("!({})", translate_validator_expr_java(inner, sig_name)),
+        Expr::MultFormula { kind, expr: inner } => {
+            let e = translate_validator_expr_java(inner, sig_name);
+            match kind {
+                QuantKind::Some => format!("{e} != null"),
+                QuantKind::No => format!("{e} == null"),
+                _ => e,
+            }
+        }
+        Expr::Cardinality(inner) => {
+            format!("{}.size()", translate_validator_expr_java(inner, sig_name))
+        }
+        _ => analyze::describe_expr(expr), // fallback: human-readable
     }
 }
 

--- a/src/backend/jvm/kotlin.rs
+++ b/src/backend/jvm/kotlin.rs
@@ -262,9 +262,28 @@ fn generate_data_class(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_
                     };
                     init_checks.push(format!("require({left_field} {op_str} {right_field}) {{ \"{left_field} must be {op_str} {right_field}\" }}"));
                 }
+                analyze::ConstraintInfo::NoSelfRef { field_name, .. } => {
+                    init_checks.push(format!("require({field_name} !== this) {{ \"{field_name} must not reference self\" }}"));
+                }
+                analyze::ConstraintInfo::Acyclic { field_name, .. } => {
+                    init_checks.push(format!("run {{ val seen = mutableSetOf<Any>(); var cur: Any? = this; while (cur != null) {{ require(seen.add(cur)) {{ \"{field_name} must not form a cycle\" }}; cur = (cur as? {sig_name})?.{field_name} }} }}", sig_name = s.name));
+                }
                 analyze::ConstraintInfo::Implication { condition, consequent, .. } => {
+                    let cond = translate_validator_expr_kt(condition, &s.name);
+                    let cons = translate_validator_expr_kt(consequent, &s.name);
                     let desc = format!("{} implies {}", analyze::describe_expr(condition), analyze::describe_expr(consequent));
-                    init_checks.push(format!("// {desc}"));
+                    init_checks.push(format!("require(!({cond}) || ({cons})) {{ \"{}\" }}", desc.replace('"', "\\\"")));
+                }
+                analyze::ConstraintInfo::Iff { left, right, .. } => {
+                    let l = translate_validator_expr_kt(left, &s.name);
+                    let r = translate_validator_expr_kt(right, &s.name);
+                    let desc = format!("{} iff {}", analyze::describe_expr(left), analyze::describe_expr(right));
+                    init_checks.push(format!("require(({l}) == ({r})) {{ \"{}\" }}", desc.replace('"', "\\\"")));
+                }
+                analyze::ConstraintInfo::Prohibition { condition, .. } => {
+                    let cond = translate_validator_expr_kt(condition, &s.name);
+                    let desc = analyze::describe_expr(condition);
+                    init_checks.push(format!("require(!({cond})) {{ \"prohibited: {}\" }}", desc.replace('"', "\\\"")));
                 }
                 analyze::ConstraintInfo::Disjoint { left, right, .. } => {
                     let left_field = left.rsplit('.').next().unwrap_or(left);
@@ -285,6 +304,17 @@ fn generate_data_class(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_
                     init_checks.push(format!("require({condition}) {{ \"must belong to one of [{cats}] (exhaustive constraint)\" }}"));
                 }
                 _ => {}
+            }
+        }
+        // Disj uniqueness checks for seq fields
+        let disj = analyze::disj_fields(ir);
+        for (dsig, dfield) in &disj {
+            if dsig == &s.name {
+                if let Some(f) = s.fields.iter().find(|f| f.name == *dfield) {
+                    if f.mult == Multiplicity::Seq {
+                        init_checks.push(format!("require({dfield}.toSet().size == {dfield}.size) {{ \"{dfield} must not contain duplicates (disj constraint)\" }}"));
+                    }
+                }
             }
         }
         if init_checks.is_empty() {
@@ -948,6 +978,57 @@ fn capitalize(s: &str) -> String {
     match c.next() {
         None => String::new(),
         Some(f) => f.to_uppercase().to_string() + c.as_str(),
+    }
+}
+
+/// Translate an Alloy expression to Kotlin for single-instance validator context.
+fn translate_validator_expr_kt(expr: &crate::parser::ast::Expr, sig_name: &str) -> String {
+    use crate::parser::ast::{Expr, LogicOp, QuantKind};
+    match expr {
+        Expr::VarRef(name) => {
+            if name == sig_name { "this".to_string() } else { name.clone() }
+        }
+        Expr::IntLiteral(n) => n.to_string(),
+        Expr::FieldAccess { base, field } => {
+            format!("{}.{}", translate_validator_expr_kt(base, sig_name), field)
+        }
+        Expr::Comparison { op, left, right } => {
+            let l = translate_validator_expr_kt(left, sig_name);
+            let r = translate_validator_expr_kt(right, sig_name);
+            let o = match op {
+                CompareOp::Eq => "==",
+                CompareOp::NotEq => "!=",
+                CompareOp::In => return format!("{l} in {r}"),
+                CompareOp::Lt => "<",
+                CompareOp::Gt => ">",
+                CompareOp::Lte => "<=",
+                CompareOp::Gte => ">=",
+            };
+            format!("{l} {o} {r}")
+        }
+        Expr::BinaryLogic { op, left, right } => {
+            let l = translate_validator_expr_kt(left, sig_name);
+            let r = translate_validator_expr_kt(right, sig_name);
+            match op {
+                LogicOp::And => format!("{l} && {r}"),
+                LogicOp::Or => format!("{l} || {r}"),
+                LogicOp::Implies => format!("!({l}) || {r}"),
+                LogicOp::Iff => format!("({l}) == ({r})"),
+            }
+        }
+        Expr::Not(inner) => format!("!({})", translate_validator_expr_kt(inner, sig_name)),
+        Expr::MultFormula { kind, expr: inner } => {
+            let e = translate_validator_expr_kt(inner, sig_name);
+            match kind {
+                QuantKind::Some => format!("{e} != null"),
+                QuantKind::No => format!("{e} == null"),
+                _ => e,
+            }
+        }
+        Expr::Cardinality(inner) => {
+            format!("{}.size", translate_validator_expr_kt(inner, sig_name))
+        }
+        _ => analyze::describe_expr(expr), // fallback: human-readable
     }
 }
 

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -1402,6 +1402,47 @@ fn generate_newtypes(ir: &OxidtrIR) -> String {
             }
         }
 
+        // Implication checks
+        for c in &all_constraints {
+            if let analyze::ConstraintInfo::Implication { sig_name: s, condition, consequent } = c {
+                if s == sig_name {
+                    let cond = translate_validator_expr_rust(condition, sig_name);
+                    let cons = translate_validator_expr_rust(consequent, sig_name);
+                    let desc = format!("{} implies {}", analyze::describe_expr(condition), analyze::describe_expr(consequent));
+                    writeln!(out, "        if {cond} && !({cons}) {{").unwrap();
+                    writeln!(out, "            return Err(\"{}\");", desc.replace('"', "\\\"")).unwrap();
+                    writeln!(out, "        }}").unwrap();
+                }
+            }
+        }
+
+        // Iff checks
+        for c in &all_constraints {
+            if let analyze::ConstraintInfo::Iff { sig_name: s, left, right } = c {
+                if s == sig_name {
+                    let l = translate_validator_expr_rust(left, sig_name);
+                    let r = translate_validator_expr_rust(right, sig_name);
+                    let desc = format!("{} iff {}", analyze::describe_expr(left), analyze::describe_expr(right));
+                    writeln!(out, "        if ({l}) != ({r}) {{").unwrap();
+                    writeln!(out, "            return Err(\"{}\");", desc.replace('"', "\\\"")).unwrap();
+                    writeln!(out, "        }}").unwrap();
+                }
+            }
+        }
+
+        // Prohibition checks
+        for c in &all_constraints {
+            if let analyze::ConstraintInfo::Prohibition { sig_name: s, condition } = c {
+                if s == sig_name {
+                    let cond = translate_validator_expr_rust(condition, sig_name);
+                    let desc = analyze::describe_expr(condition);
+                    writeln!(out, "        if {cond} {{").unwrap();
+                    writeln!(out, "            return Err(\"prohibited: {}\");", desc.replace('"', "\\\"")).unwrap();
+                    writeln!(out, "        }}").unwrap();
+                }
+            }
+        }
+
         // Inline the constraint expression directly instead of calling invariant function
         // Bind param names with type annotations for closure inference
         // Only the param matching sig_name gets value.clone(); others get empty Vec
@@ -1590,6 +1631,57 @@ pub fn find_cyclic_fields(ir: &OxidtrIR) -> HashSet<(String, String)> {
         }
     }
     result
+}
+
+/// Translate an Alloy expression to Rust for single-instance validator context.
+fn translate_validator_expr_rust(expr: &Expr, sig_name: &str) -> String {
+    use crate::parser::ast::{LogicOp, QuantKind};
+    match expr {
+        Expr::VarRef(name) => {
+            if name == sig_name { "value".to_string() } else { name.clone() }
+        }
+        Expr::IntLiteral(n) => n.to_string(),
+        Expr::FieldAccess { base, field } => {
+            format!("{}.{}", translate_validator_expr_rust(base, sig_name), field)
+        }
+        Expr::Comparison { op, left, right } => {
+            let l = translate_validator_expr_rust(left, sig_name);
+            let r = translate_validator_expr_rust(right, sig_name);
+            let o = match op {
+                CompareOp::Eq => "==",
+                CompareOp::NotEq => "!=",
+                CompareOp::In => return format!("{r}.contains(&{l})"),
+                CompareOp::Lt => "<",
+                CompareOp::Gt => ">",
+                CompareOp::Lte => "<=",
+                CompareOp::Gte => ">=",
+            };
+            format!("{l} {o} {r}")
+        }
+        Expr::BinaryLogic { op, left, right } => {
+            let l = translate_validator_expr_rust(left, sig_name);
+            let r = translate_validator_expr_rust(right, sig_name);
+            match op {
+                LogicOp::And => format!("{l} && {r}"),
+                LogicOp::Or => format!("{l} || {r}"),
+                LogicOp::Implies => format!("!({l}) || {r}"),
+                LogicOp::Iff => format!("({l}) == ({r})"),
+            }
+        }
+        Expr::Not(inner) => format!("!({})", translate_validator_expr_rust(inner, sig_name)),
+        Expr::MultFormula { kind, expr: inner } => {
+            let e = translate_validator_expr_rust(inner, sig_name);
+            match kind {
+                QuantKind::Some => format!("{e}.is_some()"),
+                QuantKind::No => format!("{e}.is_none()"),
+                _ => e,
+            }
+        }
+        Expr::Cardinality(inner) => {
+            format!("{}.len()", translate_validator_expr_rust(inner, sig_name))
+        }
+        _ => format!("/* {} */true", analyze::describe_expr(expr)), // fallback
+    }
 }
 
 fn generate_fixtures(ir: &OxidtrIR) -> String {

--- a/src/backend/swift/mod.rs
+++ b/src/backend/swift/mod.rs
@@ -2,7 +2,7 @@ pub mod expr_translator;
 
 use crate::backend::GeneratedFile;
 use crate::ir::nodes::*;
-use crate::parser::ast::{Multiplicity, SigMultiplicity, TemporalBinaryOp};
+use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity, TemporalBinaryOp};
 use crate::analyze;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
@@ -241,17 +241,81 @@ fn generate_struct(out: &mut String, s: &StructureNode, ir: &OxidtrIR, ctx: &Swi
             writeln!(out, "    {let_or_var} {}: {type_str}", to_swift_field_name(&f.name)).unwrap();
         }
 
-        // Generate validate() method for Disjoint and Exhaustive constraints
+        // Generate validate() method for constraint validation
         let sig_constraints = analyze::constraints_for_sig(ir, &s.name);
+        let disj = analyze::disj_fields(ir);
         let has_validation = sig_constraints.iter().any(|c| matches!(c,
             analyze::ConstraintInfo::Disjoint { .. } | analyze::ConstraintInfo::Exhaustive { .. }
-        ));
+            | analyze::ConstraintInfo::NoSelfRef { .. } | analyze::ConstraintInfo::Acyclic { .. }
+            | analyze::ConstraintInfo::FieldOrdering { .. }
+            | analyze::ConstraintInfo::Implication { .. } | analyze::ConstraintInfo::Iff { .. }
+            | analyze::ConstraintInfo::Prohibition { .. }
+        )) || disj.iter().any(|(dsig, _)| dsig == &s.name);
         if has_validation {
             writeln!(out).unwrap();
             writeln!(out, "    func validate() -> [String] {{").unwrap();
             writeln!(out, "        var errors: [String] = []").unwrap();
             for c in &sig_constraints {
                 match c {
+                    analyze::ConstraintInfo::NoSelfRef { field_name, .. } => {
+                        let fname = to_swift_field_name(field_name);
+                        writeln!(out, "        if {fname} as AnyObject === self as AnyObject {{").unwrap();
+                        writeln!(out, "            errors.append(\"{fname} must not reference self\")").unwrap();
+                        writeln!(out, "        }}").unwrap();
+                    }
+                    analyze::ConstraintInfo::Acyclic { field_name, .. } => {
+                        let fname = to_swift_field_name(field_name);
+                        writeln!(out, "        do {{").unwrap();
+                        writeln!(out, "            var seen = Set<ObjectIdentifier>()").unwrap();
+                        writeln!(out, "            var cur: {type_name}? = self", type_name = s.name).unwrap();
+                        writeln!(out, "            while let node = cur {{").unwrap();
+                        writeln!(out, "                let id = ObjectIdentifier(node as AnyObject)").unwrap();
+                        writeln!(out, "                if seen.contains(id) {{").unwrap();
+                        writeln!(out, "                    errors.append(\"{fname} must not form a cycle\")").unwrap();
+                        writeln!(out, "                    break").unwrap();
+                        writeln!(out, "                }}").unwrap();
+                        writeln!(out, "                seen.insert(id)").unwrap();
+                        writeln!(out, "                cur = node.{fname}").unwrap();
+                        writeln!(out, "            }}").unwrap();
+                        writeln!(out, "        }}").unwrap();
+                    }
+                    analyze::ConstraintInfo::FieldOrdering { left_field, op, right_field, .. } => {
+                        let lf = to_swift_field_name(left_field);
+                        let rf = to_swift_field_name(right_field);
+                        let (swift_op, negated_op) = match op {
+                            CompareOp::Lt => ("<", ">="),
+                            CompareOp::Gt => (">", "<="),
+                            CompareOp::Lte => ("<=", ">"),
+                            CompareOp::Gte => (">=", "<"),
+                            _ => continue,
+                        };
+                        writeln!(out, "        if {lf} {negated_op} {rf} {{").unwrap();
+                        writeln!(out, "            errors.append(\"{lf} must be {swift_op} {rf}\")").unwrap();
+                        writeln!(out, "        }}").unwrap();
+                    }
+                    analyze::ConstraintInfo::Implication { condition, consequent, .. } => {
+                        let cond = translate_validator_expr_swift(condition, &s.name);
+                        let cons = translate_validator_expr_swift(consequent, &s.name);
+                        let desc = format!("{} implies {}", analyze::describe_expr(condition), analyze::describe_expr(consequent));
+                        writeln!(out, "        if {cond} && !({cons}) {{").unwrap();
+                        writeln!(out, "            errors.append(\"{}\"))", desc.replace('"', "\\\"")).unwrap();
+                        writeln!(out, "        }}").unwrap();
+                    }
+                    analyze::ConstraintInfo::Iff { left, right, .. } => {
+                        let l = translate_validator_expr_swift(left, &s.name);
+                        let r = translate_validator_expr_swift(right, &s.name);
+                        let desc = format!("{} iff {}", analyze::describe_expr(left), analyze::describe_expr(right));
+                        writeln!(out, "        if ({l}) != ({r}) {{").unwrap();
+                        writeln!(out, "            errors.append(\"{}\"))", desc.replace('"', "\\\"")).unwrap();
+                        writeln!(out, "        }}").unwrap();
+                    }
+                    analyze::ConstraintInfo::Prohibition { condition, .. } => {
+                        let cond = translate_validator_expr_swift(condition, &s.name);
+                        let desc = analyze::describe_expr(condition);
+                        writeln!(out, "        if {cond} {{").unwrap();
+                        writeln!(out, "            errors.append(\"prohibited: {}\"))", desc.replace('"', "\\\"")).unwrap();
+                        writeln!(out, "        }}").unwrap();
+                    }
                     analyze::ConstraintInfo::Disjoint { left, right, .. } => {
                         let left_field = to_swift_field_name(left.rsplit('.').next().unwrap_or(left));
                         let right_field = to_swift_field_name(right.rsplit('.').next().unwrap_or(right));
@@ -275,6 +339,19 @@ fn generate_struct(out: &mut String, s: &StructureNode, ir: &OxidtrIR, ctx: &Swi
                         writeln!(out, "        }}").unwrap();
                     }
                     _ => {}
+                }
+            }
+            // Disj uniqueness checks for seq fields
+            for (dsig, dfield) in &disj {
+                if dsig == &s.name {
+                    if let Some(f) = s.fields.iter().find(|f| f.name == *dfield) {
+                        if f.mult == Multiplicity::Seq {
+                            let fname = to_swift_field_name(dfield);
+                            writeln!(out, "        if Set({fname}).count != {fname}.count {{").unwrap();
+                            writeln!(out, "            errors.append(\"{fname} must not contain duplicates (disj constraint)\")").unwrap();
+                            writeln!(out, "        }}").unwrap();
+                        }
+                    }
                 }
             }
             writeln!(out, "        return errors").unwrap();
@@ -1169,5 +1246,56 @@ fn expr_uses_tc(expr: &crate::parser::ast::Expr) -> bool {
         }
         Expr::FunApp { receiver, args, .. } => receiver.as_ref().map_or(false, |r| expr_uses_tc(r)) || args.iter().any(|a| expr_uses_tc(a)),
         Expr::VarRef(_) | Expr::IntLiteral(_) => false,
+    }
+}
+
+/// Translate an Alloy expression to Swift for single-instance validator context.
+fn translate_validator_expr_swift(expr: &crate::parser::ast::Expr, sig_name: &str) -> String {
+    use crate::parser::ast::{Expr, LogicOp, QuantKind};
+    match expr {
+        Expr::VarRef(name) => {
+            if name == sig_name { "self".to_string() } else { name.clone() }
+        }
+        Expr::IntLiteral(n) => n.to_string(),
+        Expr::FieldAccess { base, field } => {
+            format!("{}.{}", translate_validator_expr_swift(base, sig_name), to_swift_field_name(field))
+        }
+        Expr::Comparison { op, left, right } => {
+            let l = translate_validator_expr_swift(left, sig_name);
+            let r = translate_validator_expr_swift(right, sig_name);
+            let o = match op {
+                CompareOp::Eq => "==",
+                CompareOp::NotEq => "!=",
+                CompareOp::In => return format!("{r}.contains({l})"),
+                CompareOp::Lt => "<",
+                CompareOp::Gt => ">",
+                CompareOp::Lte => "<=",
+                CompareOp::Gte => ">=",
+            };
+            format!("{l} {o} {r}")
+        }
+        Expr::BinaryLogic { op, left, right } => {
+            let l = translate_validator_expr_swift(left, sig_name);
+            let r = translate_validator_expr_swift(right, sig_name);
+            match op {
+                LogicOp::And => format!("{l} && {r}"),
+                LogicOp::Or => format!("{l} || {r}"),
+                LogicOp::Implies => format!("!({l}) || {r}"),
+                LogicOp::Iff => format!("({l}) == ({r})"),
+            }
+        }
+        Expr::Not(inner) => format!("!({})", translate_validator_expr_swift(inner, sig_name)),
+        Expr::MultFormula { kind, expr: inner } => {
+            let e = translate_validator_expr_swift(inner, sig_name);
+            match kind {
+                QuantKind::Some => format!("{e} != nil"),
+                QuantKind::No => format!("{e} == nil"),
+                _ => e,
+            }
+        }
+        Expr::Cardinality(inner) => {
+            format!("{}.count", translate_validator_expr_swift(inner, sig_name))
+        }
+        _ => analyze::describe_expr(expr), // fallback: human-readable
     }
 }

--- a/src/extract/swift_extractor.rs
+++ b/src/extract/swift_extractor.rs
@@ -92,14 +92,20 @@ fn collect_struct_fields(
 
     for (_ln, line) in lines.by_ref() {
         let trimmed = line.trim();
+        // Track depth before processing the line
+        let depth_before = depth;
         for ch in trimmed.chars() {
             match ch { '{' => depth += 1, '}' => depth -= 1, _ => {} }
         }
         if depth == 0 { break; }
 
-        // "let name: Type" or "var name: Type"
-        if let Some(field) = parse_swift_property(trimmed) {
-            fields.push(field);
+        // Only parse fields at top level of the struct (depth 1),
+        // not inside nested blocks (func validate(), closures, etc.)
+        if depth_before == 1 {
+            // "let name: Type" or "var name: Type"
+            if let Some(field) = parse_swift_property(trimmed) {
+                fields.push(field);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- 全9種の制約バリデーション（NoSelfRef, Acyclic, FieldOrdering, Implication, Iff, Prohibition, Disjoint, Exhaustive, DisjUniqueness）を全7バックエンド（Rust, TypeScript, Kotlin, Java, Swift, Go, C#）でランタイム検証コード生成に対応
- 各バックエンドに `translate_validator_expr_*` 関数を新設し、Alloy制約式をターゲット言語に変換
- Kotlin/Java: DOC/コメントのみだった NoSelfRef/Acyclic/Implication を `require()`/`throw` によるランタイム検証に昇格
- Swift/Go/C#: `validate()` メソッドを拡張し、全制約タイプに対応
- Go Exhaustive: コメントのみだった実装を実バリデーションコードに修正
- CLAUDE.md のロードマップを更新

## Test plan

- [x] `cargo build` — zero warnings
- [x] `cargo test` — all tests pass (including self-hosting, round-trip, guarantee tests)
- [ ] `cargo test --test target_validation -- --include-ignored` で各言語の外部ツールチェイン検証

https://claude.ai/code/session_01Feh359TRUTM3eq2BArqSEU