### PR TITLE
fix: exclude native type aliases from MISSING_STRUCT in check differ

### DIFF
--- a/src/check/differ.rs
+++ b/src/check/differ.rs
@@ -3,6 +3,7 @@
 use crate::ir::nodes::OxidtrIR;
 use crate::parser::ast::Multiplicity;
 use crate::analyze;
+use crate::backend::is_native_type_alias;
 use super::{ExtractedImpl, ExtractedStruct};
 
 fn to_snake_case(s: &str) -> String {
@@ -397,8 +398,9 @@ where F: Fn(&str) -> String {
     let impl_map: std::collections::HashMap<&str, &ExtractedStruct> =
         extracted.structs.iter().map(|s| (s.name.as_str(), s)).collect();
 
-    // Missing: in IR but not in impl
+    // Missing: in IR but not in impl (skip native type aliases — they map to primitives)
     for s in &ir.structures {
+        if is_native_type_alias(&s.name) { continue; }
         if !impl_map.contains_key(s.name.as_str()) {
             diffs.push(DiffItem::MissingStruct { name: s.name.clone() });
         }

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -261,6 +261,46 @@ fn check_run_missing_models_rs_is_error() {
     assert!(matches!(err, Err(check::CheckError::ImplNotFound(_))));
 }
 
+// ── Native type aliases should not appear as MISSING_STRUCT ──────────────────
+
+#[test]
+fn differ_skips_native_type_aliases() {
+    // If the model contains sigs Str, Int, Float, Bool (native type aliases),
+    // the differ should NOT report them as MISSING_STRUCT because backends
+    // map them to language primitives instead of emitting struct definitions.
+    let ir = make_ir(
+        vec![
+            StructureNode { name: "User".into(), is_enum: false, is_var: false, sig_multiplicity: SigMultiplicity::Default, parent: None, fields: vec![
+                IRField { name: "name".into(), is_var: false, mult: Multiplicity::One, target: "Str".into(), value_type: None, raw_union_type: None },
+            ], intersection_of: vec![], module: None },
+            StructureNode { name: "Str".into(), is_enum: false, is_var: false, sig_multiplicity: SigMultiplicity::Default, parent: None, fields: vec![], intersection_of: vec![], module: None },
+            StructureNode { name: "Int".into(), is_enum: false, is_var: false, sig_multiplicity: SigMultiplicity::Default, parent: None, fields: vec![], intersection_of: vec![], module: None },
+            StructureNode { name: "Float".into(), is_enum: false, is_var: false, sig_multiplicity: SigMultiplicity::Default, parent: None, fields: vec![], intersection_of: vec![], module: None },
+            StructureNode { name: "Bool".into(), is_enum: false, is_var: false, sig_multiplicity: SigMultiplicity::Default, parent: None, fields: vec![], intersection_of: vec![], module: None },
+        ],
+        vec![],
+    );
+    let extracted = ExtractedImpl {
+        structs: vec![ExtractedStruct {
+            name: "User".into(),
+            is_enum: false,
+            is_var: false,
+            fields: vec![ExtractedField { name: "name".into(), mult: Multiplicity::One, target: "String".into(), is_var: false }],
+        }],
+        fns: vec![],
+    };
+    let diffs = differ::diff(&ir, &extracted);
+    // Should not contain MissingStruct for any native type alias
+    let native_missing: Vec<_> = diffs.iter().filter(|d| matches!(d,
+        DiffItem::MissingStruct { name } if matches!(name.as_str(), "Str" | "Int" | "Float" | "Bool")
+    )).collect();
+    assert!(native_missing.is_empty(),
+        "native type aliases should not be reported as MISSING_STRUCT: {native_missing:?}");
+    // Should not contain ExtraStruct for User either
+    assert!(!diffs.iter().any(|d| matches!(d, DiffItem::MissingStruct { name } if name == "User")),
+        "User should not be missing: {diffs:?}");
+}
+
 // ── Alloy 6: temporal constraint checking ──────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- differの `diff_with_fn_normalizer` でネイティブ型エイリアス (Str, Int, Float, Bool) を MISSING_STRUCT チェックから除外
- バックエンドはこれらを言語プリミティブにマップし構造体を生成しないため、checkで偽陽性が出ていた
- `differ_skips_native_type_aliases` テストを追加

## Test plan

- [x] `cargo test --test check` 全21テストパス
- [x] `cargo test` 全テストパス・warning増加なし

https://claude.ai/code/session_01CtQhM6x5yjwXs3EFoyZtQ7