### PR TITLE
Add modular layout support for Rust code generation

### DIFF
--- a/models/oxidtr.als
+++ b/models/oxidtr.als
@@ -6,6 +6,8 @@
 -- Alloy AST (parser output)
 -------------------------------------------------------------------------------
 
+module ast
+
 abstract sig Multiplicity {}
 one sig One  extends Multiplicity {}
 one sig Lone extends Multiplicity {}
@@ -219,6 +221,8 @@ fact FunParamsCardinality  { all f: FunDecl | #f.funParams = #f.funParams }
 -- oxidtr IR (lowered from AST)
 -------------------------------------------------------------------------------
 
+module ir
+
 sig StructureNode {
   origin:    one SigDecl,
   irIsVarSig: lone StructureNode,  -- Alloy 6: var sig marker
@@ -277,6 +281,8 @@ fun OxidtrIR.origin: one AlloyModel {
 -------------------------------------------------------------------------------
 -- Constraint analysis (ConstraintInfo variants)
 -------------------------------------------------------------------------------
+
+module analysis
 
 sig FieldOrdering {
   foSig:        one StructureNode,
@@ -346,6 +352,8 @@ sig FactCoverage {
 -------------------------------------------------------------------------------
 -- Validated newtypes (Rust TryFrom wrappers for constrained sigs)
 -------------------------------------------------------------------------------
+
+module validated
 
 sig ValidatedSigDecl       { vSigDecl:       one SigDecl }
 sig ValidatedFieldDecl     { vFieldDecl:     one FieldDecl }

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -18,6 +18,12 @@ pub struct RustBackendConfig {
 }
 
 pub fn generate_with_config(ir: &OxidtrIR, config: &RustBackendConfig) -> Vec<GeneratedFile> {
+    // If any structure has a module, use module-based layout
+    let has_modules = ir.structures.iter().any(|s| s.module.is_some());
+    if has_modules {
+        return generate_modular(ir, config);
+    }
+
     let mut files = Vec::new();
 
     files.push(GeneratedFile {
@@ -66,6 +72,479 @@ pub fn generate_with_config(ir: &OxidtrIR, config: &RustBackendConfig) -> Vec<Ge
     }
 
     files
+}
+
+/// Group structures into "concepts": abstract sig + all sub-sigs form one concept,
+/// standalone sigs form individual concepts.
+fn group_into_concepts<'a>(structures: &[&'a StructureNode]) -> Vec<(String, Vec<&'a StructureNode>)> {
+    let enum_parents: HashSet<String> = structures.iter()
+        .filter(|s| s.is_enum)
+        .map(|s| s.name.clone())
+        .collect();
+
+    // Build parent→children map
+    let mut children_of: HashMap<String, Vec<&'a StructureNode>> = HashMap::new();
+
+    for s in structures {
+        if super::is_native_type_alias(&s.name) {
+            continue;
+        }
+        if let Some(parent) = &s.parent {
+            if enum_parents.contains(parent) {
+                // This is an enum variant — grouped with parent
+                children_of.entry(parent.clone()).or_default().push(s);
+            }
+        }
+    }
+
+    let mut concepts: Vec<(String, Vec<&'a StructureNode>)> = Vec::new();
+    let mut emitted: HashSet<String> = HashSet::new();
+
+    for s in structures {
+        if emitted.contains(&s.name) || super::is_native_type_alias(&s.name) {
+            continue;
+        }
+        // Skip enum variants — they'll be grouped with their parent
+        if s.parent.as_ref().map_or(false, |p| enum_parents.contains(p)) {
+            continue;
+        }
+        let mut members = vec![*s];
+        if let Some(kids) = children_of.get(&s.name) {
+            for k in kids {
+                members.push(k);
+                emitted.insert(k.name.clone());
+            }
+        }
+        emitted.insert(s.name.clone());
+        concepts.push((s.name.clone(), members));
+    }
+    concepts
+}
+
+/// Generate module-based layout: each module gets a subdirectory,
+/// each domain concept gets its own file within that module.
+fn generate_modular(ir: &OxidtrIR, config: &RustBackendConfig) -> Vec<GeneratedFile> {
+    let use_serde = config.features.contains(&"serde".to_string());
+    let mut files = Vec::new();
+
+    // Group structures by module
+    let mut module_order: Vec<String> = Vec::new();
+    let mut by_module: HashMap<String, Vec<&StructureNode>> = HashMap::new();
+    let mut ungrouped: Vec<&StructureNode> = Vec::new();
+
+    for s in &ir.structures {
+        if let Some(m) = &s.module {
+            by_module.entry(m.clone()).or_default().push(s);
+            if !module_order.contains(m) {
+                module_order.push(m.clone());
+            }
+        } else {
+            ungrouped.push(s);
+        }
+    }
+
+    // Collect all type names across the entire IR (for cross-module imports)
+    let all_type_names: HashSet<String> = ir.structures.iter()
+        .map(|s| s.name.clone())
+        .collect();
+
+    // Track which types are defined in which module (for import resolution)
+    let mut type_to_module: HashMap<String, String> = HashMap::new();
+    for s in &ir.structures {
+        if let Some(m) = &s.module {
+            type_to_module.insert(s.name.clone(), m.clone());
+        }
+    }
+
+    // Build self-ref fields for the entire IR
+    let self_ref_fields = find_cyclic_fields(ir);
+    let disj_fields = analyze::disj_fields(ir);
+
+    // Generate each module directory
+    for module_name in &module_order {
+        let module_structures = &by_module[module_name];
+        let concepts = group_into_concepts(module_structures);
+
+        let mut mod_rs_items: Vec<String> = Vec::new();
+
+        for (concept_name, members) in &concepts {
+            let file_name = to_snake_case(concept_name);
+            let file_path = format!("{module_name}/{file_name}.rs");
+
+            let content = generate_concept_file(
+                members, ir, &self_ref_fields, use_serde, &disj_fields,
+                module_name, &type_to_module, &all_type_names,
+            );
+
+            files.push(GeneratedFile { path: file_path, content });
+            mod_rs_items.push(file_name);
+        }
+
+        // Generate mod.rs for this module
+        let mut mod_rs = String::new();
+        for item in &mod_rs_items {
+            writeln!(mod_rs, "pub mod {item};").unwrap();
+        }
+        writeln!(mod_rs).unwrap();
+        // Re-export all public types for convenience
+        for item in &mod_rs_items {
+            writeln!(mod_rs, "pub use {item}::*;").unwrap();
+        }
+        files.push(GeneratedFile {
+            path: format!("{module_name}/mod.rs"),
+            content: mod_rs,
+        });
+    }
+
+    // Ungrouped structures → top-level models.rs (if any)
+    if !ungrouped.is_empty() {
+        let mut sub_ir = ir.clone();
+        sub_ir.structures = ungrouped.iter().map(|s| (*s).clone()).collect();
+        files.push(GeneratedFile {
+            path: "models.rs".to_string(),
+            content: generate_models_with_config(&sub_ir, config),
+        });
+    }
+
+    // Generate lib.rs (top-level module declarations)
+    let mut lib_rs = String::new();
+    for module_name in &module_order {
+        writeln!(lib_rs, "pub mod {module_name};").unwrap();
+    }
+    if !ungrouped.is_empty() {
+        writeln!(lib_rs, "pub mod models;").unwrap();
+    }
+
+    // Check if TC, operations, tests, fixtures, newtypes are needed
+    let has_tc = ir.constraints.iter().any(|c| expr_uses_tc(&c.expr))
+        || ir.properties.iter().any(|p| expr_uses_tc(&p.expr));
+    if has_tc {
+        writeln!(lib_rs, "pub mod helpers;").unwrap();
+        files.push(GeneratedFile {
+            path: "helpers.rs".to_string(),
+            content: generate_helpers(ir),
+        });
+    }
+    if !ir.operations.is_empty() {
+        writeln!(lib_rs, "pub mod operations;").unwrap();
+        files.push(GeneratedFile {
+            path: "operations.rs".to_string(),
+            content: generate_operations_modular(ir, &module_order),
+        });
+    }
+    if !ir.properties.is_empty() || !ir.constraints.is_empty() {
+        files.push(GeneratedFile {
+            path: "tests.rs".to_string(),
+            content: generate_tests_modular(ir, &module_order),
+        });
+    }
+    files.push(GeneratedFile {
+        path: "fixtures.rs".to_string(),
+        content: generate_fixtures_modular(ir, &module_order),
+    });
+    writeln!(lib_rs, "pub mod fixtures;").unwrap();
+
+    let newtype_content = generate_newtypes_modular(ir, &module_order);
+    if !newtype_content.is_empty() {
+        writeln!(lib_rs, "pub mod newtypes;").unwrap();
+        files.push(GeneratedFile {
+            path: "newtypes.rs".to_string(),
+            content: newtype_content,
+        });
+    }
+
+    files.push(GeneratedFile {
+        path: "lib.rs".to_string(),
+        content: lib_rs,
+    });
+
+    files
+}
+
+/// Generate a single concept file containing one or more related structures.
+fn generate_concept_file(
+    members: &[&StructureNode],
+    ir: &OxidtrIR,
+    self_ref_fields: &HashSet<(String, String)>,
+    use_serde: bool,
+    disj_fields: &[(String, String)],
+    current_module: &str,
+    type_to_module: &HashMap<String, String>,
+    _all_type_names: &HashSet<String>,
+) -> String {
+    let mut out = String::new();
+
+    // Collect types referenced by members that are in other modules
+    let member_names: HashSet<String> = members.iter().map(|m| m.name.clone()).collect();
+    let mut needed_imports: HashMap<String, HashSet<String>> = HashMap::new(); // module → types
+
+    for s in members {
+        for f in &s.fields {
+            if let Some(module) = type_to_module.get(&f.target) {
+                if module != current_module && !super::is_native_type_alias(&f.target) {
+                    needed_imports.entry(module.clone()).or_default().insert(f.target.clone());
+                }
+            }
+        }
+        // Parent in another module
+        if let Some(parent) = &s.parent {
+            if !member_names.contains(parent) {
+                if let Some(module) = type_to_module.get(parent) {
+                    if module != current_module {
+                        needed_imports.entry(module.clone()).or_default().insert(parent.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    // Check if any field uses Set/Map
+    let needs_btreeset = members.iter().any(|s| s.fields.iter().any(|f| f.mult == Multiplicity::Set));
+    let needs_btreemap = members.iter().any(|s| s.fields.iter().any(|f| f.value_type.is_some()));
+
+    if needs_btreeset || needs_btreemap {
+        let mut imports = Vec::new();
+        if needs_btreemap { imports.push("BTreeMap"); }
+        if needs_btreeset { imports.push("BTreeSet"); }
+        writeln!(out, "use std::collections::{{{}}};", imports.join(", ")).unwrap();
+    }
+
+    if use_serde {
+        writeln!(out, "use serde::{{Serialize, Deserialize}};").unwrap();
+    }
+
+    // Cross-module imports
+    let mut sorted_modules: Vec<&String> = needed_imports.keys().collect();
+    sorted_modules.sort();
+    for module in sorted_modules {
+        let types = needed_imports.get(module).unwrap();
+        let mut sorted_types: Vec<&String> = types.iter().collect();
+        sorted_types.sort();
+        writeln!(out, "use crate::{}::{{{}}};", module, sorted_types.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", ")).unwrap();
+    }
+
+    // Intra-module imports: types from sibling files within the same module
+    let mut intra_module_types: HashSet<String> = HashSet::new();
+    for s in members {
+        for f in &s.fields {
+            if !member_names.contains(&f.target) && !super::is_native_type_alias(&f.target) {
+                if let Some(module) = type_to_module.get(&f.target) {
+                    if module == current_module {
+                        intra_module_types.insert(f.target.clone());
+                    }
+                }
+            }
+        }
+        if let Some(parent) = &s.parent {
+            if !member_names.contains(parent) {
+                if let Some(module) = type_to_module.get(parent) {
+                    if module == current_module {
+                        intra_module_types.insert(parent.clone());
+                    }
+                }
+            }
+        }
+    }
+    if !intra_module_types.is_empty() {
+        let mut sorted: Vec<&String> = intra_module_types.iter().collect();
+        sorted.sort();
+        // Use super:: to access sibling types within the same module
+        for t in &sorted {
+            writeln!(out, "use super::{t};").unwrap();
+        }
+    }
+
+    if needs_btreeset || needs_btreemap || use_serde || !needed_imports.is_empty() || !intra_module_types.is_empty() {
+        writeln!(out).unwrap();
+    }
+
+    // Build sub-IR scoped to these members for constraint analysis
+    let enum_parents: HashSet<String> = members.iter()
+        .filter(|s| s.is_enum)
+        .map(|s| s.name.clone())
+        .collect();
+    let variant_names: HashSet<String> = members.iter()
+        .filter(|s| s.parent.as_ref().map_or(false, |p| enum_parents.contains(p)))
+        .map(|s| s.name.clone())
+        .collect();
+
+    // Collect parent→children mapping for enum generation
+    let children: HashMap<String, Vec<String>> = {
+        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+        for s in members {
+            if let Some(parent) = &s.parent {
+                map.entry(parent.clone()).or_default().push(s.name.clone());
+            }
+        }
+        map
+    };
+
+    for s in members {
+        // Skip variant sigs — they become enum variants
+        if variant_names.contains(&s.name) {
+            continue;
+        }
+        if super::is_native_type_alias(&s.name) {
+            continue;
+        }
+
+        // Intersection type alias
+        if !s.intersection_of.is_empty() {
+            let first = &s.intersection_of[0];
+            let rest: Vec<&str> = s.intersection_of[1..].iter().map(|x| x.as_str()).collect();
+            if rest.is_empty() {
+                writeln!(out, "pub type {} = {};", s.name, first).unwrap();
+            } else {
+                writeln!(out, "// Intersection: {} = {}", s.name, s.intersection_of.join(" & ")).unwrap();
+                writeln!(out, "pub type {} = {}; // also includes: {}", s.name, first, rest.join(", ")).unwrap();
+            }
+            writeln!(out).unwrap();
+            continue;
+        }
+
+        // Doc comments from constraints
+        let constraint_names = analyze::constraint_names_for_sig(ir, &s.name);
+        for cn in &constraint_names {
+            writeln!(out, "/// Invariant: {cn}").unwrap();
+        }
+
+        if s.is_enum {
+            generate_enum(&mut out, s, children.get(&s.name), ir, self_ref_fields, use_serde);
+        } else {
+            generate_struct(&mut out, s, self_ref_fields, use_serde, ir, disj_fields);
+        }
+        writeln!(out).unwrap();
+    }
+
+    // Derived fields for types in this concept
+    let member_set: HashSet<&str> = members.iter().map(|s| s.name.as_str()).collect();
+    for op in &ir.operations {
+        if let Some(ref sig) = op.receiver_sig {
+            if member_set.contains(sig.as_str()) {
+                // Generate impl block for this receiver
+                let fn_name = to_snake_case(&op.name);
+                let params = op.params.iter().map(|p| {
+                    let type_str = match p.mult {
+                        Multiplicity::One => format!("&{}", p.type_name),
+                        Multiplicity::Lone => format!("Option<&{}>", p.type_name),
+                        Multiplicity::Set => format!("&std::collections::BTreeSet<{}>", p.type_name),
+                        Multiplicity::Seq => format!("&[{}]", p.type_name),
+                    };
+                    format!("{}: {type_str}", to_snake_case(&p.name))
+                }).collect::<Vec<_>>().join(", ");
+
+                let return_str = match &op.return_type {
+                    Some(rt) => {
+                        let t = rust_return_type(&rt.type_name, &rt.mult);
+                        format!(" -> {t}")
+                    }
+                    None => String::new(),
+                };
+
+                let param_str = if params.is_empty() {
+                    "&self".to_string()
+                } else {
+                    format!("&self, {params}")
+                };
+
+                writeln!(out, "impl {sig} {{").unwrap();
+                writeln!(out, "    pub fn {fn_name}({param_str}){return_str} {{").unwrap();
+                writeln!(out, "        todo!(\"oxidtr: implement {}\");", op.name).unwrap();
+                writeln!(out, "    }}").unwrap();
+                writeln!(out, "}}").unwrap();
+                writeln!(out).unwrap();
+            }
+        }
+    }
+
+    out
+}
+
+/// Generate operations.rs with modular imports
+fn generate_operations_modular(ir: &OxidtrIR, modules: &[String]) -> String {
+    let mut out = String::new();
+
+    for module in modules {
+        writeln!(out, "use crate::{module}::*;").unwrap();
+    }
+    writeln!(out).unwrap();
+
+    // Check if any operation parameter or return type uses Set multiplicity
+    let needs_btreeset = ir.operations.iter().any(|op| {
+        op.params.iter().any(|p| p.mult == Multiplicity::Set)
+            || op.return_type.as_ref().map_or(false, |r| r.mult == Multiplicity::Set)
+    });
+    if needs_btreeset {
+        writeln!(out, "use std::collections::BTreeSet;").unwrap();
+        writeln!(out).unwrap();
+    }
+
+    for op in &ir.operations {
+        if op.receiver_sig.is_some() {
+            continue;
+        }
+        let fn_name = to_snake_case(&op.name);
+        let params = op.params.iter().map(|p| {
+            let type_str = match p.mult {
+                Multiplicity::One => format!("&{}", p.type_name),
+                Multiplicity::Lone => format!("Option<&{}>", p.type_name),
+                Multiplicity::Set => format!("&BTreeSet<{}>", p.type_name),
+                Multiplicity::Seq => format!("&[{}]", p.type_name),
+            };
+            format!("{}: {type_str}", to_snake_case(&p.name))
+        }).collect::<Vec<_>>().join(", ");
+
+        let return_str = match &op.return_type {
+            Some(rt) => {
+                let t = rust_return_type(&rt.type_name, &rt.mult);
+                format!(" -> {t}")
+            }
+            None => String::new(),
+        };
+
+        if !op.body.is_empty() {
+            let param_names: Vec<String> = op.params.iter().map(|p| p.name.clone()).collect();
+            for expr in &op.body {
+                let desc = analyze::describe_expr(expr);
+                let tag = if analyze::is_pre_condition(expr, &param_names) { "pre" } else { "post" };
+                writeln!(out, "/// @{tag}: {desc}").unwrap();
+            }
+        }
+
+        writeln!(out, "pub fn {fn_name}({params}){return_str} {{").unwrap();
+        writeln!(out, "    todo!(\"oxidtr: implement {}\");", op.name).unwrap();
+        writeln!(out, "}}").unwrap();
+        writeln!(out).unwrap();
+    }
+
+    out
+}
+
+/// Generate tests.rs with modular imports
+fn generate_tests_modular(ir: &OxidtrIR, modules: &[String]) -> String {
+    // For now, reuse the existing test generation but fix imports
+    let original = generate_tests(ir);
+    // Replace `use crate::models::*` with module imports
+    let mut result = original.replace("use crate::models::*;",
+        &modules.iter().map(|m| format!("use crate::{m}::*;")).collect::<Vec<_>>().join("\n    "));
+    // Also update fixtures import
+    result = result.replace("use crate::fixtures::*;", "use crate::fixtures::*;");
+    result
+}
+
+/// Generate fixtures.rs with modular imports
+fn generate_fixtures_modular(ir: &OxidtrIR, modules: &[String]) -> String {
+    let original = generate_fixtures(ir);
+    original.replace("use crate::models::*;",
+        &modules.iter().map(|m| format!("use crate::{m}::*;")).collect::<Vec<_>>().join("\n"))
+}
+
+/// Generate newtypes.rs with modular imports
+fn generate_newtypes_modular(ir: &OxidtrIR, modules: &[String]) -> String {
+    let original = generate_newtypes(ir);
+    if original.is_empty() { return original; }
+    original.replace("use crate::models::*;",
+        &modules.iter().map(|m| format!("use crate::{m}::*;")).collect::<Vec<_>>().join("\n"))
 }
 
 

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -220,9 +220,12 @@ fn generate_modular(ir: &OxidtrIR, config: &RustBackendConfig) -> Vec<GeneratedF
         || ir.properties.iter().any(|p| expr_uses_tc(&p.expr));
     if has_tc {
         writeln!(lib_rs, "pub mod helpers;").unwrap();
+        let helpers_content = generate_helpers(ir)
+            .replace("use crate::models::*;",
+                &module_order.iter().map(|m| format!("use crate::{m}::*;")).collect::<Vec<_>>().join("\n"));
         files.push(GeneratedFile {
             path: "helpers.rs".to_string(),
-            content: generate_helpers(ir),
+            content: helpers_content,
         });
     }
     if !ir.operations.is_empty() {

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -121,6 +121,22 @@ pub fn run(model_path: &str, config: &CheckConfig) -> Result<CheckResult, CheckE
         let extracted = extract_mined(impl_dir, "models.rs", "operations.rs", extract::rust_extractor::extract)?;
         let validation_sources = collect_validation_sources_rust(impl_dir)?;
         differ::diff_with_validation(&ir, &extracted, &validation_sources)
+    } else if impl_dir.join("lib.rs").exists() {
+        // Modular Rust layout: lib.rs + module subdirectories
+        match extract::run(config.impl_dir.as_str(), Some("rust")) {
+            Ok(mined) => {
+                let mut extracted = mined_to_extracted(&mined);
+                // Also extract functions from operations.rs if it exists
+                let ops_path = impl_dir.join("operations.rs");
+                if ops_path.exists() {
+                    let ops_src = std::fs::read_to_string(&ops_path)?;
+                    extracted.fns.extend(extract_fns_generic(&ops_src));
+                }
+                let validation_sources = collect_validation_sources_rust(impl_dir)?;
+                differ::diff_with_validation(&ir, &extracted, &validation_sources)
+            }
+            Err(e) => return Err(CheckError::ImplNotFound(e)),
+        }
     } else {
         // Fallback: use mine to extract from any code in the directory
         match extract::run(config.impl_dir.as_str(), None) {

--- a/src/extract/csharp_extractor.rs
+++ b/src/extract/csharp_extractor.rs
@@ -32,7 +32,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: sig_is_var,
                 parent: None,
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
             for v in variants {
                 sigs.push(MinedSig {
@@ -42,7 +42,7 @@ pub fn extract(source: &str) -> MinedModel {
                     is_var: false,
                     parent: Some(name.clone()),
                     source_location: format!("line {}", line_num + 1),
-                    intersection_of: vec![],
+                    intersection_of: vec![], module: None,
                 });
             }
             continue;
@@ -65,7 +65,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: sig_is_var,
                 parent,
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
             continue;
         }

--- a/src/extract/go_extractor.rs
+++ b/src/extract/go_extractor.rs
@@ -77,7 +77,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: sig_is_var,
                 parent: None,
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
         }
 
@@ -92,7 +92,7 @@ pub fn extract(source: &str) -> MinedModel {
                     is_var: sig_is_var,
                     parent: None,
                     source_location: format!("line {}", line_num + 1),
-                    intersection_of: vec![],
+                    intersection_of: vec![], module: None,
                 });
             } else {
                 // Multi-line interface: consume body, check for marker method
@@ -104,7 +104,7 @@ pub fn extract(source: &str) -> MinedModel {
                     is_var: sig_is_var,
                     parent: None,
                     source_location: format!("line {}", line_num + 1),
-                    intersection_of: vec![],
+                    intersection_of: vec![], module: None,
                 });
             }
         }
@@ -119,7 +119,7 @@ pub fn extract(source: &str) -> MinedModel {
                     is_var: sig_is_var,
                     parent: None,
                     source_location: format!("line {}", line_num + 1),
-                    intersection_of: vec![],
+                    intersection_of: vec![], module: None,
                 });
                 for v in variants {
                     sigs.push(MinedSig {
@@ -129,7 +129,7 @@ pub fn extract(source: &str) -> MinedModel {
                         is_var: false,
                         parent: Some(name.clone()),
                         source_location: format!("line {}", line_num + 1),
-                        intersection_of: vec![],
+                        intersection_of: vec![], module: None,
                     });
                 }
             }

--- a/src/extract/java_extractor.rs
+++ b/src/extract/java_extractor.rs
@@ -37,7 +37,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: sig_is_var,
                 parent: None,
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
         }
 
@@ -57,7 +57,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: sig_is_var,
                 parent: None,
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
         }
 
@@ -71,7 +71,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: sig_is_var,
                 parent: None,
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
             for v in variants {
                 sigs.push(MinedSig {
@@ -81,7 +81,7 @@ pub fn extract(source: &str) -> MinedModel {
                     is_var: false,
                     parent: Some(name.clone()),
                     source_location: format!("line {}", line_num + 1),
-                    intersection_of: vec![],
+                    intersection_of: vec![], module: None,
                 });
             }
         }
@@ -106,7 +106,7 @@ pub fn extract(source: &str) -> MinedModel {
                     is_var: sig_is_var,
                     parent,
                     source_location: format!("line {}", line_num + 1),
-                    intersection_of: vec![],
+                    intersection_of: vec![], module: None,
                 });
             }
         }

--- a/src/extract/kotlin_extractor.rs
+++ b/src/extract/kotlin_extractor.rs
@@ -38,7 +38,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: sig_is_var,
                 parent: None,
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
             // Check for extends (": Parent()")
             if let Some((_child, parent)) = parse_extends(&full_text) {
@@ -55,7 +55,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: sig_is_var,
                 parent: None,
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
         }
 
@@ -68,7 +68,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: sig_is_var,
                 parent: Some(parent),
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
         }
 
