### PR TITLE
feat: support Alloy 6 multi-file models (module / open)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,39 @@ mise exec rust -- cargo run -- extract generated/
 mise exec rust -- cargo run -- extract src/ --lang rust
 ```
 
+## Alloy モデルのファイル構成 (Alloy 6 spec 準拠)
+
+Alloy 6 仕様では **1 ファイル = 1 module**、`module X` 宣言はファイル先頭のみ置ける。
+oxidtr は以下の 2 形式を両方サポートする:
+
+**推奨: 複数ファイル構成** (Alloy Analyzer 互換、例 `models/oxidtr-split.als`):
+
+```
+models/
+  oxidtr-split.als          # main: open oxidtr/{ast,ir,analysis,validated}
+  oxidtr/
+    ast.als                 # module oxidtr/ast
+    ir.als                  # module oxidtr/ir    (open oxidtr/ast)
+    analysis.als            # module oxidtr/analysis
+    validated.als           # module oxidtr/validated
+```
+
+`generate` / `check` / `extract` はメインファイル (またはディレクトリ) を渡すだけで
+`open` を辿って全モジュールを解決する。
+
+```bash
+cargo run -- generate models/oxidtr-split.als --target rust --output generated
+cargo run -- check --model models/oxidtr-split.als --impl generated
+cargo run -- extract src/ --lang rust -o out/      # -o がディレクトリ → 複数ファイル出力
+cargo run -- extract src/ --lang rust -o out.als   # -o がファイル → 単一ファイル (警告)
+```
+
+**レガシー: 単一ファイルに複数 `module X`** (`models/oxidtr.als`):
+
+1 ファイル内に `module ast ... module ir ...` を書く形式。Alloy 仕様違反で
+Alloy Analyzer には食わせられないが、oxidtr は DEPRECATED warning を出しつつ
+後方互換のため読み込みを許容する。新規モデルは multi-file 形式で書くこと。
+
 ## アーキテクチャ
 
 ```

--- a/models/oxidtr-domain.als
+++ b/models/oxidtr-domain.als
@@ -159,7 +159,14 @@ sig ParamDecl {
   paramType: one SigDecl
 }
 
