### PR TITLE
feat: Alloy native type alias mapping (Str/Int/Float/Bool)

### DIFF
--- a/src/backend/csharp/mod.rs
+++ b/src/backend/csharp/mod.rs
@@ -1,10 +1,9 @@
 pub mod expr_translator;
 
-use crate::backend::GeneratedFile;
+use crate::backend::{self, GeneratedFile, TargetLang, is_native_type_alias, resolve_type};
 use crate::ir::nodes::*;
 use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity};
 use crate::analyze;
-use crate::backend;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 
@@ -80,6 +79,7 @@ fn generate_models(ir: &OxidtrIR, ctx: &CsContext) -> String {
 
     for s in &ir.structures {
         if ctx.is_variant(&s.name) { continue; }
+        if is_native_type_alias(&s.name) { continue; }
 
         if s.is_enum {
             generate_enum(&mut out, s, ctx);
@@ -162,7 +162,8 @@ fn generate_class(out: &mut String, s: &StructureNode, ir: &OxidtrIR, _ctx: &CsC
         if f.mult == Multiplicity::Seq {
             writeln!(out, "    // @alloy: seq").unwrap();
         }
-        let type_str = mult_to_cs_type(&f.target, &f.mult);
+        let resolved_target = resolve_type(TargetLang::CSharp, &f.target);
+        let type_str = mult_to_cs_type(&resolved_target, &f.mult);
         writeln!(out, "    public {} {} {{ get; set; }}", type_str, capitalize(&f.name)).unwrap();
     }
 

--- a/src/backend/go/mod.rs
+++ b/src/backend/go/mod.rs
@@ -1,6 +1,6 @@
 pub mod expr_translator;
 
-use crate::backend::GeneratedFile;
+use crate::backend::{GeneratedFile, TargetLang, is_native_type_alias, resolve_type};
 use crate::ir::nodes::*;
 use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity, TemporalBinaryOp};
 use crate::analyze;
@@ -129,6 +129,7 @@ fn generate_models(ir: &OxidtrIR, ctx: &GoContext) -> String {
 
     for s in &ir.structures {
         if ctx.is_variant(&s.name) { continue; }
+        if is_native_type_alias(&s.name) { continue; }
 
         let constraint_names = analyze::constraint_names_for_sig(ir, &s.name);
         if !constraint_names.is_empty() {
@@ -204,10 +205,12 @@ fn generate_struct(out: &mut String, s: &StructureNode, ir: &OxidtrIR, ctx: &GoC
     } else {
         writeln!(out, "type {} struct {{", s.name).unwrap();
         for f in &s.fields {
+            let resolved_target = resolve_type(TargetLang::Go, &f.target);
             let type_str = if let Some(vt) = &f.value_type {
-                format!("map[{}]{}", f.target, vt)
+                let resolved_vt = resolve_type(TargetLang::Go, vt);
+                format!("map[{}]{}", resolved_target, resolved_vt)
             } else {
-                mult_to_go_type(&f.target, &f.mult, ctx.cyclic_fields.contains(&(s.name.clone(), f.name.clone())))
+                mult_to_go_type(&resolved_target, &f.mult, ctx.cyclic_fields.contains(&(s.name.clone(), f.name.clone())))
             };
 
             // Comments for special patterns

--- a/src/backend/jvm/java.rs
+++ b/src/backend/jvm/java.rs
@@ -1,6 +1,6 @@
 use super::{JvmContext, expr_translator};
 use super::expr_translator::JvmLang;
-use crate::backend::GeneratedFile;
+use crate::backend::{GeneratedFile, TargetLang, is_native_type_alias, resolve_type};
 use crate::ir::nodes::*;
 use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity, TemporalBinaryOp};
 use crate::analyze;
@@ -104,6 +104,7 @@ fn generate_models(ir: &OxidtrIR, ctx: &JvmContext) -> String {
             continue;
         }
         if ctx.is_variant(&s.name) { continue; }
+        if is_native_type_alias(&s.name) { continue; }
 
         let constraint_names = analyze::constraint_names_for_sig(ir, &s.name);
         if !constraint_names.is_empty() {
@@ -250,8 +251,10 @@ fn generate_record(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_fiel
                 } else {
                     format!("{} ", annotations.join(" "))
                 };
+                let resolved_target = resolve_type(TargetLang::Java, &f.target);
                 let java_type = if let Some(vt) = &f.value_type {
-                    format!("Map<{}, {}>", f.target, vt)
+                    let resolved_vt = resolve_type(TargetLang::Java, vt);
+                    format!("Map<{}, {}>", resolved_target, resolved_vt)
                 } else if let Some(_raw) = &f.raw_union_type {
                     // Union types → Object
                     match f.mult {
@@ -261,7 +264,7 @@ fn generate_record(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_fiel
                         Multiplicity::One  => "Object".to_string(),
                     }
                 } else {
-                    mult_to_java_type(&f.target, &f.mult)
+                    mult_to_java_type(&resolved_target, &f.mult)
                 };
                 (annotation_str, java_type, f.is_var)
             })
@@ -424,12 +427,14 @@ fn generate_sealed_interface(out: &mut String, s: &StructureNode, ctx: &JvmConte
                 if !all_fields.is_empty() {
                     let params: Vec<String> = all_fields.iter()
                         .map(|f| {
+                            let resolved = resolve_type(TargetLang::Java, &f.target);
                             let t = if let Some(vt) = &f.value_type {
-                                format!("Map<{}, {}>", f.target, vt)
+                                let rv = resolve_type(TargetLang::Java, vt);
+                                format!("Map<{}, {}>", resolved, rv)
                             } else if let Some(_raw) = &f.raw_union_type {
                                 "Object".to_string()
                             } else {
-                                mult_to_java_type(&f.target, &f.mult)
+                                mult_to_java_type(&resolved, &f.mult)
                             };
                             format!("{} {}", t, f.name)
                         })

--- a/src/backend/jvm/kotlin.rs
+++ b/src/backend/jvm/kotlin.rs
@@ -1,6 +1,6 @@
 use super::{JvmContext, expr_translator};
 use super::expr_translator::JvmLang;
-use crate::backend::GeneratedFile;
+use crate::backend::{GeneratedFile, TargetLang, is_native_type_alias, resolve_type};
 use crate::ir::nodes::*;
 use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity, TemporalBinaryOp};
 use crate::analyze;
@@ -92,6 +92,7 @@ fn generate_models(ir: &OxidtrIR, ctx: &JvmContext) -> String {
             continue;
         }
         if ctx.is_variant(&s.name) { continue; }
+        if is_native_type_alias(&s.name) { continue; }
 
         let constraint_names = analyze::constraint_names_for_sig(ir, &s.name);
         if !constraint_names.is_empty() {
@@ -184,8 +185,10 @@ fn generate_data_class(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_
     {
         writeln!(out, "data class {}(", s.name).unwrap();
         for (i, f) in s.fields.iter().enumerate() {
+            let resolved_target = resolve_type(TargetLang::Kotlin, &f.target);
             let type_str = if let Some(vt) = &f.value_type {
-                format!("Map<{}, {}>", f.target, vt)
+                let resolved_vt = resolve_type(TargetLang::Kotlin, vt);
+                format!("Map<{}, {}>", resolved_target, resolved_vt)
             } else if let Some(_raw) = &f.raw_union_type {
                 // Union types → Any (Kotlin lacks field-level union types without sealed classes)
                 match f.mult {
@@ -195,7 +198,7 @@ fn generate_data_class(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_
                     Multiplicity::One  => "Any".to_string(),
                 }
             } else {
-                mult_to_kt_type(&f.target, &f.mult)
+                mult_to_kt_type(&resolved_target, &f.mult)
             };
             let comma = if i < s.fields.len() - 1 { "," } else { "" };
             // Bean Validation annotations

--- a/src/backend/lean/mod.rs
+++ b/src/backend/lean/mod.rs
@@ -1,6 +1,6 @@
 pub mod expr_translator;
 
-use crate::backend::GeneratedFile;
+use crate::backend::{GeneratedFile, TargetLang, is_native_type_alias, resolve_type};
 use crate::ir::nodes::*;
 use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity};
 use crate::analyze;
@@ -106,6 +106,7 @@ fn generate_types(ir: &OxidtrIR, ctx: &LeanContext) -> String {
 
     for s in &ir.structures {
         if ctx.is_variant(&s.name) { continue; }
+        if is_native_type_alias(&s.name) { continue; }
 
         let constraint_names = analyze::constraint_names_for_sig(ir, &s.name);
         if !constraint_names.is_empty() {
@@ -259,10 +260,13 @@ fn generate_derived_fields(out: &mut String, ir: &OxidtrIR) {
 
 fn field_type_str(f: &IRField, _ctx: &LeanContext) -> String {
     if let Some(vt) = &f.value_type {
+        let resolved_key = resolve_type(TargetLang::Lean, &f.target);
+        let resolved_val = resolve_type(TargetLang::Lean, vt);
         // Map type: Key → Value as List (Key × Value)
-        return format!("List ({} × {})", f.target, vt);
+        return format!("List ({} × {})", resolved_key, resolved_val);
     }
-    lean_mult_type(&f.target, &f.mult)
+    let resolved = resolve_type(TargetLang::Lean, &f.target);
+    lean_mult_type(&resolved, &f.mult)
 }
 
 fn lean_mult_type(target: &str, mult: &Multiplicity) -> String {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -17,6 +17,100 @@ pub struct GeneratedFile {
     pub content: String,
 }
 
+// ── Alloy native type aliases ───────────────────────────────────────────────
+//
+// Alloy has no primitive types — everything is a sig instance.  These marker
+// sig names are mapped to language-native primitives by each backend so that
+// `sig Str {}` is never emitted as `pub struct Str;` but instead the field
+// type becomes `String` (Rust), `string` (TS/Go), etc.
+
+/// Returns `true` if `name` is a well-known Alloy marker sig that should be
+/// mapped to a native primitive type rather than emitted as a struct/class.
+pub fn is_native_type_alias(name: &str) -> bool {
+    matches!(name, "Str" | "Int" | "Float" | "Bool")
+}
+
+/// Target-language enum for native type resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetLang {
+    Rust,
+    TypeScript,
+    Kotlin,
+    Java,
+    Swift,
+    Go,
+    CSharp,
+    Lean,
+}
+
+/// Map an Alloy native-alias sig name to the corresponding language primitive.
+/// Returns `None` if `name` is not a native alias.
+pub fn native_type_for(lang: TargetLang, name: &str) -> Option<&'static str> {
+    match name {
+        "Str" => Some(match lang {
+            TargetLang::Rust => "String",
+            TargetLang::TypeScript => "string",
+            TargetLang::Kotlin => "String",
+            TargetLang::Java => "String",
+            TargetLang::Swift => "String",
+            TargetLang::Go => "string",
+            TargetLang::CSharp => "string",
+            TargetLang::Lean => "String",
+        }),
+        "Int" => Some(match lang {
+            TargetLang::Rust => "i64",
+            TargetLang::TypeScript => "number",
+            TargetLang::Kotlin => "Long",
+            TargetLang::Java => "long",
+            TargetLang::Swift => "Int",
+            TargetLang::Go => "int64",
+            TargetLang::CSharp => "long",
+            TargetLang::Lean => "Int",
+        }),
+        "Float" => Some(match lang {
+            TargetLang::Rust => "f64",
+            TargetLang::TypeScript => "number",
+            TargetLang::Kotlin => "Double",
+            TargetLang::Java => "double",
+            TargetLang::Swift => "Double",
+            TargetLang::Go => "float64",
+            TargetLang::CSharp => "double",
+            TargetLang::Lean => "Float",
+        }),
+        "Bool" => Some(match lang {
+            TargetLang::Rust => "bool",
+            TargetLang::TypeScript => "boolean",
+            TargetLang::Kotlin => "Boolean",
+            TargetLang::Java => "boolean",
+            TargetLang::Swift => "Bool",
+            TargetLang::Go => "bool",
+            TargetLang::CSharp => "bool",
+            TargetLang::Lean => "Bool",
+        }),
+        _ => None,
+    }
+}
+
+/// Resolve a type name: if it's a native alias, return the mapped name;
+/// otherwise return the original name unchanged.
+pub fn resolve_type(lang: TargetLang, name: &str) -> String {
+    native_type_for(lang, name)
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| name.to_string())
+}
+
+/// Reverse-map a language primitive back to the Alloy alias name.
+/// Used by `check` and `extract` to compare impl types against the model.
+pub fn reverse_native_type(lang: TargetLang, native: &str) -> Option<&'static str> {
+    // Check each alias
+    for alias in &["Str", "Int", "Float", "Bool"] {
+        if native_type_for(lang, alias) == Some(native) {
+            return Some(alias);
+        }
+    }
+    None
+}
+
 /// Detect direct ownership pattern: `all x: A | some y: B | x in y.field`
 /// Returns (owned_param_name, owner_param_name, field_name) using the
 /// provided name-transform function to build param names from type names.
@@ -81,7 +175,8 @@ pub fn collect_fixture_types(ir: &OxidtrIR) -> HashSet<String> {
         .filter(|s| s.parent.as_ref().map_or(false, |p| enum_parents.contains(p)))
         .map(|s| s.name.clone()).collect();
     ir.structures.iter()
-        .filter(|s| !variant_names.contains(&s.name) && !s.is_enum && !s.fields.is_empty())
+        .filter(|s| !variant_names.contains(&s.name) && !s.is_enum && !s.fields.is_empty()
+            && !is_native_type_alias(&s.name))
         .map(|s| s.name.clone())
         .collect()
 }

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -1,6 +1,6 @@
 pub mod expr_translator;
 
-use super::GeneratedFile;
+use super::{GeneratedFile, TargetLang, is_native_type_alias, resolve_type};
 use crate::ir::nodes::*;
 use crate::parser::ast::{CompareOp, Expr, Multiplicity, SigMultiplicity, TemporalBinaryOp};
 use crate::analyze;
@@ -163,6 +163,10 @@ fn generate_models_inner(ir: &OxidtrIR, use_serde: bool) -> String {
     for s in &ir.structures {
         // Skip variant sigs — they become enum variants
         if variant_names.contains(&s.name) {
+            continue;
+        }
+        // Skip native type aliases (Str, Int, Float, Bool)
+        if is_native_type_alias(&s.name) {
             continue;
         }
 
@@ -334,12 +338,14 @@ fn generate_struct(
             // Gap 1 & 3: annotations for sig multiplicity and disj constraints
             write_field_annotations_rust(out, ir, &s.name, f, "    ", disj_fields);
             let is_self_ref = self_ref_fields.contains(&(s.name.clone(), f.name.clone()));
+            let resolved_target = resolve_type(TargetLang::Rust, &f.target);
             let type_str = if let Some(vt) = &f.value_type {
-                format!("BTreeMap<{}, {}>", f.target, vt)
+                let resolved_vt = resolve_type(TargetLang::Rust, vt);
+                format!("BTreeMap<{}, {}>", resolved_target, resolved_vt)
             } else if let Some(raw) = &f.raw_union_type {
                 rust_union_type(raw, &f.mult)
             } else {
-                multiplicity_to_type(&f.target, &f.mult, is_self_ref)
+                multiplicity_to_type(&resolved_target, &f.mult, is_self_ref)
             };
             if f.is_var {
                 writeln!(out, "    /// MUTABLE: this field changes across state transitions").unwrap();
@@ -543,7 +549,8 @@ fn generate_tests(ir: &OxidtrIR) -> String {
         .filter(|s| s.parent.as_ref().map_or(false, |p| enum_parents.contains(p)))
         .map(|s| s.name.clone()).collect();
     let has_fixture: HashSet<String> = ir.structures.iter()
-        .filter(|s| !variant_names_set.contains(&s.name) && !s.is_enum && !s.fields.is_empty())
+        .filter(|s| !variant_names_set.contains(&s.name) && !s.is_enum && !s.fields.is_empty()
+            && !is_native_type_alias(&s.name))
         .map(|s| s.name.clone()).collect();
 
     // Check if any expression uses TC functions → need helpers import
@@ -1781,6 +1788,7 @@ fn generate_fixtures(ir: &OxidtrIR) -> String {
 
     for s in &ir.structures {
         if variant_names.contains(&s.name) || s.is_enum { continue; }
+        if is_native_type_alias(&s.name) { continue; }
 
         let struct_snake = to_snake_case(&s.name);
 
@@ -2007,6 +2015,21 @@ fn default_value_for_field_inner(
     target: &str, mult: &Multiplicity, is_boxed: bool,
     has_fixture: &HashSet<String>,
 ) -> String {
+    // Native type aliases get language-native default values
+    if let Some(native_default) = rust_native_default(target) {
+        return match mult {
+            Multiplicity::Lone => "None".to_string(),
+            Multiplicity::Set => format!("BTreeSet::from([{native_default}])"),
+            Multiplicity::Seq => format!("vec![{native_default}]"),
+            Multiplicity::One => {
+                if is_boxed {
+                    format!("Box::new({native_default})")
+                } else {
+                    native_default.to_string()
+                }
+            }
+        };
+    }
     match mult {
         Multiplicity::Lone => "None".to_string(),
         Multiplicity::Set => {
@@ -2030,6 +2053,17 @@ fn default_value_for_field_inner(
                 format!("default_{}()", to_snake_case(target))
             }
         }
+    }
+}
+
+/// Returns a Rust default value literal for a native type alias.
+fn rust_native_default(alloy_name: &str) -> Option<&'static str> {
+    match alloy_name {
+        "Str" => Some("String::new()"),
+        "Int" => Some("0i64"),
+        "Float" => Some("0.0f64"),
+        "Bool" => Some("false"),
+        _ => None,
     }
 }
 

--- a/src/backend/swift/mod.rs
+++ b/src/backend/swift/mod.rs
@@ -1,6 +1,6 @@
 pub mod expr_translator;
 
-use crate::backend::GeneratedFile;
+use crate::backend::{GeneratedFile, TargetLang, is_native_type_alias, resolve_type};
 use crate::ir::nodes::*;
 use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity, TemporalBinaryOp};
 use crate::analyze;
@@ -130,6 +130,7 @@ fn generate_models(ir: &OxidtrIR, ctx: &SwiftContext) -> String {
 
     for s in &ir.structures {
         if ctx.is_variant(&s.name) { continue; }
+        if is_native_type_alias(&s.name) { continue; }
 
         let constraint_names = analyze::constraint_names_for_sig(ir, &s.name);
         if !constraint_names.is_empty() {
@@ -220,10 +221,12 @@ fn generate_struct(out: &mut String, s: &StructureNode, ir: &OxidtrIR, ctx: &Swi
     } else {
         writeln!(out, "struct {}: Equatable {{", s.name).unwrap();
         for f in &s.fields {
+            let resolved_target = resolve_type(TargetLang::Swift, &f.target);
             let type_str = if let Some(vt) = &f.value_type {
-                format!("[{}: {}]", f.target, vt)
+                let resolved_vt = resolve_type(TargetLang::Swift, vt);
+                format!("[{}: {}]", resolved_target, resolved_vt)
             } else {
-                mult_to_swift_type(&f.target, &f.mult, ctx.cyclic_fields.contains(&(s.name.clone(), f.name.clone())))
+                mult_to_swift_type(&resolved_target, &f.mult, ctx.cyclic_fields.contains(&(s.name.clone(), f.name.clone())))
             };
 
             // Comments for special patterns

--- a/src/backend/typescript/mod.rs
+++ b/src/backend/typescript/mod.rs
@@ -1,6 +1,6 @@
 pub mod expr_translator;
 
-use super::GeneratedFile;
+use super::{GeneratedFile, TargetLang, is_native_type_alias, resolve_type};
 use crate::ir::nodes::*;
 use crate::parser::ast::{CompareOp, Multiplicity, SigMultiplicity, TemporalBinaryOp};
 use crate::analyze;
@@ -113,6 +113,10 @@ fn generate_models(ir: &OxidtrIR) -> String {
         if variant_names.contains(&s.name) {
             continue;
         }
+        // Skip native type aliases (Str, Int, Float, Bool)
+        if is_native_type_alias(&s.name) {
+            continue;
+        }
 
         // Intersection type alias: type Foo = A & B & C
         if !s.intersection_of.is_empty() {
@@ -213,8 +217,10 @@ fn generate_interface(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_f
         for f in &s.fields {
             // Gap 1 & 3: annotations for sig multiplicity and disj constraints
             write_field_annotations_ts(out, ir, &s.name, f, disj_fields);
+            let resolved_target = resolve_type(TargetLang::TypeScript, &f.target);
             let type_str = if let Some(vt) = &f.value_type {
-                format!("Map<{}, {}>", f.target, vt)
+                let resolved_vt = resolve_type(TargetLang::TypeScript, vt);
+                format!("Map<{}, {}>", resolved_target, resolved_vt)
             } else if let Some(raw) = &f.raw_union_type {
                 // Preserve raw union type (e.g. "number | string") from source language
                 if f.mult == Multiplicity::Lone {
@@ -223,7 +229,7 @@ fn generate_interface(out: &mut String, s: &StructureNode, ir: &OxidtrIR, disj_f
                     raw.clone()
                 }
             } else {
-                mult_to_ts_type(&f.target, &f.mult)
+                mult_to_ts_type(&resolved_target, &f.mult)
             };
             let readonly = if f.is_var { "" } else { "readonly " };
             if f.is_var {
@@ -299,8 +305,10 @@ fn generate_union_type(
             writeln!(out, "export interface {} {{", v).unwrap();
             writeln!(out, "  readonly kind: \"{}\";", v).unwrap();
             for f in &all_fields {
+                let resolved_target = resolve_type(TargetLang::TypeScript, &f.target);
                 let type_str = if let Some(vt) = &f.value_type {
-                    format!("Map<{}, {}>", f.target, vt)
+                    let resolved_vt = resolve_type(TargetLang::TypeScript, vt);
+                    format!("Map<{}, {}>", resolved_target, resolved_vt)
                 } else if let Some(raw) = &f.raw_union_type {
                     if f.mult == Multiplicity::Lone {
                         format!("{} | null", raw)
@@ -308,7 +316,7 @@ fn generate_union_type(
                         raw.clone()
                     }
                 } else {
-                    mult_to_ts_type(&f.target, &f.mult)
+                    mult_to_ts_type(&resolved_target, &f.mult)
                 };
                 let readonly = if f.is_var { "" } else { "readonly " };
                 writeln!(out, "  {readonly}{}: {};", f.name, type_str).unwrap();

--- a/src/check/impl_parser.rs
+++ b/src/check/impl_parser.rs
@@ -1,6 +1,7 @@
 /// Parses oxidtr-generated Rust files to extract structural information.
 /// Uses format-specific lightweight parsing (not syn) since we know the output format.
 
+use crate::backend::{TargetLang, reverse_native_type};
 use crate::parser::ast::Multiplicity;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -210,24 +211,32 @@ fn extract_fn_name(line: &str) -> Option<String> {
 
 /// Reverse-maps a Rust type string to Multiplicity.
 /// e.g. "Option<Foo>" -> Lone, "Vec<Foo>" -> Set, "Foo" -> One
+/// Also reverse-maps native types: "String" -> "Str", "i64" -> "Int", etc.
 pub fn type_to_mult(rust_type: &str) -> (Multiplicity, String) {
     let t = rust_type.trim();
     if let Some(inner) = strip_wrapper(t, "BTreeSet<", ">") {
-        return (Multiplicity::Set, inner.to_string());
+        return (Multiplicity::Set, reverse_rust_native(inner));
     }
     if let Some(inner) = strip_wrapper(t, "Vec<", ">") {
-        return (Multiplicity::Seq, inner.to_string());
+        return (Multiplicity::Seq, reverse_rust_native(inner));
     }
     if let Some(inner) = strip_wrapper(t, "Option<Box<", ">>") {
-        return (Multiplicity::Lone, inner.to_string());
+        return (Multiplicity::Lone, reverse_rust_native(inner));
     }
     if let Some(inner) = strip_wrapper(t, "Option<", ">") {
-        return (Multiplicity::Lone, inner.to_string());
+        return (Multiplicity::Lone, reverse_rust_native(inner));
     }
     if let Some(inner) = strip_wrapper(t, "Box<", ">") {
-        return (Multiplicity::One, inner.to_string());
+        return (Multiplicity::One, reverse_rust_native(inner));
     }
-    (Multiplicity::One, t.to_string())
+    (Multiplicity::One, reverse_rust_native(t))
+}
+
+/// Reverse-map a Rust native type back to the Alloy alias if applicable.
+fn reverse_rust_native(name: &str) -> String {
+    reverse_native_type(TargetLang::Rust, name)
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| name.to_string())
 }
 
 fn strip_wrapper<'a>(s: &'a str, prefix: &str, suffix: &str) -> Option<&'a str> {

--- a/tests/backend_rust.rs
+++ b/tests/backend_rust.rs
@@ -724,3 +724,66 @@ fn rust_non_receiver_fun_still_in_operations() {
     let ops = find_file(&files, "operations.rs");
     assert!(ops.contains("fn get_role("), "non-receiver fun should remain in operations.rs:\n{ops}");
 }
+
+// ── Native type alias mapping ───────────────────────────────────────────────
+
+#[test]
+fn rust_native_str_maps_to_string() {
+    let files = generate_from(r#"
+        sig Str {}
+        sig User { name: one Str }
+    "#);
+    let models = find_file(&files, "models.rs");
+    assert!(!models.contains("pub struct Str"), "Str sig should not be emitted as struct:\n{models}");
+    assert!(models.contains("pub name: String,"), "Str field should map to String:\n{models}");
+}
+
+#[test]
+fn rust_native_int_maps_to_i64() {
+    let files = generate_from(r#"
+        sig Int {}
+        sig Counter { value: one Int }
+    "#);
+    let models = find_file(&files, "models.rs");
+    assert!(!models.contains("pub struct Int"), "Int sig should not be emitted:\n{models}");
+    assert!(models.contains("pub value: i64,"), "Int field should map to i64:\n{models}");
+}
+
+#[test]
+fn rust_native_float_maps_to_f64() {
+    let files = generate_from(r#"
+        sig Float {}
+        sig Measurement { reading: one Float }
+    "#);
+    let models = find_file(&files, "models.rs");
+    assert!(!models.contains("pub struct Float"), "Float sig should not be emitted:\n{models}");
+    assert!(models.contains("pub reading: f64,"), "Float field should map to f64:\n{models}");
+}
+
+#[test]
+fn rust_native_bool_maps_to_bool() {
+    let files = generate_from(r#"
+        sig Bool {}
+        sig Flag { active: one Bool }
+    "#);
+    let models = find_file(&files, "models.rs");
+    assert!(!models.contains("pub struct Bool"), "Bool sig should not be emitted:\n{models}");
+    assert!(models.contains("pub active: bool,"), "Bool field should map to bool:\n{models}");
+}
+
+#[test]
+fn rust_native_type_with_multiplicities() {
+    let files = generate_from(r#"
+        sig Str {}
+        sig Int {}
+        sig Item {
+            tags: set Str,
+            label: lone Str,
+            scores: seq Int
+        }
+    "#);
+    let models = find_file(&files, "models.rs");
+    assert!(models.contains("pub tags: BTreeSet<String>,"), "set Str → BTreeSet<String>:\n{models}");
+    assert!(models.contains("pub label: Option<String>,"), "lone Str → Option<String>:\n{models}");
+    assert!(models.contains("pub scores: Vec<i64>,"), "seq Int → Vec<i64>:\n{models}");
+}

--- a/tests/backend_ts.rs
+++ b/tests/backend_ts.rs
@@ -388,3 +388,40 @@ fn ts_derived_field_generates_method() {
     let models = find_file(&files, "models.ts");
     assert!(models.contains("balance(): M.Int"), "should generate method on class:\n{models}");
 }
+
+// ── Native type alias mapping ───────────────────────────────────────────────
+
+#[test]
+fn ts_native_str_maps_to_string() {
+    let files = generate_from(r#"
+        sig Str {}
+        sig User { name: one Str }
+    "#);
+    let models = find_file(&files, "models.ts");
+    assert!(!models.contains("export interface Str"), "Str sig should not be emitted:\n{models}");
+    assert!(models.contains("name: string;"), "Str field should map to string:\n{models}");
+}
+
+#[test]
+fn ts_native_int_maps_to_number() {
+    let files = generate_from(r#"
+        sig Int {}
+        sig Counter { value: one Int, items: set Int }
+    "#);
+    let models = find_file(&files, "models.ts");
+    assert!(!models.contains("export interface Int"), "Int sig should not be emitted:\n{models}");
+    assert!(models.contains("value: number;"), "Int field should map to number:\n{models}");
+    assert!(models.contains("items: Set<number>;"), "set Int → Set<number>:\n{models}");
+}
+
+#[test]
+fn ts_native_bool_maps_to_boolean() {
+    let files = generate_from(r#"
+        sig Bool {}
+        sig Flag { active: one Bool, flags: seq Bool }
+    "#);
+    let models = find_file(&files, "models.ts");
+    assert!(!models.contains("export interface Bool"), "Bool sig should not be emitted:\n{models}");
+    assert!(models.contains("active: boolean;"), "Bool field should map to boolean:\n{models}");
+    assert!(models.contains("flags: boolean[];"), "seq Bool → boolean[]:\n{models}");
+}


### PR DESCRIPTION
## Summary

- **Alloyにはプリミティブ型がない**（全てがsigインスタンス）ため、`Str`/`Int`/`Float`/`Bool`というマーカーsig名を各バックエンドが言語ネイティブのプリミティブ型に自動マッピングする機能を追加
- `sig Str {}` は `pub struct Str;` として生成されず、フィールド型が直接 `String`（Rust）、`string`（TS）等になる
- 全7バックエンド（Rust/TS/Kotlin/Java/Swift/Go/C#/Lean）対応、check/impl_parserの逆変換、fixture生成のネイティブデフォルト値も対応

### マッピングテーブル

| Alloy | Rust | TS | Kotlin | Java | Swift | Go | C# | Lean |
|-------|------|----|--------|------|-------|----|----|------|
| `Str` | `String` | `string` | `String` | `String` | `String` | `string` | `string` | `String` |
| `Int` | `i64` | `number` | `Long` | `long` | `Int` | `int64` | `long` | `Int` |
| `Float` | `f64` | `number` | `Double` | `double` | `Double` | `float64` | `double` | `Float` |
| `Bool` | `bool` | `boolean` | `Boolean` | `boolean` | `Bool` | `bool` | `bool` | `Bool` |

### 変更点

- `src/backend/mod.rs`: 共有関数 `is_native_type_alias`/`resolve_type`/`reverse_native_type` 追加
- 全7バックエンド: sig生成スキップ + フィールド型解決
- `src/check/impl_parser.rs`: Rust型→Alloyエイリアスの逆変換
- Fixture生成: ネイティブデフォルト値（`String::new()`, `0i64`, `false`等）
- 8件の新規テスト（Rust 5件 + TS 3件）

## Test plan

- [x] `cargo test` 全847テスト通過
- [x] ゼロwarning
- [x] 既存セルフホストテスト（self_hosting, round_trip等）に影響なし

https://claude.ai/code/session_01EiBTL4U1KeaTsKppNmmRd1