@@ -81,7 +81,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: sig_is_var,
                 parent: None,
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
         }
 
@@ -95,7 +95,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: sig_is_var,
                 parent: None,
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
             for v in variants {
                 sigs.push(MinedSig {
@@ -105,7 +105,7 @@ pub fn extract(source: &str) -> MinedModel {
                     is_var: false,
                     parent: Some(name.clone()),
                     source_location: format!("line {}", line_num + 1),
-                    intersection_of: vec![],
+                    intersection_of: vec![], module: None,
                 });
             }
         }

--- a/src/extract/lean_extractor.rs
+++ b/src/extract/lean_extractor.rs
@@ -25,7 +25,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: false,
                 parent: None,
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
             continue;
         }
@@ -40,7 +40,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: false,
                 parent: None,
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
             for v in variants {
                 sigs.push(MinedSig {
@@ -50,7 +50,7 @@ pub fn extract(source: &str) -> MinedModel {
                     is_var: false,
                     parent: Some(name.clone()),
                     source_location: format!("line {}", line_num + 1),
-                    intersection_of: vec![],
+                    intersection_of: vec![], module: None,
                 });
             }
             continue;

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -23,6 +23,8 @@ pub fn detect_lang(path: &Path) -> Option<String> {
         if path.join("Models.kt").exists() { return Some("kt".to_string()); }
         if path.join("Models.java").exists() { return Some("java".to_string()); }
         if path.join("models.rs").exists() { return Some("rust".to_string()); }
+        // Modular layout: lib.rs at root with module subdirectories
+        if path.join("lib.rs").exists() { return Some("rust".to_string()); }
         if path.join("Models.swift").exists() { return Some("swift".to_string()); }
         if path.join("models.go").exists() { return Some("go".to_string()); }
         if path.join("Models.cs").exists() { return Some("csharp".to_string()); }
@@ -306,8 +308,18 @@ fn mine_directory(dir: &Path, lang: &str) -> Result<MinedModel, String> {
         let content = std::fs::read_to_string(file)
             .map_err(|e| format!("cannot read {}: {e}", file.display()))?;
         let mined = extract_with_lang(&content, lang)?;
+
+        // Infer module name from subdirectory relative to the base dir.
+        // e.g. dir/ast/sig_decl.rs → module "ast"
+        // e.g. dir/models.rs → module None
+        let inferred_module = infer_module_from_path(file, dir);
+
         // Dedup: merge same-name sigs (supplement missing fields, prefer more complete)
-        for sig in mined.sigs {
+        for mut sig in mined.sigs {
+            // Apply inferred module if not already set
+            if sig.module.is_none() {
+                sig.module = inferred_module.clone();
+            }
             if let Some(existing) = merged.sigs.iter_mut().find(|s| s.name == sig.name) {
                 // Supplement missing fields from the new source
                 for f in &sig.fields {
@@ -327,6 +339,10 @@ fn mine_directory(dir: &Path, lang: &str) -> Result<MinedModel, String> {
                 if existing.intersection_of.is_empty() && !sig.intersection_of.is_empty() {
                     existing.intersection_of = sig.intersection_of.clone();
                 }
+                // Prefer module if either provides one
+                if existing.module.is_none() && sig.module.is_some() {
+                    existing.module = sig.module.clone();
+                }
             } else {
                 merged.sigs.push(sig);
             }
@@ -339,6 +355,35 @@ fn mine_directory(dir: &Path, lang: &str) -> Result<MinedModel, String> {
     merged.fact_candidates.dedup_by(|a, b| a.alloy_text == b.alloy_text);
 
     Ok(merged)
+}
+
+/// Infer module name from file path relative to the base directory.
+/// e.g. base_dir/ast/sig_decl.rs → Some("ast")
+/// e.g. base_dir/models.rs → None
+/// e.g. base_dir/src/ir/nodes.rs → Some("ir") (innermost directory)
+fn infer_module_from_path(file: &Path, base_dir: &Path) -> Option<String> {
+    let relative = file.strip_prefix(base_dir).ok()?;
+    let parent = relative.parent()?;
+    // Only infer module if the file is in a subdirectory (not at root level)
+    if parent.as_os_str().is_empty() {
+        return None;
+    }
+    // Use the first path component as the module name
+    // e.g. "ast/sig_decl.rs" → "ast"
+    let module_name = parent.components().next()?;
+    let name = module_name.as_os_str().to_str()?;
+    // Skip common non-module directories
+    if name == "src" || name == "Sources" || name == "Tests" || name == "__tests__" {
+        // If there's a deeper component, use that instead
+        let rest: std::path::PathBuf = parent.components().skip(1).collect();
+        if !rest.as_os_str().is_empty() {
+            return rest.components().next()
+                .and_then(|c| c.as_os_str().to_str())
+                .map(|s| s.to_string());
+        }
+        return None;
+    }
+    Some(name.to_string())
 }
 
 fn collect_files(dir: &Path, ext: &str) -> Vec<std::path::PathBuf> {
@@ -412,6 +457,8 @@ pub struct MinedSig {
     pub source_location: String,
     /// Components for intersection type aliases (e.g. ["A", "B", "C"] for `type T = A & B & C`).
     pub intersection_of: Vec<String>,
+    /// Module grouping inferred from directory structure or package declarations.
+    pub module: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -545,7 +592,7 @@ pub fn resolve_external_types(model: &mut MinedModel) {
             is_var: false,
             parent: None,
             source_location: "external type".to_string(),
-            intersection_of: vec![],
+            intersection_of: vec![], module: None,
         });
     }
 }

--- a/src/extract/renderer.rs
+++ b/src/extract/renderer.rs
@@ -6,10 +6,39 @@ use std::fmt::Write;
 pub fn render(model: &MinedModel) -> String {
     let mut out = String::new();
 
-    // Render sigs
+    // Group sigs by module, preserving order within each group.
+    // Sigs with no module come first (ungrouped), then each module section.
+    let mut ungrouped: Vec<&MinedSig> = Vec::new();
+    let mut module_order: Vec<String> = Vec::new();
+    let mut by_module: std::collections::HashMap<String, Vec<&MinedSig>> = std::collections::HashMap::new();
+
     for sig in &model.sigs {
+        if let Some(m) = &sig.module {
+            by_module.entry(m.clone()).or_default().push(sig);
+            if !module_order.contains(m) {
+                module_order.push(m.clone());
+            }
+        } else {
+            ungrouped.push(sig);
+        }
+    }
+
+    // Render ungrouped sigs first
+    for sig in &ungrouped {
         render_sig(&mut out, sig);
         writeln!(out).unwrap();
+    }
+
+    // Render each module section
+    for module_name in &module_order {
+        writeln!(out, "module {module_name}").unwrap();
+        writeln!(out).unwrap();
+        if let Some(sigs) = by_module.get(module_name) {
+            for sig in sigs {
+                render_sig(&mut out, sig);
+                writeln!(out).unwrap();
+            }
+        }
     }
 
     // Render fact candidates (as comments with confidence)

--- a/src/extract/rust_extractor.rs
+++ b/src/extract/rust_extractor.rs
@@ -34,7 +34,7 @@ pub fn extract(source: &str) -> MinedModel {
                             is_var: sig_is_var,
                             parent: None,
                             source_location: format!("line {}", line_num + 1),
-                            intersection_of: vec![],
+                            intersection_of: vec![], module: None,
                         });
                         i += 1; // advance past this unit struct line
                     } else {
@@ -74,7 +74,7 @@ pub fn extract(source: &str) -> MinedModel {
                             is_var: sig_is_var,
                             parent: None,
                             source_location: format!("line {}", line_num + 1),
-                            intersection_of: vec![],
+                            intersection_of: vec![], module: None,
                         });
                     }
                     continue;
@@ -188,7 +188,7 @@ pub fn extract(source: &str) -> MinedModel {
                         is_var: sig_is_var,
                         parent: None,
                         source_location: format!("line {}", line_num + 1),
-                        intersection_of: vec![],
+                        intersection_of: vec![], module: None,
                     });
                     for (vname, vfields) in variants {
                         sigs.push(MinedSig {
@@ -198,7 +198,7 @@ pub fn extract(source: &str) -> MinedModel {
                             is_var: false,
                             parent: Some(name.clone()),
                             source_location: format!("line {}", line_num + 1),
-                            intersection_of: vec![],
+                            intersection_of: vec![], module: None,
                         });
                     }
                     continue;

--- a/src/extract/schema_extractor.rs
+++ b/src/extract/schema_extractor.rs
@@ -95,7 +95,7 @@ fn parse_definition(name: &str, body: &str) -> Vec<MinedSig> {
                 is_var: false,
             parent: None,
             source_location: loc.clone(),
-            intersection_of: vec![],
+            intersection_of: vec![], module: None,
         });
         for v in variants {
             sigs.push(MinedSig {
@@ -105,7 +105,7 @@ fn parse_definition(name: &str, body: &str) -> Vec<MinedSig> {
                 is_var: false,
                 parent: Some(name.to_string()),
                 source_location: loc.clone(),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
         }
     } else if body.contains("\"oneOf\"") && body.contains("\"discriminator\"") {
@@ -117,7 +117,7 @@ fn parse_definition(name: &str, body: &str) -> Vec<MinedSig> {
                 is_var: false,
             parent: None,
             source_location: loc.clone(),
-            intersection_of: vec![],
+            intersection_of: vec![], module: None,
         });
         let variant_sigs = extract_discriminated_variants(name, body, &loc);
         sigs.extend(variant_sigs);
@@ -131,7 +131,7 @@ fn parse_definition(name: &str, body: &str) -> Vec<MinedSig> {
                 is_var: false,
             parent: None,
             source_location: loc,
-            intersection_of: vec![],
+            intersection_of: vec![], module: None,
         });
     } else if body.contains("\"type\": \"string\"") {
         // Bare abstract sig (enum with no known variants)
@@ -142,7 +142,7 @@ fn parse_definition(name: &str, body: &str) -> Vec<MinedSig> {
                 is_var: false,
             parent: None,
             source_location: loc,
-            intersection_of: vec![],
+            intersection_of: vec![], module: None,
         });
     }
 
@@ -255,7 +255,7 @@ fn extract_discriminated_variants(parent_name: &str, body: &str, loc: &str) -> V
                 is_var: false,
             parent: Some(parent_name.to_string()),
             source_location: loc.to_string(),
-            intersection_of: vec![],
+            intersection_of: vec![], module: None,
         });
     }
 

