### PR TITLE
refactor: extract rust import rewriting and tighten extractor identifier guard

### DIFF
--- a/src/backend/rust/import_rewrite.rs
+++ b/src/backend/rust/import_rewrite.rs
@@ -1,0 +1,64 @@
+/// Rewrites `use super::models::*;` in a generated Rust source string so that
+/// it imports types from per-module sources instead of the monolithic
+/// `models.rs`.
+///
+/// When `has_models` is true, the original `use super::models::*;` is kept
+/// alongside the per-module imports — `models.rs` still exists for ungrouped
+/// types in that case.
+pub(super) fn rewrite_models_import(
+    content: String,
+    modules: &[String],
+    has_models: bool,
+) -> String {
+    let mut imports: Vec<String> = modules
+        .iter()
+        .map(|m| format!("use super::{m}::*;"))
+        .collect();
+    if has_models {
+        imports.push("use super::models::*;".to_string());
+    }
+    content.replace("use super::models::*;", &imports.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rewrite_models_import;
+
+    #[test]
+    fn replaces_models_import_with_module_imports() {
+        let input = "use super::models::*;\nfn f() {}\n".to_string();
+        let modules = vec!["a".to_string(), "b".to_string()];
+        let out = rewrite_models_import(input, &modules, false);
+        assert_eq!(out, "use super::a::*;\nuse super::b::*;\nfn f() {}\n");
+    }
+
+    #[test]
+    fn keeps_models_import_when_has_models() {
+        let input = "use super::models::*;\n".to_string();
+        let modules = vec!["a".to_string()];
+        let out = rewrite_models_import(input, &modules, true);
+        assert_eq!(out, "use super::a::*;\nuse super::models::*;\n");
+    }
+
+    #[test]
+    fn no_modules_only_models() {
+        let input = "use super::models::*;\n".to_string();
+        let out = rewrite_models_import(input, &[], true);
+        assert_eq!(out, "use super::models::*;\n");
+    }
+
+    #[test]
+    fn no_modules_no_models_strips_import() {
+        let input = "use super::models::*;\nfn f() {}\n".to_string();
+        let out = rewrite_models_import(input, &[], false);
+        assert_eq!(out, "\nfn f() {}\n");
+    }
+
+    #[test]
+    fn leaves_other_content_intact() {
+        let input = "fn f() {}\n".to_string();
+        let modules = vec!["a".to_string()];
+        let out = rewrite_models_import(input.clone(), &modules, false);
+        assert_eq!(out, input);
+    }
+}

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -1,4 +1,7 @@
 pub mod expr_translator;
+mod import_rewrite;
+
+use self::import_rewrite::rewrite_models_import;
 
 use super::{GeneratedFile, TargetLang, is_native_type_alias, resolve_type};
 use crate::ir::nodes::*;
@@ -220,9 +223,11 @@ fn generate_modular(ir: &OxidtrIR, config: &RustBackendConfig) -> Vec<GeneratedF
         || ir.properties.iter().any(|p| expr_uses_tc(&p.expr));
     if has_tc {
         writeln!(lib_rs, "pub mod helpers;").unwrap();
-        let helpers_content = generate_helpers(ir)
-            .replace("use super::models::*;",
-                &module_order.iter().map(|m| format!("use super::{m}::*;")).collect::<Vec<_>>().join("\n"));
+        let helpers_content = rewrite_models_import(
+            generate_helpers(ir),
+            &module_order,
+            !ungrouped.is_empty(),
+        );
         files.push(GeneratedFile {
             path: "helpers.rs".to_string(),
             content: helpers_content,

--- a/src/extract/rust_extractor.rs
+++ b/src/extract/rust_extractor.rs
@@ -742,7 +742,7 @@ fn extract_facts_from_lines(
                 let before = line[..pos].trim();
                 // Extract the last identifier/chain before .unwrap()
                 let field = before.rsplit(|c: char| c == ' ' || c == '=' || c == '(').next().unwrap_or(before).trim();
-                if !field.is_empty() {
+                if looks_like_identifier_chain(field) {
                     facts.push(MinedFactCandidate {
                         alloy_text: format!("{field} is one (unsafe unwrap)"),
                         confidence: Confidence::Low,
@@ -758,7 +758,7 @@ fn extract_facts_from_lines(
             if let Some(pos) = line.find(".unwrap_or") {
                 let before = line[..pos].trim();
                 let field = before.rsplit(|c: char| c == ' ' || c == '=' || c == '(').next().unwrap_or(before).trim();
-                if !field.is_empty() {
+                if looks_like_identifier_chain(field) {
                     facts.push(MinedFactCandidate {
                         alloy_text: format!("{field} is lone (with default)"),
                         confidence: Confidence::Medium,
@@ -920,4 +920,53 @@ fn extract_contains_fact(line: &str) -> String {
 /// Extract @temporal annotations — delegates to shared implementation.
 fn extract_temporal_annotations(source: &str, facts: &mut Vec<MinedFactCandidate>) {
     super::extract_temporal_annotations(source, facts);
+}
+
+/// Checks whether a string looks like a valid Rust identifier chain
+/// (e.g. `foo`, `foo.bar`, `self.field.sub_field`) — i.e. something we can
+/// reasonably emit as an Alloy-side reference.
+///
+/// Rejects chain-call residue like `")"` or `"))"` which the rsplit-based
+/// parser used to surface as "identifiers" when the receiver of `.unwrap()`
+/// was itself a method call (e.g. `rcu.read().get().unwrap()`).
+fn looks_like_identifier_chain(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    // Must start with a letter or underscore — an identifier cannot begin
+    // with `)`, digits, or punctuation.
+    let first = s.chars().next().unwrap();
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return false;
+    }
+    // Every remaining char must be an identifier char or a chain separator.
+    s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::looks_like_identifier_chain;
+
+    #[test]
+    fn accepts_plain_identifiers() {
+        assert!(looks_like_identifier_chain("foo"));
+        assert!(looks_like_identifier_chain("_x"));
+        assert!(looks_like_identifier_chain("foo.bar"));
+        assert!(looks_like_identifier_chain("self.field.sub"));
+    }
+
+    #[test]
+    fn rejects_dangling_parens() {
+        assert!(!looks_like_identifier_chain(")"));
+        assert!(!looks_like_identifier_chain("))"));
+        assert!(!looks_like_identifier_chain(".foo"));
+        assert!(!looks_like_identifier_chain(""));
+    }
+
+    #[test]
+    fn rejects_call_syntax() {
+        assert!(!looks_like_identifier_chain("foo()"));
+        assert!(!looks_like_identifier_chain("foo(x)"));
+    }
 }


### PR DESCRIPTION
## Summary

- Move the models→module import rewrite logic out of `src/backend/rust/mod.rs` into a dedicated `import_rewrite` submodule with unit tests. The new `rewrite_models_import` helper preserves `use super::models::*;` when ungrouped types still live in `models.rs`, fixing the implicit assumption in the prior `.replace(...)` call.
- Tighten the rust extractor's `.unwrap()` / `.unwrap_or` heuristics: replace the `!field.is_empty()` guard with a new `looks_like_identifier_chain` helper so chain-call residue like `")"` or `"))"` no longer surfaces as bogus Alloy identifiers when the receiver of `.unwrap()` is itself a method call (e.g. `rcu.read().get().unwrap()`).

## Test plan

- [x] `cargo build` (zero warnings from changed code)
- [x] `cargo test` — full suite passes
- [x] New unit tests in `src/backend/rust/import_rewrite.rs` cover the four import-rewrite cases (modules-only, modules+models, models-only, no-op)
- [x] New unit tests in `src/extract/rust_extractor.rs` cover identifier acceptance, dangling-paren rejection, and call-syntax rejection

https://claude.ai/code/session_01TnjsVytC1KPjDgzpQPYfoX