+sig ImportDecl {
+  importPath:  one SigDecl,
+  importAlias: lone SigDecl
+}
+
 sig AlloyModel {
+  moduleDecl: lone SigDecl,
+  imports: set ImportDecl,
   sigs:    set SigDecl,
   facts:   set FactDecl,
   preds:   set PredDecl,

--- a/models/oxidtr-internal.als
+++ b/models/oxidtr-internal.als
@@ -57,6 +57,7 @@ one sig Pipe     extends Token {}
 one sig Plus     extends Token {}
 one sig Ampersand extends Token {}
 one sig Minus    extends Token {}
+one sig Slash    extends Token {}
 one sig Ident    extends Token {}
 one sig Int      extends Token {}
 one sig Eof      extends Token {}
@@ -253,6 +254,15 @@ sig MergeResult {
   mergedModel: one MinedModel,
   conflicts:   set MergeConflict
 }
+
+-- Multi-file renderer output: one entry per emitted `.als` file.
+sig RenderedFile {
+  renderedPath:    one SigDecl,
+  renderedContent: one SigDecl
+}
+
+-- Host-language std::path::PathBuf placeholder (external type).
+sig PathBuf {}
 
 -------------------------------------------------------------------------------
 -- Guarantee analysis

--- a/models/oxidtr-split.als
+++ b/models/oxidtr-split.als
@@ -1,0 +1,131 @@
+module oxidtr
+
+-- Alloy 6 spec-compliant multi-file variant of models/oxidtr.als.
+-- Each sub-module lives in oxidtr/<name>.als and is imported via `open`.
+-- Cross-module facts, preds, and asserts live here (in the main file).
+
+open oxidtr/ast
+open oxidtr/ir
+open oxidtr/analysis
+open oxidtr/validated
+
+-------------------------------------------------------------------------------
+-- IR structural facts (cross-module: ast + ir)
+-------------------------------------------------------------------------------
+
+fact NoCyclicIRParent {
+  no sn: StructureNode | sn in sn.^irParent
+}
+
+fact IRParentAsymmetric {
+  all sn: StructureNode | all p: StructureNode |
+    sn.irParent = p implies p.irParent = p.irParent
+}
+
+fact IRFieldTargetRelatedToFields {
+  all f: IRField | all sn: StructureNode |
+    f in sn.irFields implies f.irTarget = f.irTarget
+}
+
+fact IRFieldOwnership {
+  all f: IRField | some sn: StructureNode | f in sn.irFields
+}
+
+fact NoSelfRefIrIsVar {
+  no f: IRField | f in f.irIsVar
+}
+
+fact UniqueStructurePerSig {
+  all ir: OxidtrIR | all s1: ir.structures | all s2: ir.structures |
+    s1.origin = s2.origin implies s1 = s2
+}
+
+fact IRStructuresCardinality  { all ir: OxidtrIR | #ir.structures = #ir.structures }
+fact IRConstraintsCardinality { all ir: OxidtrIR | #ir.constraints = #ir.constraints }
+fact IROperationsCardinality  { all ir: OxidtrIR | #ir.operations = #ir.operations }
+fact IRPropertiesCardinality  { all ir: OxidtrIR | #ir.properties = #ir.properties }
+
+fact StructureNodeCardinality { all sn: StructureNode | #sn.irFields = #sn.irFields }
+fact OperationNodeCardinality { all op: OperationNode | #op.oparams = #op.oparams }
+fact PropertyNodeCardinality  { all pn: PropertyNode | #pn.pconstraints = #pn.pconstraints }
+
+-------------------------------------------------------------------------------
+-- Lowering invariants (cross-module: ast + ir)
+-------------------------------------------------------------------------------
+
+fact SigToStructureBijection {
+  all s: SigDecl | all ir: OxidtrIR |
+    some sn: ir.structures | sn.origin = s
+}
+
+fact FactToConstraint {
+  all f: FactDecl | all ir: OxidtrIR |
+    some cn: ir.constraints | cn.corigin = f
+}
+
+fact PredToOperation {
+  all p: PredDecl | all ir: OxidtrIR |
+    some on: ir.operations | on.oorigin = p
+}
+
+fact AssertToProperty {
+  all a: AssertDecl | all ir: OxidtrIR |
+    some pn: ir.properties | pn.porigin = a
+}
+
+-------------------------------------------------------------------------------
+-- Predicates: lowering operations
+-------------------------------------------------------------------------------
+
+pred lowerOneSig[ir: one OxidtrIR, s: one SigDecl, sn: one StructureNode] {
+  sn.origin = s
+  sn in ir.structures
+}
+
+pred addField[s: one SigDecl, f: one FieldDecl] {
+  f in s.fields
+}
+
+pred addStructure[ir: one OxidtrIR, sn: one StructureNode] {
+  sn in ir.structures
+}
+
+pred addConstraint[ir: one OxidtrIR, cn: one ConstraintNode] {
+  cn in ir.constraints
+}
+
+pred setIRParent[child: one StructureNode, par: one StructureNode] {
+  child.irParent = par
+}
+
+pred evalExpr[e: one Expr]           { e = e }
+pred useMult[m: one Multiplicity]    { m = m }
+pred useCompareOp[op: one CompareOp] { op = op }
+pred useLogicOp[op: one LogicOp]     { op = op }
+pred useQuantKind[q: one QuantKind]  { q = q }
+
+-------------------------------------------------------------------------------
+-- Safety assertions
+-------------------------------------------------------------------------------
+
+assert NoCyclicInheritance {
+  no s: SigDecl | s in s.^parent
+}
+
+assert UniqueStructureOrigins {
+  all ir: OxidtrIR | all s1: ir.structures | all s2: ir.structures |
+    s1.origin = s2.origin implies s1 = s2
+}
+
+assert IRParentNoCycle {
+  no sn: StructureNode | sn in sn.^irParent
+}
+
+assert StructureCoverage {
+  all ir: OxidtrIR | all sn: ir.structures | some s: SigDecl | sn.origin = s
+}
+
+check NoCyclicInheritance    for 6
+check UniqueStructureOrigins for 6
+check IRParentNoCycle        for 6
+check StructureCoverage      for 6

--- a/models/oxidtr.als
+++ b/models/oxidtr.als
@@ -163,7 +163,14 @@ sig ParamDecl {
   paramType: one SigDecl
 }
 
+sig ImportDecl {
+  importPath:  one SigDecl,     -- qualified path of `open foo/bar`
+  importAlias: lone SigDecl     -- optional `as Alias` suffix
+}
+
 sig AlloyModel {
+  moduleDecl: lone SigDecl,
+  imports: set ImportDecl,
   sigs:    set SigDecl,
   facts:   set FactDecl,
   preds:   set PredDecl,

--- a/models/oxidtr/analysis.als
+++ b/models/oxidtr/analysis.als
@@ -1,0 +1,81 @@
+module oxidtr/analysis
+
+-- Constraint / anomaly / coverage analysis over the lowered IR.
+-- Depends on: oxidtr/ast, oxidtr/ir.
+
+open oxidtr/ast
+open oxidtr/ir
+
+-------------------------------------------------------------------------------
+-- Constraint analysis (ConstraintInfo variants)
+-------------------------------------------------------------------------------
+
+sig FieldOrdering {
+  foSig:        one StructureNode,
+  foLeftField:  one FieldDecl,
+  foOp:         one CompareOp,
+  foRightField: one FieldDecl
+}
+
+sig Implication {
+  implSig:        one StructureNode,
+  implCondition:  one Expr,
+  implConsequent: one Expr
+}
+
+sig Prohibition {
+  prohSig:       one StructureNode,
+  prohCondition: one Expr
+}
+
+sig Disjoint {
+  disjSig:   one StructureNode,
+  disjLeft:  one Expr,
+  disjRight: one Expr
+}
+
+sig Exhaustive {
+  exhSig:        one StructureNode,
+  exhCategories: set Expr
+}
+
+sig ValueBound {
+  vbSig:   one StructureNode,
+  vbField: one FieldDecl
+}
+
+-------------------------------------------------------------------------------
+-- Anomaly detection (AnomalyPattern variants)
+-------------------------------------------------------------------------------
+
+abstract sig AnomalyPattern {}
+
+sig UnconstrainedField extends AnomalyPattern {
+  ucfSig:   one StructureNode,
+  ucfField: one IRField
+}
+
+sig UnboundedCollection extends AnomalyPattern {
+  ubcSig:   one StructureNode,
+  ubcField: one IRField
+}
+
+sig UnguardedSelfRef extends AnomalyPattern {
+  usrSig:   one StructureNode,
+  usrField: one IRField
+}
+
+-------------------------------------------------------------------------------
+-- Fact coverage analysis
+-------------------------------------------------------------------------------
+
+sig PairwiseCoverage {
+  pcSig:   one StructureNode,
+  pcFactA: one ConstraintNode,
+  pcFactB: one ConstraintNode
+}
+
+sig FactCoverage {
+  fcPairwise:        set PairwiseCoverage,
+  fcUncoveredFields: set IRField
+}

--- a/models/oxidtr/ast.als
+++ b/models/oxidtr/ast.als
@@ -1,0 +1,216 @@
+module oxidtr/ast
+
+-- Alloy AST (parser output).
+-- Depends on: nothing (leaf module).
+
+abstract sig Multiplicity {}
+one sig One  extends Multiplicity {}
+one sig Lone extends Multiplicity {}
+one sig Set  extends Multiplicity {}
+one sig Seq  extends Multiplicity {}
+
+sig FieldDecl {
+  fname:  one SigDecl,
+  isVar:  lone FieldDecl, -- Alloy 6: mutable field marker (self-ref = true)
+  mult:   one Multiplicity,
+  target: one SigDecl
+}
+
+sig SigDecl {
+  isAbstract:      lone SigDecl,
+  isVarSig:        lone SigDecl,
+  sigMultiplicity: one SigMultiplicity,
+  parent:          lone SigDecl,
+  fields:          set FieldDecl
+}
+
+abstract sig Expr {}
+
+sig VarRef      extends Expr {}
+sig FieldAccess extends Expr {
+  base:         one Expr,
+  accessTarget: one SigDecl
+}
+sig Cardinality extends Expr { inner: one Expr }
+sig IntLiteral extends Expr {}
+sig TransitiveClosure extends Expr { tcInner: one Expr }
+sig SetOp extends Expr {
+  setOpKind:  one SetOpKind,
+  setOpLeft:  one Expr,
+  setOpRight: one Expr
+}
+sig Product extends Expr {
+  prodLeft:  one Expr,
+  prodRight: one Expr
+}
+sig MultFormula extends Expr {
+  mfKind: one QuantKind,
+  mfExpr: one Expr
+}
+sig Prime extends Expr { primeInner: one Expr }
+sig TemporalUnary extends Expr {
+  tuOp:   one TemporalUnaryOp,
+  tuExpr: one Expr
+}
+
+abstract sig TemporalUnaryOp {}
+one sig Always       extends TemporalUnaryOp {}
+one sig Eventually   extends TemporalUnaryOp {}
+one sig After        extends TemporalUnaryOp {}
+one sig Historically extends TemporalUnaryOp {}
+one sig Once         extends TemporalUnaryOp {}
+one sig Before       extends TemporalUnaryOp {}
+
+sig TemporalBinary extends Expr {
+  tbOp:    one TemporalBinaryOp,
+  tbLeft:  one Expr,
+  tbRight: one Expr
+}
+
+abstract sig TemporalBinaryOp {}
+one sig Until     extends TemporalBinaryOp {}
+one sig Since     extends TemporalBinaryOp {}
+one sig Release   extends TemporalBinaryOp {}
+one sig Triggered extends TemporalBinaryOp {}
+
+sig FunApp extends Expr {
+  receiver: lone Expr,
+  funArgs:  seq Expr
+}
+
+abstract sig TemporalKind {}
+one sig Invariant     extends TemporalKind {}
+one sig Liveness      extends TemporalKind {}
+one sig PastInvariant extends TemporalKind {}
+one sig PastLiveness  extends TemporalKind {}
+one sig Step          extends TemporalKind {}
+one sig Binary        extends TemporalKind {}
+
+abstract sig CompareOp {}
+one sig In    extends CompareOp {}
+one sig Eq    extends CompareOp {}
+one sig NotEq extends CompareOp {}
+one sig Lt    extends CompareOp {}
+one sig Gt    extends CompareOp {}
+one sig Lte   extends CompareOp {}
+one sig Gte   extends CompareOp {}
+
+sig Comparison extends Expr {
+  cop:    one CompareOp,
+  cleft:  one Expr,
+  cright: one Expr
+}
+
+abstract sig LogicOp {}
+one sig And     extends LogicOp {}
+one sig Or      extends LogicOp {}
+one sig Implies extends LogicOp {}
+one sig Iff     extends LogicOp {}
+
+sig BinaryLogic extends Expr {
+  lop:    one LogicOp,
+  lleft:  one Expr,
+  lright: one Expr
+}
+
+sig Not extends Expr { notInner: one Expr }
+
+abstract sig QuantKind {}
+one sig All  extends QuantKind {}
+one sig Some extends QuantKind {}
+one sig No   extends QuantKind {}
+
+abstract sig SetOpKind {}
+one sig Union        extends SetOpKind {}
+one sig Intersection extends SetOpKind {}
+one sig Difference   extends SetOpKind {}
+
+abstract sig SigMultiplicity {}
+one sig Default extends SigMultiplicity {}
+
+sig QuantBinding {
+  qbDomain: one Expr
+}
+
+sig Quantifier extends Expr {
+  qkind:    one QuantKind,
+  bindings: set QuantBinding,
+  qbody:    one Expr
+}
+
+sig FactDecl   { factBody:   one Expr }
+sig AssertDecl { assertBody: one Expr }
+
+sig PredDecl {
+  predParams: set ParamDecl,
+  predBody:   set Expr
+}
+
+sig FunDecl {
+  receiverSig:   lone SigDecl,
+  funParams:     set ParamDecl,
+  funReturnMult: one Multiplicity,
+  funBody:       one Expr
+}
+
+sig ParamDecl {
+  paramMult: one Multiplicity,
+  paramType: one SigDecl
+}
+
+sig ImportDecl {
+  importPath:  one SigDecl,
+  importAlias: lone SigDecl
+}
+
+sig AlloyModel {
+  moduleDecl: lone SigDecl,
+  imports:    set ImportDecl,
+  sigs:       set SigDecl,
+  facts:      set FactDecl,
+  preds:      set PredDecl,
+  funs:       set FunDecl,
+  asserts:    set AssertDecl
+}
+
+-------------------------------------------------------------------------------
+-- AST structural facts
+-------------------------------------------------------------------------------
+
+fact NoCyclicParent {
+  no s: SigDecl | s in s.^parent
+}
+
+fact ParentAsymmetric {
+  all s: SigDecl | all p: SigDecl |
+    s.parent = p implies p.isAbstract = p.isAbstract
+}
+
+fact NoSelfAbstract {
+  no s: SigDecl | s in s.isAbstract
+}
+
+fact NoSelfRefIsVar {
+  no f: FieldDecl | f in f.isVar
+}
+
+fact FieldOwnershipBidirectional {
+  all f: FieldDecl | all s: SigDecl | f in s.fields implies f.fname = s
+}
+
+fact FieldTargetRelatedToFields {
+  all f: FieldDecl | all s: SigDecl |
+    f in s.fields implies f.target = f.target
+}
+
+fact SigFieldCount { all s: SigDecl | #s.fields = #s.fields }
+
+fact AlloyModelSigsCardinality    { all m: AlloyModel | #m.sigs = #m.sigs }
+fact AlloyModelFactsCardinality   { all m: AlloyModel | #m.facts = #m.facts }
+fact AlloyModelPredsCardinality   { all m: AlloyModel | #m.preds = #m.preds }
+fact AlloyModelAssertsCardinality { all m: AlloyModel | #m.asserts = #m.asserts }
+fact AlloyModelFunsCardinality    { all m: AlloyModel | #m.funs = #m.funs }
+fact PredParamsCardinality { all p: PredDecl | #p.predParams = #p.predParams }
+fact PredBodyCardinality   { all p: PredDecl | #p.predBody = #p.predBody }
+fact FunParamsCardinality  { all f: FunDecl | #f.funParams = #f.funParams }
+fact QuantifierBindingsCardinality { all q: Quantifier | #q.bindings = #q.bindings }

--- a/models/oxidtr/ir.als
+++ b/models/oxidtr/ir.als
@@ -1,0 +1,60 @@
+module oxidtr/ir
+
+-- oxidtr IR (lowered from AST).
+-- Depends on: oxidtr/ast.
+
+open oxidtr/ast
+
+sig StructureNode {
+  origin:     one SigDecl,
+  irIsVarSig: lone StructureNode,
+  irFields:   set IRField,
+  irParent:   lone StructureNode
+}
+
+sig IRField {
+  irIsVar:  lone IRField,
+  irMult:   one Multiplicity,
+  irTarget: one StructureNode
+}
+
+sig ConstraintNode {
+  corigin: one FactDecl,
+  cexpr:   one Expr
+}
+
+sig IRReturnType {
+  retMult: one Multiplicity
+}
+
+sig OperationNode {
+  oorigin:      one PredDecl,
+  oreceiverSig: lone StructureNode,
+  oparams:      set IRParam,
+  oreturnType:  lone IRReturnType
+}
+
+abstract sig LoweringError {}
+sig InvalidReference extends LoweringError {}
+
+sig IRParam {
+  ipMult: one Multiplicity,
+  ipType: one StructureNode
+}
+
+sig PropertyNode {
+  porigin:      one AssertDecl,
+  pconstraints: set ConstraintNode
+}
+
+sig OxidtrIR {
+  source:      one AlloyModel,
+  structures:  set StructureNode,
+  constraints: set ConstraintNode,
+  operations:  set OperationNode,
+  properties:  set PropertyNode
+}
+
+fun OxidtrIR.origin: one AlloyModel {
+  this.source
+}

--- a/models/oxidtr/validated.als
+++ b/models/oxidtr/validated.als
@@ -1,0 +1,20 @@
+module oxidtr/validated
+
+-- Validated newtype wrappers for constrained sigs (Rust TryFrom targets).
+-- Depends on: oxidtr/ast, oxidtr/ir.
+
+open oxidtr/ast
+open oxidtr/ir
+
+sig ValidatedSigDecl       { vSigDecl:       one SigDecl }
+sig ValidatedFieldDecl     { vFieldDecl:     one FieldDecl }
+sig ValidatedAlloyModel    { vAlloyModel:    one AlloyModel }
+sig ValidatedFactDecl      { vFactDecl:      one FactDecl }
+sig ValidatedAssertDecl    { vAssertDecl:    one AssertDecl }
+sig ValidatedPredDecl      { vPredDecl:      one PredDecl }
+sig ValidatedFunDecl       { vFunDecl:       one FunDecl }
+sig ValidatedIRField       { vIRField:       one IRField }
+sig ValidatedStructureNode { vStructureNode: one StructureNode }
+sig ValidatedOperationNode { vOperationNode: one OperationNode }
+sig ValidatedPropertyNode  { vPropertyNode:  one PropertyNode }
+sig ValidatedOxidtrIR      { vOxidtrIR:      one OxidtrIR }

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -82,8 +82,12 @@ pub struct CheckConfig {
 }
 
 pub fn run(model_path: &str, config: &CheckConfig) -> Result<CheckResult, CheckError> {
-    let source = std::fs::read_to_string(model_path)?;
-    let ast = parser::parse(&source)?;
+    let ast = crate::generate::load_model(model_path)
+        .map_err(|e| match e {
+            crate::generate::GenerateError::IoError(io) => CheckError::IoError(io),
+            crate::generate::GenerateError::ParseError(pe) => CheckError::ParseError(pe),
+            crate::generate::GenerateError::LoweringError(le) => CheckError::LoweringError(le),
+        })?;
     let ir = ir::lower(&ast)?;
 
     let impl_dir = Path::new(&config.impl_dir);

--- a/src/extract/renderer.rs
+++ b/src/extract/renderer.rs
@@ -2,12 +2,23 @@
 
 use super::*;
 use std::fmt::Write;
+use std::path::PathBuf;
 
+/// A single file emitted by the renderer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderedFile {
+    pub path: PathBuf,
+    pub content: String,
+}
+
+/// Legacy single-file renderer. Produces a concatenated string with
+/// mid-file `module X` grouping markers — this is **not** Alloy-spec-compliant
+/// but is retained for backward compatibility with existing callers/tests.
+///
+/// For spec-compliant multi-file output, use `render_files`.
 pub fn render(model: &MinedModel) -> String {
     let mut out = String::new();
 
-    // Group sigs by module, preserving order within each group.
-    // Sigs with no module come first (ungrouped), then each module section.
     let mut ungrouped: Vec<&MinedSig> = Vec::new();
     let mut module_order: Vec<String> = Vec::new();
     let mut by_module: std::collections::HashMap<String, Vec<&MinedSig>> = std::collections::HashMap::new();
@@ -23,13 +34,11 @@ pub fn render(model: &MinedModel) -> String {
         }
     }
 
-    // Render ungrouped sigs first
     for sig in &ungrouped {
         render_sig(&mut out, sig);
         writeln!(out).unwrap();
     }
 
-    // Render each module section
     for module_name in &module_order {
         writeln!(out, "module {module_name}").unwrap();
         writeln!(out).unwrap();
@@ -41,22 +50,148 @@ pub fn render(model: &MinedModel) -> String {
         }
     }
 
-    // Render fact candidates (as comments with confidence)
-    if !model.fact_candidates.is_empty() {
-        writeln!(out, "-- Fact candidates (review required)").unwrap();
-        for fact in &model.fact_candidates {
-            let conf = match fact.confidence {
-                Confidence::High => "HIGH",
-                Confidence::Medium => "MEDIUM",
-                Confidence::Low => "LOW",
-            };
-            writeln!(out, "-- [{conf}] from: {} ({})", fact.source_pattern, fact.source_location).unwrap();
-            writeln!(out, "-- fact {{ {} }}", fact.alloy_text).unwrap();
-            writeln!(out).unwrap();
+    render_fact_candidates(&mut out, &model.fact_candidates);
+
+    out
+}
+
+/// Alloy-spec-compliant multi-file renderer.
+///
+/// - If no sig declares a `module`, returns a single `main.als` file with
+///   identical content to the legacy `render()` output.
+/// - If sigs are partitioned across modules, emits one file per module
+///   (`oxidtr/ast` → `oxidtr/ast.als`) plus a main file with `open` directives.
+/// - Cross-module field references produce `open` directives in the dependent
+///   module file automatically.
+pub fn render_files(model: &MinedModel) -> Vec<RenderedFile> {
+    // Partition sigs into (module → sigs) preserving insertion order.
+    let mut module_order: Vec<String> = Vec::new();
+    let mut by_module: std::collections::BTreeMap<String, Vec<&MinedSig>> =
+        std::collections::BTreeMap::new();
+    let mut ungrouped: Vec<&MinedSig> = Vec::new();
+    for sig in &model.sigs {
+        match &sig.module {
+            Some(m) => {
+                by_module.entry(m.clone()).or_default().push(sig);
+                if !module_order.contains(m) {
+                    module_order.push(m.clone());
+                }
+            }
+            None => ungrouped.push(sig),
         }
     }
 
-    out
+    // No modules → single-file legacy-compat output.
+    if module_order.is_empty() {
+        let mut out = String::new();
+        for sig in &ungrouped {
+            render_sig(&mut out, sig);
+            writeln!(out).unwrap();
+        }
+        render_fact_candidates(&mut out, &model.fact_candidates);
+        return vec![RenderedFile {
+            path: PathBuf::from("main.als"),
+            content: out,
+        }];
+    }
+
+    // Index sig → owning module for cross-reference analysis.
+    let sig_owner: std::collections::HashMap<String, String> = model
+        .sigs
+        .iter()
+        .filter_map(|s| s.module.as_ref().map(|m| (s.name.clone(), m.clone())))
+        .collect();
+
+    let mut files: Vec<RenderedFile> = Vec::new();
+
+    // Main file — top-level sigs (module = None) + `open` for every sub-module.
+    let main_name = "oxidtr";
+    let mut main_content = String::new();
+    for m in &module_order {
+        writeln!(main_content, "open {m}").unwrap();
+    }
+    if !module_order.is_empty() && (!ungrouped.is_empty() || !model.fact_candidates.is_empty()) {
+        writeln!(main_content).unwrap();
+    }
+    for sig in &ungrouped {
+        render_sig(&mut main_content, sig);
+        writeln!(main_content).unwrap();
+    }
+    render_fact_candidates(&mut main_content, &model.fact_candidates);
+    files.push(RenderedFile {
+        path: PathBuf::from(format!("{main_name}.als")),
+        content: main_content,
+    });
+
+    // One file per module.
+    for m in &module_order {
+        let sigs = by_module.get(m).cloned().unwrap_or_default();
+        let mut deps: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for sig in &sigs {
+            if let Some(parent) = &sig.parent {
+                if let Some(parent_mod) = sig_owner.get(parent) {
+                    if parent_mod != m {
+                        deps.insert(parent_mod.clone());
+                    }
+                }
+            }
+            for f in &sig.fields {
+                if let Some(target_mod) = sig_owner.get(&f.target) {
+                    if target_mod != m {
+                        deps.insert(target_mod.clone());
+                    }
+                }
+            }
+            for comp in &sig.intersection_of {
+                if let Some(comp_mod) = sig_owner.get(comp) {
+                    if comp_mod != m {
+                        deps.insert(comp_mod.clone());
+                    }
+                }
+            }
+        }
+
+        let mut content = String::new();
+        writeln!(content, "module {m}").unwrap();
+        if !deps.is_empty() {
+            writeln!(content).unwrap();
+            for dep in &deps {
+                writeln!(content, "open {dep}").unwrap();
+            }
+        }
+        writeln!(content).unwrap();
+        for sig in &sigs {
+            render_sig(&mut content, sig);
+            writeln!(content).unwrap();
+        }
+
+        // `module foo/bar` → `foo/bar.als`
+        let mut path = PathBuf::new();
+        for segment in m.split('/') {
+            path.push(segment);
+        }
+        path.set_extension("als");
+        files.push(RenderedFile { path, content });
+    }
+
+    files
+}
+
+fn render_fact_candidates(out: &mut String, facts: &[MinedFactCandidate]) {
+    if facts.is_empty() {
+        return;
+    }
+    writeln!(out, "-- Fact candidates (review required)").unwrap();
+    for fact in facts {
+        let conf = match fact.confidence {
+            Confidence::High => "HIGH",
+            Confidence::Medium => "MEDIUM",
+            Confidence::Low => "LOW",
+        };
+        writeln!(out, "-- [{conf}] from: {} ({})", fact.source_pattern, fact.source_location).unwrap();
+        writeln!(out, "-- fact {{ {} }}", fact.alloy_text).unwrap();
+        writeln!(out).unwrap();
+    }
 }
 
 fn render_sig(out: &mut String, sig: &MinedSig) {

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -103,13 +103,54 @@ pub struct GenerateResult {
     pub warnings: Vec<Warning>,
 }
 
+/// Load an Alloy model from a file or directory.
+///
+/// - File input: resolves `open` directives relative to the file's parent dir.
+/// - Directory input: auto-discovers the main file by convention
+///   (`oxidtr.als`, `main.als`, or `<dirname>.als`) and resolves `open` from there.
+pub fn load_model(input_path: &str) -> Result<parser::ast::AlloyModel, GenerateError> {
+    let p = Path::new(input_path);
+    if p.is_file() {
+        return parser::parse_from_path(p).map_err(GenerateError::ParseError);
+    }
+    if p.is_dir() {
+        let conventional = ["oxidtr.als", "main.als"]
+            .iter()
+            .map(|n| p.join(n))
+            .chain(p.file_name().and_then(|n| n.to_str()).map(|n| p.join(format!("{n}.als"))))
+            .find(|path| path.exists());
+        let main = match conventional {
+            Some(m) => m,
+            None => first_als_file(p).ok_or_else(|| {
+                GenerateError::IoError(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("no .als file found in directory: {}", p.display()),
+                ))
+            })?,
+        };
+        return parser::parse_from_path(&main).map_err(GenerateError::ParseError);
+    }
+    Err(GenerateError::IoError(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        format!("input path not found: {input_path}"),
+    )))
+}
+
+fn first_als_file(dir: &Path) -> Option<std::path::PathBuf> {
+    let mut entries: Vec<_> = std::fs::read_dir(dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().map_or(false, |ext| ext == "als"))
+        .collect();
+    entries.sort();
+    entries.into_iter().next()
+}
+
 /// Run the generate pipeline: parse → lower → analyze → generate → write.
 pub fn run(input_path: &str, config: &GenerateConfig) -> Result<GenerateResult, GenerateError> {
-    // Read input
-    let source = std::fs::read_to_string(input_path)?;
-
-    // Parse
-    let model = parser::parse(&source)?;
+    // Parse input file or directory, resolving `open` directives via parse_from_path.
+    let model = load_model(input_path)?;
 
     // Lower to IR
     let ir = ir::lower(&model)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,19 +137,61 @@ fn main() {
                 }
             }
 
-            let rendered = extract::renderer::render(&result.model);
+            let sig_count = result.model.sigs.len();
+            let fact_count = result.model.fact_candidates.len();
+            let has_modules = result.model.sigs.iter().any(|s| s.module.is_some());
 
-            if let Some(path) = output {
-                if let Err(e) = std::fs::write(&path, &rendered) {
-                    eprintln!("error: cannot write {path}: {e}");
-                    std::process::exit(1);
+            match output {
+                Some(path) => {
+                    let out_path = std::path::Path::new(&path);
+                    let is_dir_output = out_path.is_dir()
+                        || (!out_path.exists() && out_path.extension().is_none());
+
+                    if is_dir_output {
+                        let files = extract::renderer::render_files(&result.model);
+                        if let Err(e) = std::fs::create_dir_all(out_path) {
+                            eprintln!("error: cannot create {path}: {e}");
+                            std::process::exit(1);
+                        }
+                        let mut written = Vec::new();
+                        for f in &files {
+                            let full = out_path.join(&f.path);
+                            if let Some(parent) = full.parent() {
+                                if let Err(e) = std::fs::create_dir_all(parent) {
+                                    eprintln!("error: cannot create {}: {e}", parent.display());
+                                    std::process::exit(1);
+                                }
+                            }
+                            if let Err(e) = std::fs::write(&full, &f.content) {
+                                eprintln!("error: cannot write {}: {e}", full.display());
+                                std::process::exit(1);
+                            }
+                            written.push(full.display().to_string());
+                        }
+                        println!("Mined {sig_count} sig(s), {fact_count} fact candidate(s) → {path}/ ({} file(s))", written.len());
+                        for w in &written {
+                            println!("  {w}");
+                        }
+                    } else {
+                        if has_modules {
+                            eprintln!(
+                                "[WARN] module-partitioned model flattened into single file ({path}); \
+                                 pass a directory path to `-o` for spec-compliant multi-file output"
+                            );
+                        }
+                        let rendered = extract::renderer::render(&result.model);
+                        if let Err(e) = std::fs::write(&path, &rendered) {
+                            eprintln!("error: cannot write {path}: {e}");
+                            std::process::exit(1);
+                        }
+                        println!("Mined {sig_count} sig(s), {fact_count} fact candidate(s) → {path}");
+                    }
                 }
-                println!("Mined {} sig(s), {} fact candidate(s) → {path}",
-                    result.model.sigs.len(), result.model.fact_candidates.len());
-            } else {
-                print!("{rendered}");
-                eprintln!("\nMined {} sig(s), {} fact candidate(s)",
-                    result.model.sigs.len(), result.model.fact_candidates.len());
+                None => {
+                    let rendered = extract::renderer::render(&result.model);
+                    print!("{rendered}");
+                    eprintln!("\nMined {sig_count} sig(s), {fact_count} fact candidate(s)");
+                }
             }
 
             // Report sources

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -201,7 +201,17 @@ pub struct FunDecl {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportDecl {
+    pub path: String,             // e.g. "oxidtr/ast"
+    pub alias: Option<String>,    // from `as Foo` suffix
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AlloyModel {
+    /// Qualified module name from the `module` header (Alloy 6 spec: file-level only).
+    pub module_decl: Option<String>,
+    /// `open` directives (resolved later by `parse_from_path`).
+    pub imports: Vec<ImportDecl>,
     pub sigs: Vec<SigDecl>,
     pub facts: Vec<FactDecl>,
     pub preds: Vec<PredDecl>,

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -65,6 +65,7 @@ pub enum Token {
     Plus,
     Ampersand,
     Minus,
+    Slash,
     // Literals
     Ident(String),
     Int(i64),
@@ -211,6 +212,7 @@ impl<'a> Lexer<'a> {
             }
             b'+' => { self.advance(); return Token::Plus; }
             b'&' => { self.advance(); return Token::Ampersand; }
+            b'/' => { self.advance(); return Token::Slash; }
             b'-' => {
                 self.advance();
                 if self.peek_byte() == Some(b'>') {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -103,6 +103,8 @@ impl<'a> Parser<'a> {
 
     fn parse_model(&mut self) -> Result<AlloyModel, ParseError> {
         let mut model = AlloyModel {
+            module_decl: None,
+            imports: Vec::new(),
             sigs: Vec::new(),
             facts: Vec::new(),
             preds: Vec::new(),
@@ -159,10 +161,28 @@ impl<'a> Parser<'a> {
                     model.sigs.push(sig);
                 }
                 Token::Module => {
-                    self.parse_module_decl();
+                    let path = self.parse_module_decl();
+                    // First module declaration becomes the file-level module header.
+                    // Subsequent ones are retained for backward compat but violate
+                    // Alloy 6 spec (one `module` per file) — emit a deprecation notice.
+                    if model.module_decl.is_none() && model.sigs.is_empty() {
+                        model.module_decl = path.clone();
+                    } else {
+                        eprintln!(
+                            "[DEPRECATED] mid-file `module {}` is a legacy oxidtr extension; \
+                             Alloy 6 spec allows `module` only at file start. \
+                             Split into separate files + `open` declarations.",
+                            path.as_deref().unwrap_or("?"),
+                        );
+                    }
+                    if let Some(p) = path {
+                        self.current_module = Some(p);
+                    }
                 }
                 Token::Open => {
-                    self.skip_to_eol();
+                    if let Some(import) = self.parse_open_decl() {
+                        model.imports.push(import);
+                    }
                 }
                 Token::Enum => {
                     let mut sigs = self.parse_enum()?;
@@ -865,38 +885,74 @@ impl<'a> Parser<'a> {
         self.skip_to_next_toplevel();
     }
 
-    /// Parse `module name` declaration and set current_module.
-    /// All subsequent declarations are tagged with this module name until
-    /// the next `module` declaration or end of file.
-    fn parse_module_decl(&mut self) {
+    /// Parse `module qualified/name` and return the qualified path.
+    ///
+    /// Alloy 6 spec requires `module` at file start only; mid-file declarations
+    /// are a legacy oxidtr extension retained for backward compatibility.
+    fn parse_module_decl(&mut self) -> Option<String> {
         self.next(); // consume `module`
-        // Collect the module path as a string (e.g. "ast", "my/model")
-        let mut name = String::new();
-        loop {
-            match self.peek() {
-                Token::Ident(s) => {
-                    self.next();
-                    name.push_str(&s);
-                }
-                _ => break,
-            }
-            // Handle path separators: module my/model
-            // The lexer doesn't produce '/' as a token, so the path
-            // will be in the ident itself or we stop at the next top-level.
-            // For simple names like `module ast`, this works directly.
-        }
-        if !name.is_empty() {
-            self.current_module = Some(name);
-        }
-        // Skip any remaining tokens on the line (e.g. version info)
+        let path = self.parse_qualified_path();
+        // Skip trailing params / version info until the next top-level token.
         self.skip_to_next_toplevel();
+        path
     }
 
-    /// Skip `open path[params] as alias` declaration.
-    /// Consumes the leading keyword then skips to the next top-level token.
-    fn skip_to_eol(&mut self) {
-        self.next(); // consume open
+    /// Parse `open qualified/path[Params] as Alias` into an ImportDecl.
+    fn parse_open_decl(&mut self) -> Option<ImportDecl> {
+        self.next(); // consume `open`
+        let path = self.parse_qualified_path()?;
+        // Optional parameter list: `[Type, ...]`
+        if self.peek() == Token::LBracket {
+            self.next();
+            let mut depth = 1;
+            while depth > 0 {
+                match self.next() {
+                    Token::LBracket => depth += 1,
+                    Token::RBracket => depth -= 1,
+                    Token::Eof => break,
+                    _ => {}
+                }
+            }
+        }
+        // Optional `as Alias`
+        let alias = if let Token::Ident(ref s) = self.peek() {
+            if s == "as" {
+                self.next();
+                match self.next() {
+                    Token::Ident(name) => Some(name),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
         self.skip_to_next_toplevel();
+        Some(ImportDecl { path, alias })
+    }
+
+    /// Parse `a/b/c` as a slash-separated path.
+    ///
+    /// Each segment may be either an identifier or an Alloy keyword — e.g.
+    /// `util/ordering`, `pkg/one`, or `oxidtr/ast` are all legal module paths.
+    fn parse_qualified_path(&mut self) -> Option<String> {
+        let mut parts = Vec::new();
+        loop {
+            match token_as_path_segment(&self.peek()) {
+                Some(s) => {
+                    self.next();
+                    parts.push(s);
+                }
+                None => break,
+            }
+            if self.peek() == Token::Slash {
+                self.next();
+                continue;
+            }
+            break;
+        }
+        if parts.is_empty() { None } else { Some(parts.join("/")) }
     }
 
     fn skip_to_next_toplevel(&mut self) {
@@ -976,9 +1032,136 @@ fn scan_intersection_annotations(input: &str) -> std::collections::HashMap<Strin
     map
 }
 
+/// Return the textual form of a token if it can appear as a path segment
+/// (identifier or keyword). Module/open paths like `util/ordering` or
+/// `pkg/one` legitimately use words that happen to be Alloy keywords.
+fn token_as_path_segment(tok: &Token) -> Option<String> {
+    Some(match tok {
+        Token::Ident(s) => s.clone(),
+        Token::Sig => "sig".into(),
+        Token::Abstract => "abstract".into(),
+        Token::Extends => "extends".into(),
+        Token::One => "one".into(),
+        Token::Lone => "lone".into(),
+        Token::Set => "set".into(),
+        Token::Seq => "seq".into(),
+        Token::Fact => "fact".into(),
+        Token::Pred => "pred".into(),
+        Token::Fun => "fun".into(),
+        Token::Assert => "assert".into(),
+        Token::All => "all".into(),
+        Token::Some_ => "some".into(),
+        Token::No => "no".into(),
+        Token::Not => "not".into(),
+        Token::And => "and".into(),
+        Token::Or => "or".into(),
+        Token::Implies => "implies".into(),
+        Token::Iff => "iff".into(),
+        Token::In => "in".into(),
+        Token::Check => "check".into(),
+        Token::Run => "run".into(),
+        Token::Disj => "disj".into(),
+        Token::Enum => "enum".into(),
+        Token::Module => "module".into(),
+        Token::Open => "open".into(),
+        Token::Var => "var".into(),
+        Token::Always => "always".into(),
+        Token::Eventually => "eventually".into(),
+        Token::After => "after".into(),
+        Token::Historically => "historically".into(),
+        Token::Once => "once".into(),
+        Token::Before => "before".into(),
+        Token::Until => "until".into(),
+        Token::Since => "since".into(),
+        Token::Release => "release".into(),
+        Token::Triggered => "triggered".into(),
+        _ => return None,
+    })
+}
+
 pub fn parse(input: &str) -> Result<AlloyModel, ParseError> {
     let union_annotations = scan_union_annotations(input);
     let intersection_annotations = scan_intersection_annotations(input);
     let mut parser = Parser::new_with_annotations(input, union_annotations, intersection_annotations);
     parser.parse_model()
+}
+
+/// Load and parse an Alloy model from disk, resolving `open` directives by
+/// reading sibling files (`open foo/bar` → `<base_dir>/foo/bar.als`).
+///
+/// The returned `AlloyModel` is a flattened union of the main file and all
+/// transitively opened modules. Each top-level declaration retains the
+/// qualified module name from its source file's `module` header.
+///
+/// Cycles are detected via canonical-path tracking and silently broken
+/// (double-open is idempotent). Missing open targets produce a ParseError.
+pub fn parse_from_path(path: &std::path::Path) -> Result<AlloyModel, ParseError> {
+    let mut visited = std::collections::HashSet::new();
+    parse_from_path_inner(path, &mut visited)
+}
+
+fn parse_from_path_inner(
+    path: &std::path::Path,
+    visited: &mut std::collections::HashSet<std::path::PathBuf>,
+) -> Result<AlloyModel, ParseError> {
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    if !visited.insert(canonical) {
+        return Ok(AlloyModel {
+            module_decl: None,
+            imports: Vec::new(),
+            sigs: Vec::new(),
+            facts: Vec::new(),
+            preds: Vec::new(),
+            funs: Vec::new(),
+            asserts: Vec::new(),
+        });
+    }
+
+    let source = std::fs::read_to_string(path).map_err(|e| {
+        ParseError::InvalidSyntax {
+            message: format!("cannot read {}: {e}", path.display()),
+            pos: 0,
+        }
+    })?;
+    let mut model = parse(&source)?;
+
+    let base_dir = path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+
+    // Take imports out so we can consume them; any transitively-imported
+    // model's imports are merged in as well (reflecting the full import graph).
+    let imports = std::mem::take(&mut model.imports);
+    let mut merged_imports = imports.clone();
+
+    for import in imports {
+        let mut target = base_dir.clone();
+        for segment in import.path.split('/') {
+            target.push(segment);
+        }
+        target.set_extension("als");
+
+        if !target.exists() {
+            // Parameterized or library modules (e.g. `util/ordering`) may not
+            // have a local file — skip with a non-fatal notice on stderr.
+            eprintln!(
+                "[open] cannot resolve `{}` (expected at {}); skipping",
+                import.path,
+                target.display()
+            );
+            continue;
+        }
+
+        let sub = parse_from_path_inner(&target, visited)?;
+        model.sigs.extend(sub.sigs);
+        model.facts.extend(sub.facts);
+        model.preds.extend(sub.preds);
+        model.funs.extend(sub.funs);
+        model.asserts.extend(sub.asserts);
+        merged_imports.extend(sub.imports);
+    }
+
+    model.imports = merged_imports;
+    Ok(model)
 }

--- a/tests/cli_multi_file.rs
+++ b/tests/cli_multi_file.rs
@@ -1,0 +1,136 @@
+//! End-to-end tests for multi-file `.als` input/output across generate/check/extract.
+
+use oxidtr::generate::{load_model, run as generate_run, GenerateConfig};
+use oxidtr::check::{run as check_run, CheckConfig};
+use std::fs;
+use std::path::PathBuf;
+
+fn fresh_dir(name: &str) -> PathBuf {
+    let mut d = std::env::temp_dir();
+    d.push(format!("oxidtr-cli-mf-{}-{}", name, std::process::id()));
+    if d.exists() { let _ = fs::remove_dir_all(&d); }
+    fs::create_dir_all(&d).unwrap();
+    d
+}
+
+#[test]
+fn load_model_resolves_open_from_file_input() {
+    let root = fresh_dir("load-file");
+    let sub = root.join("oxidtr");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(
+        root.join("oxidtr.als"),
+        "module oxidtr\nopen oxidtr/ast\n\nsig Top {}\n",
+    ).unwrap();
+    fs::write(
+        sub.join("ast.als"),
+        "module oxidtr/ast\n\nsig Node {}\n",
+    ).unwrap();
+
+    let m = load_model(root.join("oxidtr.als").to_str().unwrap()).expect("load");
+    let names: std::collections::HashSet<&str> =
+        m.sigs.iter().map(|s| s.name.as_str()).collect();
+    assert!(names.contains("Top"));
+    assert!(names.contains("Node"));
+}
+
+#[test]
+fn load_model_resolves_from_directory_convention() {
+    let root = fresh_dir("load-dir");
+    let sub = root.join("oxidtr");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(
+        root.join("oxidtr.als"),
+        "module oxidtr\nopen oxidtr/ast\n\nsig Top {}\n",
+    ).unwrap();
+    fs::write(
+        sub.join("ast.als"),
+        "module oxidtr/ast\n\nsig Node {}\n",
+    ).unwrap();
+
+    // Passing the directory should discover `oxidtr.als` as the main file.
+    let m = load_model(root.to_str().unwrap()).expect("load");
+    let names: std::collections::HashSet<&str> =
+        m.sigs.iter().map(|s| s.name.as_str()).collect();
+    assert!(names.contains("Top"));
+    assert!(names.contains("Node"));
+}
+
+#[test]
+fn generate_uses_load_model_for_multi_file_input() {
+    let root = fresh_dir("gen-mf");
+    let sub = root.join("oxidtr");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(
+        root.join("oxidtr.als"),
+        "module oxidtr\nopen oxidtr/ast\n\nsig Top { node: one Node }\n",
+    ).unwrap();
+    fs::write(
+        sub.join("ast.als"),
+        "module oxidtr/ast\n\nsig Node {}\n",
+    ).unwrap();
+
+    let out = root.join("generated");
+    let config = GenerateConfig::new("rust", out.to_str().unwrap());
+    let result = generate_run(root.join("oxidtr.als").to_str().unwrap(), &config)
+        .expect("generate");
+    assert!(!result.files_written.is_empty(),
+        "generate should produce files for multi-file input");
+    // Ensure both sigs appear somewhere in generated output
+    let all: String = result.files_written.iter()
+        .filter_map(|p| fs::read_to_string(p).ok())
+        .collect();
+    assert!(all.contains("Top"), "Top sig missing in output");
+    assert!(all.contains("Node"), "Node sig missing in output");
+}
+
+#[test]
+fn check_accepts_multi_file_model() {
+    let root = fresh_dir("check-mf");
+    let sub = root.join("oxidtr");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(
+        root.join("oxidtr.als"),
+        "module oxidtr\nopen oxidtr/ast\n\nsig Top { node: one Node }\n",
+    ).unwrap();
+    fs::write(
+        sub.join("ast.als"),
+        "module oxidtr/ast\n\nsig Node {}\n",
+    ).unwrap();
+
+    // Generate impl first
+    let out = root.join("generated");
+    let config = GenerateConfig::new("rust", out.to_str().unwrap());
+    generate_run(root.join("oxidtr.als").to_str().unwrap(), &config)
+        .expect("generate before check");
+
+    let cfg = CheckConfig { impl_dir: out.to_str().unwrap().to_string() };
+    let result = check_run(root.join("oxidtr.als").to_str().unwrap(), &cfg)
+        .expect("check");
+    assert!(result.is_ok(),
+        "check should be clean after round-trip; diffs: {:?}", result.diffs);
+}
+
+#[test]
+fn extract_directory_output_writes_multiple_files() {
+    // Build a small Rust crate with module subdirs, extract, then ensure
+    // render_files produces >=2 files under `-o <dir>`.
+    let root = fresh_dir("extract-dir");
+    let src = root.join("src");
+    let ast = src.join("ast");
+    let ir = src.join("ir");
+    fs::create_dir_all(&ast).unwrap();
+    fs::create_dir_all(&ir).unwrap();
+    fs::write(ast.join("types.rs"), "pub struct Node { pub name: String }\n").unwrap();
+    fs::write(ir.join("types.rs"), "pub struct IRNode { pub origin: Node }\n").unwrap();
+
+    let merge = oxidtr::extract::run_merge(src.to_str().unwrap(), Some("rust"))
+        .expect("run_merge");
+    let files = oxidtr::extract::renderer::render_files(&merge.model);
+    let has_ast = files.iter().any(|f| f.path.to_string_lossy().contains("ast"));
+    let has_ir = files.iter().any(|f| f.path.to_string_lossy().contains("ir"));
+    assert!(has_ast, "expected ast file in {:?}",
+        files.iter().map(|f| f.path.display().to_string()).collect::<Vec<_>>());
+    assert!(has_ir, "expected ir file in {:?}",
+        files.iter().map(|f| f.path.display().to_string()).collect::<Vec<_>>());
+}

--- a/tests/parser_multi_file.rs
+++ b/tests/parser_multi_file.rs
@@ -1,0 +1,129 @@
+use oxidtr::parser;
+use std::fs;
+
+/// Create a temp dir inside cargo's target dir (self-contained, no external deps).
+fn fresh_tmp_dir(name: &str) -> std::path::PathBuf {
+    let mut d = std::env::temp_dir();
+    d.push(format!("oxidtr-multifile-{}-{}", name, std::process::id()));
+    if d.exists() {
+        let _ = fs::remove_dir_all(&d);
+    }
+    fs::create_dir_all(&d).expect("create tmp dir");
+    d
+}
+
+#[test]
+fn parse_records_open_directives_as_imports() {
+    let src = r#"
+module foo
+
+open bar
+open baz/qux as Q
+
+sig A {}
+"#;
+    let model = parser::parse(src).expect("parse");
+    assert_eq!(model.module_decl.as_deref(), Some("foo"));
+    assert_eq!(model.imports.len(), 2);
+    assert_eq!(model.imports[0].path, "bar");
+    assert_eq!(model.imports[0].alias, None);
+    assert_eq!(model.imports[1].path, "baz/qux");
+    assert_eq!(model.imports[1].alias.as_deref(), Some("Q"));
+}
+
+#[test]
+fn parse_slash_separated_module_path() {
+    let src = "module oxidtr/ast\n\nsig A {}\n";
+    let model = parser::parse(src).expect("parse");
+    assert_eq!(model.module_decl.as_deref(), Some("oxidtr/ast"));
+    assert_eq!(model.sigs.len(), 1);
+    assert_eq!(model.sigs[0].module.as_deref(), Some("oxidtr/ast"));
+}
+
+#[test]
+fn parse_open_with_parameter_brackets_is_skipped() {
+    // parameterized modules like `open util/ordering[Time]` must parse
+    // (we record them but cannot resolve the file)
+    let src = "module m\n\nopen util/ordering[Time]\n\nsig S {}\n";
+    let model = parser::parse(src).expect("parse");
+    assert_eq!(model.imports.len(), 1);
+    assert_eq!(model.imports[0].path, "util/ordering");
+    assert_eq!(model.sigs.len(), 1);
+}
+
+#[test]
+fn parse_from_path_merges_opened_files() {
+    let dir = fresh_tmp_dir("merge");
+    let sub = dir.join("sub");
+    fs::create_dir_all(&sub).unwrap();
+
+    fs::write(
+        dir.join("main.als"),
+        "module main\nopen sub/child\n\nsig Root { child: one Leaf }\n",
+    )
+    .unwrap();
+    fs::write(
+        sub.join("child.als"),
+        "module sub/child\n\nsig Leaf {}\n",
+    )
+    .unwrap();
+
+    let model = parser::parse_from_path(&dir.join("main.als")).expect("parse_from_path");
+    let names: Vec<&str> = model.sigs.iter().map(|s| s.name.as_str()).collect();
+    assert!(names.contains(&"Root"), "sigs: {names:?}");
+    assert!(names.contains(&"Leaf"), "sigs: {names:?}");
+
+    // qualified module names preserved per file
+    let leaf = model.sigs.iter().find(|s| s.name == "Leaf").unwrap();
+    assert_eq!(leaf.module.as_deref(), Some("sub/child"));
+    let root = model.sigs.iter().find(|s| s.name == "Root").unwrap();
+    assert_eq!(root.module.as_deref(), Some("main"));
+}
+
+#[test]
+fn parse_from_path_cycle_does_not_infinite_loop() {
+    let dir = fresh_tmp_dir("cycle");
+    fs::write(
+        dir.join("a.als"),
+        "module a\nopen b\n\nsig A {}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("b.als"),
+        "module b\nopen a\n\nsig B {}\n",
+    )
+    .unwrap();
+
+    let model = parser::parse_from_path(&dir.join("a.als")).expect("parse_from_path");
+    let names: Vec<&str> = model.sigs.iter().map(|s| s.name.as_str()).collect();
+    assert!(names.contains(&"A"));
+    assert!(names.contains(&"B"));
+}
+
+#[test]
+fn parse_from_path_missing_open_is_non_fatal() {
+    let dir = fresh_tmp_dir("missing");
+    fs::write(
+        dir.join("main.als"),
+        "module main\nopen util/ordering[Time]\n\nsig S {}\n",
+    )
+    .unwrap();
+    // Should not error out — library/parameterized opens without a local file
+    // are skipped with a stderr notice.
+    let model = parser::parse_from_path(&dir.join("main.als")).expect("parse_from_path");
+    assert_eq!(model.sigs.len(), 1);
+}
+
+#[test]
+fn legacy_midfile_module_backward_compat() {
+    // Existing oxidtr.als uses mid-file `module X` to group sigs.
+    // The first declaration remains the file-level header; subsequent
+    // ones simply switch the grouping context for backward compat.
+    let src = "module ast\n\nsig A {}\n\nmodule ir\n\nsig B {}\n";
+    let model = parser::parse(src).expect("parse");
+    assert_eq!(model.module_decl.as_deref(), Some("ast"));
+    let a = model.sigs.iter().find(|s| s.name == "A").unwrap();
+    let b = model.sigs.iter().find(|s| s.name == "B").unwrap();
+    assert_eq!(a.module.as_deref(), Some("ast"));
+    assert_eq!(b.module.as_deref(), Some("ir"));
+}

--- a/tests/renderer_multi_file.rs
+++ b/tests/renderer_multi_file.rs
@@ -1,0 +1,149 @@
+use oxidtr::extract::renderer::{render_files, RenderedFile};
+use oxidtr::extract::{MinedModel, MinedSig, MinedField, MinedMultiplicity};
+
+fn sig_with_module(name: &str, module: Option<&str>, parent: Option<&str>, fields: Vec<MinedField>) -> MinedSig {
+    MinedSig {
+        name: name.to_string(),
+        fields,
+        is_abstract: false,
+        is_var: false,
+        parent: parent.map(|s| s.to_string()),
+        source_location: "test".to_string(),
+        intersection_of: vec![],
+        module: module.map(|s| s.to_string()),
+    }
+}
+
+fn field(name: &str, target: &str) -> MinedField {
+    MinedField {
+        name: name.to_string(),
+        is_var: false,
+        mult: MinedMultiplicity::One,
+        target: target.to_string(),
+        raw_union_type: None,
+    }
+}
+
+fn find_file<'a>(files: &'a [RenderedFile], path: &str) -> &'a RenderedFile {
+    files
+        .iter()
+        .find(|f| f.path.to_string_lossy() == path)
+        .unwrap_or_else(|| panic!("expected file {path} in {:?}",
+            files.iter().map(|f| f.path.display().to_string()).collect::<Vec<_>>()))
+}
+
+#[test]
+fn no_modules_returns_single_main_als() {
+    let model = MinedModel {
+        sigs: vec![sig_with_module("A", None, None, vec![])],
+        fact_candidates: vec![],
+    };
+    let files = render_files(&model);
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].path.to_string_lossy(), "main.als");
+    assert!(files[0].content.contains("sig A"));
+}
+
+#[test]
+fn single_module_produces_module_file_and_main() {
+    let model = MinedModel {
+        sigs: vec![sig_with_module("Leaf", Some("foo/bar"), None, vec![])],
+        fact_candidates: vec![],
+    };
+    let files = render_files(&model);
+    let main = find_file(&files, "oxidtr.als");
+    assert!(main.content.contains("open foo/bar"));
+    let sub = find_file(&files, "foo/bar.als");
+    assert!(sub.content.starts_with("module foo/bar"));
+    assert!(sub.content.contains("sig Leaf"));
+}
+
+#[test]
+fn cross_module_field_reference_emits_open_in_dependent_file() {
+    let model = MinedModel {
+        sigs: vec![
+            sig_with_module("Base", Some("oxidtr/ast"), None, vec![]),
+            sig_with_module(
+                "IR",
+                Some("oxidtr/ir"),
+                None,
+                vec![field("origin", "Base")],
+            ),
+        ],
+        fact_candidates: vec![],
+    };
+    let files = render_files(&model);
+    let ir_file = find_file(&files, "oxidtr/ir.als");
+    assert!(
+        ir_file.content.contains("open oxidtr/ast"),
+        "ir.als should import ast:\n{}",
+        ir_file.content
+    );
+    let ast_file = find_file(&files, "oxidtr/ast.als");
+    // ast.als should not depend on ir (unidirectional ref)
+    assert!(
+        !ast_file.content.contains("open oxidtr/ir"),
+        "ast.als must not import ir"
+    );
+}
+
+#[test]
+fn parent_sig_in_other_module_emits_open() {
+    let model = MinedModel {
+        sigs: vec![
+            sig_with_module("Token", Some("lex"), None, vec![]),
+            sig_with_module("Ident", Some("parse"), Some("Token"), vec![]),
+        ],
+        fact_candidates: vec![],
+    };
+    let files = render_files(&model);
+    let parse = find_file(&files, "parse.als");
+    assert!(parse.content.contains("open lex"));
+}
+
+#[test]
+fn main_file_contains_ungrouped_sigs_and_opens() {
+    let model = MinedModel {
+        sigs: vec![
+            sig_with_module("Leaf", Some("sub"), None, vec![]),
+            sig_with_module("Top", None, None, vec![]),
+        ],
+        fact_candidates: vec![],
+    };
+    let files = render_files(&model);
+    let main = find_file(&files, "oxidtr.als");
+    assert!(main.content.contains("open sub"));
+    assert!(main.content.contains("sig Top"));
+}
+
+#[test]
+fn rendered_multi_file_output_parses_via_parse_from_path() {
+    // Round-trip: render multi-file, write to temp dir, parse_from_path, confirm sigs recovered.
+    use std::fs;
+    let model = MinedModel {
+        sigs: vec![
+            sig_with_module("A", Some("pkg/one"), None, vec![field("x", "B")]),
+            sig_with_module("B", Some("pkg/two"), None, vec![]),
+        ],
+        fact_candidates: vec![],
+    };
+    let files = render_files(&model);
+
+    let dir = std::env::temp_dir().join(format!("oxidtr-render-rt-{}", std::process::id()));
+    if dir.exists() { let _ = fs::remove_dir_all(&dir); }
+    fs::create_dir_all(&dir).unwrap();
+    for f in &files {
+        let full = dir.join(&f.path);
+        if let Some(parent) = full.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&full, &f.content).unwrap();
+    }
+
+    let parsed = oxidtr::parser::parse_from_path(&dir.join("oxidtr.als"))
+        .expect("parse_from_path succeeds");
+    let names: std::collections::HashSet<&str> =
+        parsed.sigs.iter().map(|s| s.name.as_str()).collect();
+    assert!(names.contains("A"));
+    assert!(names.contains("B"));
+}

--- a/tests/self_hosting_multi_file.rs
+++ b/tests/self_hosting_multi_file.rs
@@ -1,0 +1,93 @@
+//! End-to-end self-hosting verification using the spec-compliant multi-file
+//! variant (`models/oxidtr-split.als` + `models/oxidtr/*.als`).
+
+use oxidtr::{check, generate, ir, parser};
+use std::path::Path;
+
+#[test]
+fn split_model_parses_via_parse_from_path() {
+    let model = parser::parse_from_path(Path::new("models/oxidtr-split.als"))
+        .expect("parse_from_path resolves all opens");
+    assert!(
+        model.sigs.len() > 50,
+        "expected 50+ sigs after merging all sub-modules, got {}",
+        model.sigs.len()
+    );
+    // Imports should be recorded on the top-level model.
+    let import_paths: Vec<&str> = model.imports.iter().map(|i| i.path.as_str()).collect();
+    assert!(import_paths.contains(&"oxidtr/ast"));
+    assert!(import_paths.contains(&"oxidtr/ir"));
+    assert!(import_paths.contains(&"oxidtr/analysis"));
+    assert!(import_paths.contains(&"oxidtr/validated"));
+}
+
+#[test]
+fn split_model_preserves_qualified_module_names() {
+    let model = parser::parse_from_path(Path::new("models/oxidtr-split.als"))
+        .expect("parse_from_path");
+    // SigDecl from ast should carry module "oxidtr/ast"
+    let sig_decl = model
+        .sigs
+        .iter()
+        .find(|s| s.name == "SigDecl")
+        .expect("SigDecl should be present");
+    assert_eq!(sig_decl.module.as_deref(), Some("oxidtr/ast"));
+
+    // StructureNode from ir should carry module "oxidtr/ir"
+    let structure_node = model
+        .sigs
+        .iter()
+        .find(|s| s.name == "StructureNode")
+        .expect("StructureNode should be present");
+    assert_eq!(structure_node.module.as_deref(), Some("oxidtr/ir"));
+}
+
+#[test]
+fn split_model_lowers_to_ir() {
+    let model = parser::parse_from_path(Path::new("models/oxidtr-split.als"))
+        .expect("parse_from_path");
+    let lowered = ir::lower(&model).expect("lower");
+    assert!(lowered.structures.len() > 50);
+}
+
+#[test]
+fn split_model_generate_round_trip_rust() {
+    let out = std::env::temp_dir().join(format!("oxidtr-split-gen-{}", std::process::id()));
+    if out.exists() { let _ = std::fs::remove_dir_all(&out); }
+
+    let config = generate::GenerateConfig::new("rust", out.to_str().unwrap());
+    generate::run("models/oxidtr-split.als", &config)
+        .expect("generate rust from split model");
+
+    let check_config = check::CheckConfig { impl_dir: out.to_str().unwrap().to_string() };
+    let result = check::run("models/oxidtr-split.als", &check_config)
+        .expect("check round-trip");
+    assert!(
+        result.is_ok(),
+        "split model round-trip should be clean; diffs: {:?}",
+        result.diffs
+    );
+}
+
+#[test]
+fn legacy_and_split_models_agree_on_sig_set() {
+    // Both the legacy flat `oxidtr.als` and the new split variant should
+    // describe the same structural model.
+    let legacy = parser::parse_from_path(Path::new("models/oxidtr.als"))
+        .expect("parse legacy oxidtr.als");
+    let split = parser::parse_from_path(Path::new("models/oxidtr-split.als"))
+        .expect("parse split variant");
+
+    let legacy_names: std::collections::BTreeSet<&str> =
+        legacy.sigs.iter().map(|s| s.name.as_str()).collect();
+    let split_names: std::collections::BTreeSet<&str> =
+        split.sigs.iter().map(|s| s.name.as_str()).collect();
+
+    let only_in_legacy: Vec<&&str> = legacy_names.difference(&split_names).collect();
+    let only_in_split: Vec<&&str> = split_names.difference(&legacy_names).collect();
+
+    assert!(
+        only_in_legacy.is_empty() && only_in_split.is_empty(),
+        "sig sets diverge — only_in_legacy={only_in_legacy:?}, only_in_split={only_in_split:?}"
+    );
+}


### PR DESCRIPTION
Closes #49.

## Summary

- **Parser**: `parse_from_path(&Path)` recursively resolves `open foo/bar` → `<base>/foo/bar.als`, merging the flattened model. `Token::Slash` added; qualified paths accept Alloy keywords as segments (`pkg/one`, `util/ordering`). `ImportDecl` captured on `AlloyModel`.
- **Renderer**: `render_files(&MinedModel) -> Vec<RenderedFile>` emits one `.als` per module plus a main file with cross-module `open` directives inferred from field/parent/intersection references. Legacy `render() -> String` retained.
- **CLI**: `generate` / `check` accept file **or** directory input via a shared `load_model` helper. `extract -o <dir>` writes multi-file output; `-o <file>.als` falls back to single-file with a flatten warning.
- **Self-hosting**: new `models/oxidtr-split.als` + `models/oxidtr/{ast,ir,analysis,validated}.als` spec-compliant layout demonstrates multi-file end-to-end. The legacy `models/oxidtr.als` is kept for backward compat and emits a `[DEPRECATED]` notice when mid-file `module X` declarations are encountered.

## Acceptance criteria (from #49)

- [x] `cargo test` 全テスト通過 (887 passed / 5 ignored, zero failures)
- [x] ベースライン+20 本以上の新規テスト (+23: parser ×7, renderer ×6, cli ×5, self-hosting ×5)
- [x] `cargo build` warning ゼロ
- [x] `models/oxidtr-split.als` + `models/oxidtr/*.als` が Alloy Analyzer 準拠 (1 ファイル 1 module, `open` による依存解決)
- [x] `oxidtr extract <dir> -o out/` 複数 `.als` 出力
- [x] `oxidtr extract <file>.rs -o out.als` 単一 `.als` 出力
- [x] `oxidtr generate models/oxidtr-split.als` — main から `open` を辿って全 module を生成
- [x] `oxidtr check --model models/oxidtr-split.als --impl generated/` — 0 diff
- [x] 既存 mid-file `module X` 形式は warning 付きで動作継続 (`models/oxidtr.als` のままパス)

## 設計判断

- `models/oxidtr.als` はレガシー互換のため現行形式を維持 (多数の既存テストが `include_str!` / `read_to_string` で参照)。新規モデルは `models/oxidtr-split.als` パターンを推奨。
- `parse_from_path` は循環 `open` を canonical path でガードし、二重取り込みを冪等化。
- ライブラリ系 `open util/ordering[Time]` のようなローカルに実ファイルが無い import は、stderr に notice を出してスキップ (従来動作の維持)。

## Test plan

- [x] `cargo test` — 887 passed / 0 failed / 5 ignored (target validation は外部ツール依存)
- [x] `parser_multi_file`: open 解決 / slash 付き path / パラメータ付き open / ファイル間 merge / 循環検出 / 欠損 open non-fatal / mid-file legacy
- [x] `renderer_multi_file`: 単一 main.als / モジュール分離 / cross-module `open` 自動挿入 / 親 sig 参照 / ungrouped sigs / round-trip via `parse_from_path`
- [x] `cli_multi_file`: file 入力 / dir 入力 / multi-file generate / multi-file check round-trip / dir 出力 extract
- [x] `self_hosting_multi_file`: split モデル parse / qualified module 保持 / IR lower / Rust generate+check round-trip 0 diff / legacy vs split 構造等価

https://claude.ai/code/session_016EaAaTFt7rHDie4xAq8sCN