--- a/src/extract/swift_extractor.rs
+++ b/src/extract/swift_extractor.rs
@@ -32,7 +32,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: sig_is_var,
                 parent: None,
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
         }
 
@@ -46,7 +46,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: sig_is_var,
                 parent: None,
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
             for vs in variant_sigs {
                 sigs.push(vs);
@@ -212,7 +212,7 @@ fn collect_enum_cases(
                 is_var: false,
                 parent: Some(parent_name.to_string()),
                 source_location: format!("line {}", ln + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
         }
     }

--- a/src/extract/ts_extractor.rs
+++ b/src/extract/ts_extractor.rs
@@ -42,7 +42,7 @@ pub fn extract(source: &str) -> MinedModel {
                 is_var: sig_is_var,
                 parent: iface_parent,
                 source_location: format!("line {}", line_num + 1),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             });
         }
 
@@ -56,6 +56,7 @@ pub fn extract(source: &str) -> MinedModel {
                 parent: None,
                 source_location: format!("line {}", line_num + 1),
                 intersection_of: components,
+                module: None,
             });
         }
 
@@ -75,7 +76,7 @@ pub fn extract(source: &str) -> MinedModel {
                     is_var: sig_is_var,
                     parent: None,
                     source_location: format!("line {}", line_num + 1),
-                    intersection_of: vec![],
+                    intersection_of: vec![], module: None,
                 });
                 for v in &variants {
                     let vname = v.trim_matches('"').trim_matches('\'').to_string();
@@ -86,7 +87,7 @@ pub fn extract(source: &str) -> MinedModel {
                         is_var: false,
                         parent: Some(name.clone()),
                         source_location: format!("line {}", line_num + 1),
-                        intersection_of: vec![],
+                        intersection_of: vec![], module: None,
                     });
                 }
             } else {
@@ -98,7 +99,7 @@ pub fn extract(source: &str) -> MinedModel {
                     is_var: sig_is_var,
                     parent: None,
                     source_location: format!("line {}", line_num + 1),
-                    intersection_of: vec![],
+                    intersection_of: vec![], module: None,
                 });
                 // Set parent on existing sigs that match variant names
                 for v in &variants {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -57,6 +57,7 @@ fn lower_sig(sig: &SigDecl) -> StructureNode {
         parent: sig.parent.clone(),
         fields,
         intersection_of: sig.intersection_of.clone(),
+        module: sig.module.clone(),
     }
 }
 
@@ -64,6 +65,7 @@ fn lower_fact(fact: &FactDecl) -> ConstraintNode {
     ConstraintNode {
         name: fact.name.clone(),
         expr: fact.body.clone(),
+        module: fact.module.clone(),
     }
 }
 
@@ -84,6 +86,7 @@ fn lower_pred(pred: &PredDecl) -> OperationNode {
         params,
         return_type: None,
         body: pred.body.clone(),
+        module: pred.module.clone(),
     }
 }
 
@@ -107,6 +110,7 @@ fn lower_fun(fun: &FunDecl) -> OperationNode {
             type_name: fun.return_type.clone(),
         }),
         body: vec![fun.body.clone()],
+        module: fun.module.clone(),
     }
 }
 
@@ -114,5 +118,6 @@ fn lower_assert(assert_decl: &AssertDecl) -> PropertyNode {
     PropertyNode {
         name: assert_decl.name.clone(),
         expr: assert_decl.body.clone(),
+        module: assert_decl.module.clone(),
     }
 }

--- a/src/ir/nodes.rs
+++ b/src/ir/nodes.rs
@@ -27,12 +27,15 @@ pub struct StructureNode {
     /// For type aliases that are intersections (e.g. `type Base = A & B & C`).
     /// Backends render these as intersection/composition types rather than plain structs.
     pub intersection_of: Vec<String>,
+    /// Module grouping from `module X` declarations in the Alloy source.
+    pub module: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConstraintNode {
     pub name: Option<String>,
     pub expr: Expr,
+    pub module: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -55,12 +58,14 @@ pub struct OperationNode {
     pub params: Vec<IRParam>,
     pub return_type: Option<IRReturnType>,
     pub body: Vec<Expr>,
+    pub module: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PropertyNode {
     pub name: String,
     pub expr: Expr,
+    pub module: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -35,6 +35,7 @@ pub struct SigDecl {
     pub parent: Option<String>,
     pub fields: Vec<FieldDecl>,
     pub intersection_of: Vec<String>,
+    pub module: Option<String>, // inline module grouping
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -170,6 +171,7 @@ pub struct ParamDecl {
 pub struct FactDecl {
     pub name: Option<String>,
     pub body: Expr,
+    pub module: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -177,12 +179,14 @@ pub struct PredDecl {
     pub name: String,
     pub params: Vec<ParamDecl>,
     pub body: Vec<Expr>, // pre/post conditions combined for now
+    pub module: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AssertDecl {
     pub name: String,
     pub body: Expr,
+    pub module: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -193,6 +197,7 @@ pub struct FunDecl {
     pub return_mult: Multiplicity,
     pub return_type: String,
     pub body: Expr,
+    pub module: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -38,6 +38,8 @@ struct Parser<'a> {
     intersection_annotations: std::collections::HashMap<String, Vec<String>>,
     /// Track current sig name for annotation lookup
     current_sig_name: String,
+    /// Track current inline module name (set by `module X` declarations)
+    current_module: Option<String>,
 }
 
 impl<'a> Parser<'a> {
@@ -48,6 +50,7 @@ impl<'a> Parser<'a> {
             union_annotations: std::collections::HashMap::new(),
             intersection_annotations: std::collections::HashMap::new(),
             current_sig_name: String::new(),
+            current_module: None,
         }
     }
 
@@ -62,6 +65,7 @@ impl<'a> Parser<'a> {
             union_annotations: annotations,
             intersection_annotations,
             current_sig_name: String::new(),
+            current_module: None,
         }
     }
 
@@ -110,58 +114,82 @@ impl<'a> Parser<'a> {
             match self.peek() {
                 Token::Eof => break,
                 Token::Sig => {
-                    model.sigs.push(self.parse_sig(false, false)?);
+                    let mut sig = self.parse_sig(false, false)?;
+                    sig.module = self.current_module.clone();
+                    model.sigs.push(sig);
                 }
                 Token::Var => {
                     // Alloy 6: `var sig` — mutable atom set
                     self.next();
-                    model.sigs.push(self.parse_sig(false, true)?);
+                    let mut sig = self.parse_sig(false, true)?;
+                    sig.module = self.current_module.clone();
+                    model.sigs.push(sig);
                 }
                 Token::Abstract => {
                     self.next();
                     // Alloy 6: `abstract var sig` — not typical but handle gracefully
                     let is_var = if self.peek() == Token::Var { self.next(); true } else { false };
                     self.expect(&Token::Sig)?;
-                    model.sigs.push(self.parse_sig_body(true, is_var, SigMultiplicity::Default)?);
+                    let mut sig = self.parse_sig_body(true, is_var, SigMultiplicity::Default)?;
+                    sig.module = self.current_module.clone();
+                    model.sigs.push(sig);
                 }
                 Token::One => {
                     self.next();
                     let is_var = if self.peek() == Token::Var { self.next(); true } else { false };
                     self.expect(&Token::Sig)?;
-                    model.sigs.push(self.parse_sig_body(false, is_var, SigMultiplicity::One)?);
+                    let mut sig = self.parse_sig_body(false, is_var, SigMultiplicity::One)?;
+                    sig.module = self.current_module.clone();
+                    model.sigs.push(sig);
                 }
                 Token::Some_ => {
                     self.next();
                     let is_var = if self.peek() == Token::Var { self.next(); true } else { false };
                     self.expect(&Token::Sig)?;
-                    model.sigs.push(self.parse_sig_body(false, is_var, SigMultiplicity::Some)?);
+                    let mut sig = self.parse_sig_body(false, is_var, SigMultiplicity::Some)?;
+                    sig.module = self.current_module.clone();
+                    model.sigs.push(sig);
                 }
                 Token::Lone => {
                     self.next();
                     let is_var = if self.peek() == Token::Var { self.next(); true } else { false };
                     self.expect(&Token::Sig)?;
-                    model.sigs.push(self.parse_sig_body(false, is_var, SigMultiplicity::Lone)?);
+                    let mut sig = self.parse_sig_body(false, is_var, SigMultiplicity::Lone)?;
+                    sig.module = self.current_module.clone();
+                    model.sigs.push(sig);
                 }
                 Token::Module => {
-                    self.skip_to_eol();
+                    self.parse_module_decl();
                 }
                 Token::Open => {
                     self.skip_to_eol();
                 }
                 Token::Enum => {
-                    model.sigs.extend(self.parse_enum()?);
+                    let mut sigs = self.parse_enum()?;
+                    for sig in &mut sigs {
+                        sig.module = self.current_module.clone();
+                    }
+                    model.sigs.extend(sigs);
                 }
                 Token::Fact => {
-                    model.facts.push(self.parse_fact()?);
+                    let mut fact = self.parse_fact()?;
+                    fact.module = self.current_module.clone();
+                    model.facts.push(fact);
                 }
                 Token::Pred => {
-                    model.preds.push(self.parse_pred()?);
+                    let mut pred = self.parse_pred()?;
+                    pred.module = self.current_module.clone();
+                    model.preds.push(pred);
                 }
                 Token::Fun => {
-                    model.funs.push(self.parse_fun()?);
+                    let mut fun = self.parse_fun()?;
+                    fun.module = self.current_module.clone();
+                    model.funs.push(fun);
                 }
                 Token::Assert => {
-                    model.asserts.push(self.parse_assert()?);
+                    let mut assert_decl = self.parse_assert()?;
+                    assert_decl.module = self.current_module.clone();
+                    model.asserts.push(assert_decl);
                 }
                 Token::Check | Token::Run => {
                     self.skip_command();
@@ -204,6 +232,7 @@ impl<'a> Parser<'a> {
             parent: None,
             fields: Vec::new(),
             intersection_of: Vec::new(),
+            module: None,
         });
         for variant in variants {
             sigs.push(SigDecl {
@@ -214,6 +243,7 @@ impl<'a> Parser<'a> {
                 parent: Some(name.clone()),
                 fields: Vec::new(),
                 intersection_of: Vec::new(),
+                module: None,
             });
         }
         Ok(sigs)
@@ -259,6 +289,7 @@ impl<'a> Parser<'a> {
             parent,
             fields,
             intersection_of,
+            module: None, // set by parse_model from current_module
         })
     }
 
@@ -315,7 +346,7 @@ impl<'a> Parser<'a> {
         let body = self.parse_expr()?;
         self.expect(&Token::RBrace)?;
 
-        Ok(FactDecl { name, body })
+        Ok(FactDecl { name, body, module: None })
     }
 
     fn parse_pred(&mut self) -> Result<PredDecl, ParseError> {
@@ -341,7 +372,7 @@ impl<'a> Parser<'a> {
         }
         self.expect(&Token::RBrace)?;
 
-        Ok(PredDecl { name, params, body })
+        Ok(PredDecl { name, params, body, module: None })
     }
 
     fn parse_fun(&mut self) -> Result<FunDecl, ParseError> {
@@ -378,7 +409,7 @@ impl<'a> Parser<'a> {
         let body = self.parse_expr()?;
         self.expect(&Token::RBrace)?;
 
-        Ok(FunDecl { name, receiver_sig, params, return_mult, return_type, body })
+        Ok(FunDecl { name, receiver_sig, params, return_mult, return_type, body, module: None })
     }
 
     fn parse_param(&mut self) -> Result<ParamDecl, ParseError> {
@@ -395,7 +426,7 @@ impl<'a> Parser<'a> {
         self.expect(&Token::LBrace)?;
         let body = self.parse_expr()?;
         self.expect(&Token::RBrace)?;
-        Ok(AssertDecl { name, body })
+        Ok(AssertDecl { name, body, module: None })
     }
 
     fn parse_expr(&mut self) -> Result<Expr, ParseError> {
@@ -834,10 +865,37 @@ impl<'a> Parser<'a> {
         self.skip_to_next_toplevel();
     }
 
-    /// Skip `module path` or `open path[params] as alias` declaration.
+    /// Parse `module name` declaration and set current_module.
+    /// All subsequent declarations are tagged with this module name until
+    /// the next `module` declaration or end of file.
+    fn parse_module_decl(&mut self) {
+        self.next(); // consume `module`
+        // Collect the module path as a string (e.g. "ast", "my/model")
+        let mut name = String::new();
+        loop {
+            match self.peek() {
+                Token::Ident(s) => {
+                    self.next();
+                    name.push_str(&s);
+                }
+                _ => break,
+            }
+            // Handle path separators: module my/model
+            // The lexer doesn't produce '/' as a token, so the path
+            // will be in the ident itself or we stop at the next top-level.
+            // For simple names like `module ast`, this works directly.
+        }
+        if !name.is_empty() {
+            self.current_module = Some(name);
+        }
+        // Skip any remaining tokens on the line (e.g. version info)
+        self.skip_to_next_toplevel();
+    }
+
+    /// Skip `open path[params] as alias` declaration.
     /// Consumes the leading keyword then skips to the next top-level token.
     fn skip_to_eol(&mut self) {
-        self.next(); // consume module/open
+        self.next(); // consume open
         self.skip_to_next_toplevel();
     }
 

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -33,7 +33,7 @@ fn differ_no_diff_when_in_sync() {
                 mult: Multiplicity::One,
                 target: "String".into(),
                 value_type: None, raw_union_type: None }],
-            intersection_of: vec![],
+            intersection_of: vec![], module: None,
         }],
         vec![],
     );
@@ -59,7 +59,7 @@ fn differ_no_diff_when_in_sync() {
 fn differ_missing_struct() {
     use oxidtr::check::ExtractedImpl;
     let ir = make_ir(
-        vec![StructureNode { name: "User".into(), is_enum: false, is_var: false, sig_multiplicity: SigMultiplicity::Default, parent: None, fields: vec![], intersection_of: vec![] }],
+        vec![StructureNode { name: "User".into(), is_enum: false, is_var: false, sig_multiplicity: SigMultiplicity::Default, parent: None, fields: vec![], intersection_of: vec![], module: None }],
         vec![],
     );
     let extracted = ExtractedImpl { structs: vec![], fns: vec![] };
@@ -90,7 +90,7 @@ fn differ_missing_field() {
             sig_multiplicity: SigMultiplicity::Default,
             parent: None,
             fields: vec![IRField { name: "email".into(), is_var: false, mult: Multiplicity::One, target: "String".into(), value_type: None, raw_union_type: None }],
-            intersection_of: vec![],
+            intersection_of: vec![], module: None,
         }],
         vec![],
     );
@@ -109,7 +109,7 @@ fn differ_missing_field() {
 fn differ_extra_field() {
     use oxidtr::check::{ExtractedImpl, ExtractedStruct, ExtractedField};
     let ir = make_ir(
-        vec![StructureNode { name: "User".into(), is_enum: false, is_var: false, sig_multiplicity: SigMultiplicity::Default, parent: None, fields: vec![], intersection_of: vec![] }],
+        vec![StructureNode { name: "User".into(), is_enum: false, is_var: false, sig_multiplicity: SigMultiplicity::Default, parent: None, fields: vec![], intersection_of: vec![], module: None }],
         vec![],
     );
     let extracted = ExtractedImpl {
@@ -139,7 +139,7 @@ fn differ_multiplicity_mismatch() {
             sig_multiplicity: SigMultiplicity::Default,
             parent: None,
             fields: vec![IRField { name: "manager".into(), is_var: false, mult: Multiplicity::Lone, target: "User".into(), value_type: None, raw_union_type: None }],
-            intersection_of: vec![],
+            intersection_of: vec![], module: None,
         }],
         vec![],
     );
@@ -167,7 +167,7 @@ fn differ_missing_fn() {
     use oxidtr::check::ExtractedImpl;
     let ir = make_ir(
         vec![],
-        vec![OperationNode { name: "add_user".into(), receiver_sig: None, params: vec![], return_type: None, body: vec![] }],
+        vec![OperationNode { name: "add_user".into(), receiver_sig: None, params: vec![], return_type: None, body: vec![], module: None }],
     );
     let extracted = ExtractedImpl { structs: vec![], fns: vec![] };
     let diffs = differ::diff(&ir, &extracted);
@@ -268,7 +268,7 @@ fn check_detects_missing_transition_test() {
     // A fact with prime operator should require a transition_ test
     let ir = OxidtrIR {
         structures: vec![],
-        constraints: vec![ConstraintNode {
+        constraints: vec![ConstraintNode { module: None,
             name: Some("StateUpdate".to_string()),
             expr: Expr::TemporalUnary {
                 op: ast::TemporalUnaryOp::Always,
@@ -309,7 +309,7 @@ fn check_detects_missing_transition_test() {
 fn check_passes_when_transition_test_present() {
     let ir = OxidtrIR {
         structures: vec![],
-        constraints: vec![ConstraintNode {
+        constraints: vec![ConstraintNode { module: None,
             name: Some("StateUpdate".to_string()),
             expr: Expr::TemporalUnary {
                 op: ast::TemporalUnaryOp::Always,
@@ -329,7 +329,7 @@ fn check_passes_when_transition_test_present() {
 fn check_detects_missing_invariant_test_for_temporal_without_prime() {
     let ir = OxidtrIR {
         structures: vec![],
-        constraints: vec![ConstraintNode {
+        constraints: vec![ConstraintNode { module: None,
             name: Some("AlwaysPositive".to_string()),
             expr: Expr::TemporalUnary {
                 op: ast::TemporalUnaryOp::Always,
@@ -359,7 +359,7 @@ fn check_accepts_space_separated_invariant_test_name() {
     // check should recognize this as matching the temporal test requirement
     let ir = OxidtrIR {
         structures: vec![],
-        constraints: vec![ConstraintNode {
+        constraints: vec![ConstraintNode { module: None,
             name: Some("FlagImpliesPositive".to_string()),
             expr: Expr::TemporalUnary {
                 op: ast::TemporalUnaryOp::Always,
@@ -386,7 +386,7 @@ fn check_accepts_space_separated_temporal_binary_test_name() {
     use oxidtr::parser::ast::TemporalBinaryOp;
     let ir = OxidtrIR {
         structures: vec![],
-        constraints: vec![ConstraintNode {
+        constraints: vec![ConstraintNode { module: None,
             name: Some("FlagUntilLarge".to_string()),
             expr: Expr::TemporalBinary {
                 op: TemporalBinaryOp::Until,
@@ -407,7 +407,7 @@ fn check_accepts_space_separated_temporal_binary_test_name() {
 fn check_accepts_space_separated_liveness_test_name() {
     let ir = OxidtrIR {
         structures: vec![],
-        constraints: vec![ConstraintNode {
+        constraints: vec![ConstraintNode { module: None,
             name: Some("WillConverge".to_string()),
             expr: Expr::TemporalUnary {
                 op: ast::TemporalUnaryOp::Eventually,
@@ -428,7 +428,7 @@ fn check_accepts_space_separated_transition_test_name() {
     // TS generates `it('transition StateUpdate', ...)` for prime constraints
     let ir = OxidtrIR {
         structures: vec![],
-        constraints: vec![ConstraintNode {
+        constraints: vec![ConstraintNode { module: None,
             name: Some("StateUpdate".to_string()),
             expr: Expr::TemporalUnary {
                 op: ast::TemporalUnaryOp::Always,
@@ -456,6 +456,7 @@ fn missing_assert_detected() {
         properties: vec![PropertyNode {
             name: "NoSelfLoop".to_string(),
             expr: Expr::VarRef("placeholder".to_string()),
+            module: None,
         }],
     };
     let sources = vec!["fn some_other_test() {}".to_string()];
@@ -475,6 +476,7 @@ fn present_assert_not_flagged() {
         properties: vec![PropertyNode {
             name: "NoSelfLoop".to_string(),
             expr: Expr::VarRef("placeholder".to_string()),
+            module: None,
         }],
     };
     let sources = vec!["fn no_self_loop() { assert!(true); }".to_string()];

--- a/tests/expr_translator.rs
+++ b/tests/expr_translator.rs
@@ -94,7 +94,7 @@ fn make_ir_two_sigs(
         sig_multiplicity: SigMultiplicity::Default,
         parent: None,
         fields: vec![],
-        intersection_of: vec![],
+        intersection_of: vec![], module: None,
     };
     let node_a = StructureNode {
         name: sig_a.to_string(),
@@ -107,7 +107,7 @@ fn make_ir_two_sigs(
             mult,
             target: sig_b.to_string(),
             is_var: false, value_type: None, raw_union_type: None }],
-        intersection_of: vec![],
+        intersection_of: vec![], module: None,
     };
     OxidtrIR {
         structures: vec![node_a, node_b],
@@ -129,7 +129,7 @@ fn make_ir_self_ref(sig_name: &str, field_name: &str, mult: Multiplicity) -> Oxi
             mult,
             target: sig_name.to_string(),
             is_var: false, value_type: None, raw_union_type: None }],
-        intersection_of: vec![],
+        intersection_of: vec![], module: None,
     };
     OxidtrIR {
         structures: vec![node],

--- a/tests/extract_rust.rs
+++ b/tests/extract_rust.rs
@@ -380,7 +380,7 @@ fn resolve_external_types_filters_type_parameters() {
                 is_abstract: false,
                 parent: None,
                 source_location: "test".to_string(),
-                intersection_of: vec![],
+                intersection_of: vec![], module: None,
             },
         ],
         fact_candidates: vec![],

--- a/tests/extract_ts.rs
+++ b/tests/extract_ts.rs
@@ -389,6 +389,7 @@ sig DisplayProps extends BaseProps {}
         parent: None,
         fields: vec![],
         intersection_of: vec!["TransformProps".to_string(), "DisplayProps".to_string()],
+        module: None,
     });
     let files = oxidtr::backend::typescript::generate(&ir);
     let models = files.iter().find(|f| f.path == "models.ts").expect("models.ts");

--- a/tests/generate_pipeline.rs
+++ b/tests/generate_pipeline.rs
@@ -57,10 +57,20 @@ fn generate_self_model_pipeline() {
     let result = generate::run("models/oxidtr.als", &test_config(out_dir.to_str().unwrap())).unwrap();
     assert!(!result.files_written.is_empty());
 
-    let models = std::fs::read_to_string(out_dir.join("models.rs")).unwrap();
-    assert!(models.contains("pub struct SigDecl"));
-    assert!(models.contains("pub struct OxidtrIR"));
-    assert!(models.contains("pub enum Multiplicity"));
+    // oxidtr.als uses module declarations → modular layout
+    let sig_decl = std::fs::read_to_string(out_dir.join("ast/sig_decl.rs")).unwrap();
+    assert!(sig_decl.contains("pub struct SigDecl"));
+
+    let oxidtr_ir = std::fs::read_to_string(out_dir.join("ir/oxidtr_i_r.rs")).unwrap();
+    assert!(oxidtr_ir.contains("pub struct OxidtrIR"));
+
+    let mult = std::fs::read_to_string(out_dir.join("ast/multiplicity.rs")).unwrap();
+    assert!(mult.contains("pub enum Multiplicity"));
+
+    // Verify lib.rs with module declarations
+    let lib_rs = std::fs::read_to_string(out_dir.join("lib.rs")).unwrap();
+    assert!(lib_rs.contains("pub mod ast;"));
+    assert!(lib_rs.contains("pub mod ir;"));
 }
 
 #[test]

--- a/tests/guarantee_differentiation.rs
+++ b/tests/guarantee_differentiation.rs
@@ -372,7 +372,9 @@ fn self_hosting_all_targets_still_work() {
     let go_files = go::generate(&ir_val);
 
     // Each backend produces models + tests at minimum
-    assert!(file_exists(&rust_files, "models.rs"), "Rust should generate models.rs");
+    // oxidtr.als uses module declarations → Rust generates lib.rs + module dirs
+    assert!(file_exists(&rust_files, "lib.rs") || file_exists(&rust_files, "models.rs"),
+        "Rust should generate lib.rs (modular) or models.rs (flat)");
     assert!(file_exists(&ts_files, "models.ts"), "TS should generate models.ts");
     assert!(file_exists(&kt_files, "Models.kt"), "Kotlin should generate Models.kt");
     assert!(file_exists(&java_files, "Models.java"), "Java should generate Models.java");

--- a/tests/round_trip.rs
+++ b/tests/round_trip.rs
@@ -180,9 +180,28 @@ fn self_hosting_round_trip_rust() {
     let model = parser::parse(&source).unwrap();
     let ir_obj = ir::lower(&model).unwrap();
     let files = rust::generate(&ir_obj);
-    let models_rs = files.iter().find(|f| f.path == "models.rs").unwrap();
 
-    let mined = rust_extractor::extract(&models_rs.content);
+    // For modular layout: concatenate all .rs model files (excluding tests/fixtures/etc.)
+    // For flat layout: use models.rs directly
+    let models_content = if let Some(models_rs) = files.iter().find(|f| f.path == "models.rs") {
+        models_rs.content.clone()
+    } else {
+        // Modular layout: concatenate all per-concept .rs files
+        files.iter()
+            .filter(|f| f.path.ends_with(".rs")
+                && !f.path.ends_with("mod.rs")
+                && !f.path.ends_with("lib.rs")
+                && f.path != "tests.rs"
+                && f.path != "fixtures.rs"
+                && f.path != "helpers.rs"
+                && f.path != "operations.rs"
+                && f.path != "newtypes.rs")
+            .map(|f| f.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    let mined = rust_extractor::extract(&models_content);
 
     // Verify key structures survive the round-trip
     assert_sig_exists(&mined.sigs, "SigDecl");

--- a/tests/self_host_guarantees.rs
+++ b/tests/self_host_guarantees.rs
@@ -397,7 +397,11 @@ fn guarantee_4_mine_covers_all_sigs_and_fields() {
         let dir = tmp.path();
         let files = generate_fn(&ir);
         for file in &files {
-            std::fs::write(dir.join(&file.path), &file.content).unwrap();
+            let file_path = dir.join(&file.path);
+            if let Some(parent) = file_path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&file_path, &file.content).unwrap();
         }
 
         // Also write validators.ts for TS
@@ -461,7 +465,11 @@ fn guarantee_5_check_detects_missing_validation() {
     let tmp = tempfile::tempdir().unwrap();
     let dir = tmp.path();
     for file in &files {
-        std::fs::write(dir.join(&file.path), &file.content).unwrap();
+        let file_path = dir.join(&file.path);
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&file_path, &file.content).unwrap();
     }
 
     // Verify the model has named facts
@@ -514,7 +522,11 @@ fn guarantee_5_check_detects_removed_validation() {
     let tmp = tempfile::tempdir().unwrap();
     let dir = tmp.path();
     for file in &files {
-        std::fs::write(dir.join(&file.path), &file.content).unwrap();
+        let file_path = dir.join(&file.path);
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&file_path, &file.content).unwrap();
     }
 
     // Remove the tests.rs file entirely — this simulates losing all validations

--- a/tests/self_hosting.rs
+++ b/tests/self_hosting.rs
@@ -32,21 +32,34 @@ fn self_model_generates_rust() {
     let ir = ir::lower(&model).unwrap();
     let files = rust::generate(&ir);
 
-    assert!(files.iter().any(|f| f.path == "models.rs"), "no models.rs");
+    // Modular layout: lib.rs + module dirs; Flat layout: models.rs
+    let has_modular = files.iter().any(|f| f.path == "lib.rs");
+    let has_flat = files.iter().any(|f| f.path == "models.rs");
+    assert!(has_modular || has_flat, "should generate lib.rs (modular) or models.rs (flat)");
     assert!(files.iter().any(|f| f.path == "tests.rs"), "no tests.rs");
 
-    let models = files.iter().find(|f| f.path == "models.rs").unwrap();
+    // Concatenate all model content for assertion checks
+    let all_models: String = if has_flat {
+        files.iter().find(|f| f.path == "models.rs").unwrap().content.clone()
+    } else {
+        files.iter()
+            .filter(|f| f.path.ends_with(".rs") && !f.path.ends_with("mod.rs")
+                && !f.path.ends_with("lib.rs") && f.path != "tests.rs"
+                && f.path != "fixtures.rs" && f.path != "helpers.rs"
+                && f.path != "operations.rs" && f.path != "newtypes.rs")
+            .map(|f| f.content.as_str()).collect::<Vec<_>>().join("\n")
+    };
 
     // Verify key types from the self-hosting model exist
-    assert!(models.content.contains("pub enum Multiplicity"));
-    assert!(models.content.contains("pub struct SigDecl"));
-    assert!(models.content.contains("pub struct FieldDecl"));
-    assert!(models.content.contains("pub struct AlloyModel"));
-    assert!(models.content.contains("pub struct OxidtrIR"));
-    assert!(models.content.contains("pub struct StructureNode"));
-    assert!(models.content.contains("pub struct ConstraintNode"));
-    assert!(models.content.contains("pub struct OperationNode"));
-    assert!(models.content.contains("pub struct PropertyNode"));
+    assert!(all_models.contains("pub enum Multiplicity"));
+    assert!(all_models.contains("pub struct SigDecl"));
+    assert!(all_models.contains("pub struct FieldDecl"));
+    assert!(all_models.contains("pub struct AlloyModel"));
+    assert!(all_models.contains("pub struct OxidtrIR"));
+    assert!(all_models.contains("pub struct StructureNode"));
+    assert!(all_models.contains("pub struct ConstraintNode"));
+    assert!(all_models.contains("pub struct OperationNode"));
+    assert!(all_models.contains("pub struct PropertyNode"));
 }
 
 #[test]
@@ -105,7 +118,17 @@ fn self_hosted_crate_content_check() {
     let ir = ir::lower(&model).unwrap();
     let files = rust::generate(&ir);
 
-    let models = files.iter().find(|f| f.path == "models.rs").unwrap();
+    // Concatenate all model content for modular or flat layout
+    let all_models: String = if let Some(m) = files.iter().find(|f| f.path == "models.rs") {
+        m.content.clone()
+    } else {
+        files.iter()
+            .filter(|f| f.path.ends_with(".rs") && !f.path.ends_with("mod.rs")
+                && !f.path.ends_with("lib.rs") && f.path != "tests.rs"
+                && f.path != "fixtures.rs" && f.path != "helpers.rs"
+                && f.path != "operations.rs" && f.path != "newtypes.rs")
+            .map(|f| f.content.as_str()).collect::<Vec<_>>().join("\n")
+    };
     let tests = files.iter().find(|f| f.path == "tests.rs").unwrap();
 
     // No invariants.rs should be generated
@@ -113,10 +136,10 @@ fn self_hosted_crate_content_check() {
         "should NOT generate invariants.rs");
 
     // Key types from oxidtr domain
-    assert!(models.content.contains("pub enum Multiplicity"));
-    assert!(models.content.contains("pub struct SigDecl"));
-    assert!(models.content.contains("pub struct OxidtrIR"));
-    assert!(models.content.contains("pub struct StructureNode"));
+    assert!(all_models.contains("pub enum Multiplicity"));
+    assert!(all_models.contains("pub struct SigDecl"));
+    assert!(all_models.contains("pub struct OxidtrIR"));
+    assert!(all_models.contains("pub struct StructureNode"));
 
     // Tests use inlined translated expressions, not invariant function calls
     assert!(tests.content.contains(".iter().all("),

--- a/tests/target_validation.rs
+++ b/tests/target_validation.rs
@@ -40,44 +40,67 @@ edition = "2021"
     )
     .unwrap();
 
-    // Write lib.rs that includes generated modules
-    let mut lib_rs = String::new();
-    lib_rs.push_str("#[allow(dead_code, unused_variables, unused_imports)]\n");
-    lib_rs.push_str("pub mod models;\n");
+    // Detect modular layout (has lib.rs) vs flat layout (has models.rs)
+    let has_lib_rs = files.iter().any(|f| f.path == "lib.rs");
 
-    let has_helpers = files.iter().any(|f| f.path == "helpers.rs");
-    let has_operations = files.iter().any(|f| f.path == "operations.rs");
-    let has_tests = files.iter().any(|f| f.path == "tests.rs");
-    let has_fixtures = files.iter().any(|f| f.path == "fixtures.rs");
-    let has_newtypes = files.iter().any(|f| f.path == "newtypes.rs");
-
-    if has_helpers {
-        lib_rs.push_str("pub mod helpers;\n");
-    }
-    if has_operations {
-        lib_rs.push_str("pub mod operations;\n");
-    }
-    if has_fixtures {
+    if has_lib_rs {
+        // Modular layout: the generator produces its own lib.rs
+        // Write all generated files (creating subdirectories as needed)
+        for file in &files {
+            let file_path = format!("{crate_dir}/src/{}", file.path);
+            if let Some(parent) = std::path::Path::new(&file_path).parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            let mut content = String::new();
+            // lib.rs and mod.rs need crate-level allow, others get file-level
+            if file.path == "lib.rs" {
+                content.push_str("#![allow(dead_code, unused_variables, unused_imports, non_snake_case)]\n");
+            } else if !file.path.ends_with("mod.rs") {
+                content.push_str("#![allow(dead_code, unused_variables, unused_imports, non_snake_case)]\n");
+            }
+            content.push_str(&file.content);
+            std::fs::write(&file_path, content).unwrap();
+        }
+    } else {
+        // Flat layout: construct lib.rs manually
+        let mut lib_rs = String::new();
         lib_rs.push_str("#[allow(dead_code, unused_variables, unused_imports)]\n");
-        lib_rs.push_str("pub mod fixtures;\n");
-    }
-    if has_newtypes {
-        lib_rs.push_str("#[allow(dead_code, unused_variables, unused_imports)]\n");
-        lib_rs.push_str("pub mod newtypes;\n");
-    }
-    if has_tests {
-        lib_rs.push_str("#[allow(dead_code, unused_variables, unused_imports)]\n");
-        lib_rs.push_str("mod tests;\n");
-    }
+        lib_rs.push_str("pub mod models;\n");
 
-    std::fs::write(format!("{crate_dir}/src/lib.rs"), lib_rs).unwrap();
+        let has_helpers = files.iter().any(|f| f.path == "helpers.rs");
+        let has_operations = files.iter().any(|f| f.path == "operations.rs");
+        let has_tests = files.iter().any(|f| f.path == "tests.rs");
+        let has_fixtures = files.iter().any(|f| f.path == "fixtures.rs");
+        let has_newtypes = files.iter().any(|f| f.path == "newtypes.rs");
 
-    // Write generated files
-    for file in &files {
-        let mut content = String::new();
-        content.push_str("#![allow(dead_code, unused_variables, unused_imports, non_snake_case)]\n");
-        content.push_str(&file.content);
-        std::fs::write(format!("{crate_dir}/src/{}", file.path), content).unwrap();
+        if has_helpers {
+            lib_rs.push_str("pub mod helpers;\n");
+        }
+        if has_operations {
+            lib_rs.push_str("pub mod operations;\n");
+        }
+        if has_fixtures {
+            lib_rs.push_str("#[allow(dead_code, unused_variables, unused_imports)]\n");
+            lib_rs.push_str("pub mod fixtures;\n");
+        }
+        if has_newtypes {
+            lib_rs.push_str("#[allow(dead_code, unused_variables, unused_imports)]\n");
+            lib_rs.push_str("pub mod newtypes;\n");
+        }
+        if has_tests {
+            lib_rs.push_str("#[allow(dead_code, unused_variables, unused_imports)]\n");
+            lib_rs.push_str("mod tests;\n");
+        }
+
+        std::fs::write(format!("{crate_dir}/src/lib.rs"), lib_rs).unwrap();
+
+        // Write generated files
+        for file in &files {
+            let mut content = String::new();
+            content.push_str("#![allow(dead_code, unused_variables, unused_imports, non_snake_case)]\n");
+            content.push_str(&file.content);
+            std::fs::write(format!("{crate_dir}/src/{}", file.path), content).unwrap();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds support for generating Rust code in a modular layout where structures are organized into subdirectories by module, with each domain concept getting its own file. The generator now detects when structures have module annotations and automatically switches from flat layout (single `models.rs`) to modular layout (module directories with `lib.rs`).

## Key Changes

### Parser & AST
- Added `module` field to `SigDecl` to track inline module grouping from `module X` declarations
- Parser now recognizes `module` declarations and assigns them to subsequently parsed signatures
- Module information is propagated through facts, predicates, and enums

### Rust Backend Generation
- Added `generate_modular()` function that creates a hierarchical file structure:
  - Each module gets a subdirectory with concept-based `.rs` files
  - Each module has a `mod.rs` that declares and re-exports its types
  - Top-level `lib.rs` declares all modules
- Implemented `group_into_concepts()` to organize structures into logical units (abstract sig + variants form one concept)
- Implemented `generate_concept_file()` to generate individual concept files with proper:
  - Cross-module imports using `crate::module::Type` syntax
  - Intra-module imports using `super::Type` syntax
  - Automatic dependency resolution
- Added modular variants of helper functions: `generate_operations_modular()`, `generate_tests_modular()`, `generate_fixtures_modular()`, `generate_newtypes_modular()`

### Extraction & Mining
- Updated `extract/mod.rs` to infer module names from file paths (e.g., `ast/sig_decl.rs` → module "ast")
- Added `infer_module_from_path()` to extract module information from directory structure
- Updated `extract/renderer.rs` to render mined models with module sections
- Modified language extractors (Rust, TypeScript, Go, Java, Kotlin, C#, Lean, Swift) to initialize `module: None` field

### Detection & Compatibility
- Updated `detect_lang()` to recognize modular Rust layout by checking for `lib.rs`
- Updated `check/mod.rs` to handle both flat and modular Rust layouts
- Modified tests to work with both layout styles by concatenating model files when needed

### Alloy Model
- Updated `models/oxidtr.als` to use `module ast` and `module ir` declarations, demonstrating the feature

## Implementation Details
- The generator automatically chooses layout based on presence of module annotations in the IR
- Module ordering is preserved from the source
- Ungrouped structures (without module) go to top-level `models.rs` in modular layout
- Enum variants are grouped with their parent enum in the same concept file
- Cross-module type references are automatically resolved with proper import paths
- All existing tests updated to handle both flat and modular layouts transparently

https://claude.ai/code/session_01BqmJ7A1b15yjAAZbx8Ano1