### PR TITLE
fix(rust): compile generated tests.rs when preds are used in asserts

### DIFF
--- a/src/backend/rust/expr_translator.rs
+++ b/src/backend/rust/expr_translator.rs
@@ -400,6 +400,19 @@ fn build_nested_quantifier(
 /// Translate Alloy function application. Known integer functions (plus, minus, mul, div, rem)
 /// with a receiver are translated to arithmetic operators.
 fn translate_fun_app(name: &str, receiver: Option<&Expr>, args: &[Expr], translate: impl Fn(&Expr) -> String) -> String {
+    translate_fun_app_with(name, receiver, args, translate, false)
+}
+
+/// Like `translate_fun_app`, but when `args_by_ref` is true each argument of
+/// a bare function call is prefixed with `&` — matching the `&T` parameter
+/// convention used when lowering Alloy preds/funs to Rust free functions.
+fn translate_fun_app_with(
+    name: &str,
+    receiver: Option<&Expr>,
+    args: &[Expr],
+    translate: impl Fn(&Expr) -> String,
+    args_by_ref: bool,
+) -> String {
     // Alloy integer arithmetic: receiver.plus[n] → receiver + n
     if let Some(recv) = receiver {
         let op = match name {
@@ -415,13 +428,22 @@ fn translate_fun_app(name: &str, receiver: Option<&Expr>, args: &[Expr], transla
             let a = translate(arg);
             return format!("{r} {op} {a}");
         }
-        // Non-arithmetic method call with receiver
+        // Non-arithmetic method call with receiver — the receiver itself
+        // carries the `&self` reference so args stay owned.
         let a: Vec<_> = args.iter().map(&translate).collect();
         let r = translate(recv);
         return format!("{r}.{name}({})", a.join(", "));
     }
-    // Bare function call: f[x, y] → f(x, y)
-    let a: Vec<_> = args.iter().map(translate).collect();
+    // Bare function call: f[x, y] → f(x, y).
+    // For calls to generated pred/fun operations the parameters are `&T`, so
+    // each arg needs a leading `&` to match the signature.
+    let a: Vec<_> = args
+        .iter()
+        .map(|e| {
+            let s = translate(e);
+            if args_by_ref { format!("&{s}") } else { s }
+        })
+        .collect();
     format!("{name}({})", a.join(", "))
 }
 
@@ -685,7 +707,10 @@ fn translate_inner_ir(
             format!("{l} && {r}")
         }
         Expr::FunApp { name, receiver, args } => {
-            translate_fun_app(name, receiver.as_deref(), args, |e| ti(e, false))
+            // Bare calls into generated operations (preds / funs) take `&T`
+            // params — ensure args are passed by reference.
+            let is_operation = receiver.is_none() && is_operation_call(name, ir);
+            translate_fun_app_with(name, receiver.as_deref(), args, |e| ti(e, false), is_operation)
         }
     };
 
@@ -694,6 +719,10 @@ fn translate_inner_ir(
     } else {
         result
     }
+}
+
+fn is_operation_call(name: &str, ir: &OxidtrIR) -> bool {
+    ir.operations.iter().any(|op| op.name == name)
 }
 
 /// Generate Eq/NotEq comparison handling lone (Option<T>) fields correctly.

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -448,7 +448,7 @@ fn generate_concept_file(
                         let t = rust_return_type(&rt.type_name, &rt.mult);
                         format!(" -> {t}")
                     }
-                    None => String::new(),
+                    None => " -> bool".to_string(),
                 };
 
                 let param_str = if params.is_empty() {
@@ -509,7 +509,7 @@ fn generate_operations_modular(ir: &OxidtrIR, modules: &[String]) -> String {
                 let t = rust_return_type(&rt.type_name, &rt.mult);
                 format!(" -> {t}")
             }
-            None => String::new(),
+            None => " -> bool".to_string(),
         };
 
         if !op.body.is_empty() {
@@ -708,7 +708,7 @@ fn generate_derived_fields(out: &mut String, ir: &OxidtrIR) {
                     let t = rust_return_type(&rt.type_name, &rt.mult);
                     format!(" -> {t}")
                 }
-                None => String::new(),
+                None => " -> bool".to_string(),
             };
 
             let param_str = if params.is_empty() {
@@ -990,7 +990,7 @@ fn generate_operations(ir: &OxidtrIR) -> String {
                 let t = rust_return_type(&rt.type_name, &rt.mult);
                 format!(" -> {t}")
             }
-            None => String::new(),
+            None => " -> bool".to_string(),
         };
 
         // Doc comments with pre/post separation (Feature 7)
@@ -1104,6 +1104,8 @@ fn generate_tests(ir: &OxidtrIR) -> String {
     }
     writeln!(out, "#[allow(unused_imports)]").unwrap();
     writeln!(out, "use super::fixtures::*;").unwrap();
+    writeln!(out, "#[allow(unused_imports)]").unwrap();
+    writeln!(out, "use super::operations::*;").unwrap();
     writeln!(out).unwrap();
 
     // Property tests from asserts — translated expressions
@@ -2026,7 +2028,11 @@ fn generate_newtypes(ir: &OxidtrIR) -> String {
                     let cond = translate_validator_expr_rust(condition, sig_name, ir);
                     let cons = translate_validator_expr_rust(consequent, sig_name, ir);
                     let desc = format!("{} implies {}", analyze::describe_expr(condition), analyze::describe_expr(consequent));
-                    writeln!(out, "        if {cond} && !({cons}) {{").unwrap();
+                    // Parenthesize the condition so disjunctive antecedents
+                    // (`(A or B) implies C`) keep their grouping when combined
+                    // with the `&& !(cons)` check — Rust's `&&` binds tighter
+                    // than `||` so bare `A || B && !(C)` misparses.
+                    writeln!(out, "        if ({cond}) && !({cons}) {{").unwrap();
                     writeln!(out, "            return Err(\"{}\");", desc.replace('"', "\\\"")).unwrap();
                     writeln!(out, "        }}").unwrap();
                 }

--- a/tests/test_generation.rs
+++ b/tests/test_generation.rs
@@ -364,3 +364,86 @@ fn generate_arithmetic_plus_with_receiver() {
     // Should translate plus[1] with receiver to arithmetic: count + 1
     assert!(content.contains("+ 1"), "plus[1] should translate to arithmetic + 1:\n{content}");
 }
+
+// ── ④ Predicate call + tests import ────────────────────────────────────────
+
+/// BUG: tests.rs was missing `use super::operations::*;` so predicate
+/// calls inside translated assert bodies failed to resolve (E0425).
+#[test]
+fn tests_rs_imports_operations() {
+    let files = generate_from(r#"
+        sig Instr { op: one OpCode }
+        sig OpCode {}
+        pred is_memory[i: one Instr] { i.op = i.op }
+        assert Dummy { all i: Instr | is_memory[i] }
+    "#);
+    let tests_rs = find_file(&files, "tests.rs");
+    assert!(
+        tests_rs.contains("use super::operations::*;"),
+        "tests.rs must import operations::*; to resolve predicate calls:\n{tests_rs}"
+    );
+}
+
+/// BUG: predicates were emitted as `fn f(x: &T)` with no return type, so
+/// tests calling them in boolean contexts (`!(is_memory(i) && ...)`)
+/// failed with E0308 "expected bool, found ()".
+#[test]
+fn predicate_returns_bool() {
+    let files = generate_from(r#"
+        sig Instr { op: one OpCode }
+        sig OpCode {}
+        pred is_memory[i: one Instr] { i.op = i.op }
+    "#);
+    let ops = find_file(&files, "operations.rs");
+    // Predicate (no explicit return type) must lower to `-> bool`.
+    assert!(
+        ops.contains("fn is_memory(") && ops.contains(") -> bool"),
+        "pred should lower to `fn is_memory(...) -> bool`:\n{ops}"
+    );
+}
+
+/// BUG: `is_X(i)` was emitted with owned `i` while the signature took
+/// `&T`, producing E0308 type mismatches. Call sites targeting a known
+/// predicate/function must pass args by reference.
+#[test]
+fn predicate_call_passes_args_by_reference() {
+    let files = generate_from(r#"
+        sig Instr { op: one OpCode }
+        sig OpCode {}
+        pred is_memory[i: one Instr] { i.op = i.op }
+        assert Dummy { all i: Instr | is_memory[i] }
+    "#);
+    let tests_rs = find_file(&files, "tests.rs");
+    assert!(
+        tests_rs.contains("is_memory(&i)"),
+        "pred call in tests.rs should pass `&i`, not owned `i`:\n{tests_rs}"
+    );
+}
+
+// ── ⑤ Validator implication precedence ──────────────────────────────────────
+
+/// BUG: `(A or B) implies C` in a fact lowered to `A || B && !C` in the
+/// newtype validator, which Rust parses as `A || (B && !C)` — the wrong
+/// semantics. The condition must be parenthesized.
+#[test]
+fn validator_implication_disjunctive_antecedent_is_parenthesized() {
+    let files = generate_from(r#"
+        sig S { a: one Color, b: one Color }
+        sig Color {}
+        fact F {
+            all s: S |
+                (s.a = s.a or s.a = s.b) implies s.b = s.b
+        }
+    "#);
+    let newtypes = find_file(&files, "newtypes.rs");
+    // The implication must render as `if (A || B) && !(C)` not `if A || B && !(C)`.
+    // We conservatively require that somewhere in newtypes.rs the sequence
+    // `if (` appears followed by `||` on the same conditional line.
+    let has_parenthesized_or = newtypes
+        .lines()
+        .any(|l| l.trim_start().starts_with("if (") && l.contains("||") && l.contains(") && !("));
+    assert!(
+        has_parenthesized_or,
+        "validator must parenthesize disjunctive antecedent of implies:\n{newtypes}"
+    );
+}


### PR DESCRIPTION
## Summary

Fix four related bugs in the Rust backend that caused generated
`tests.rs` / `newtypes.rs` to fail to compile (or compile with
incorrect semantics) when a spec references preds from an assert
body or uses a disjunctive antecedent in an `implies` fact.

## Bugs

1. **Missing import in `tests.rs`** — `use super::operations::*;`
   was never emitted, so any bare pred call inside a translated
   assert body failed with `E0425: cannot find function`.
2. **Preds emitted without `-> bool`** — calling them in a boolean
   context produced `E0308: expected bool, found ()`.
3. **Pred call sites passed owned args to `&T` params** — another
   `E0308` mismatch.
4. **Validator implication lost precedence** — `(A or B) implies C`
   lowered to `if A || B && !(C)`, which Rust parses as
   `A || (B && !C)` — the wrong grouping.

## Changes

- `src/backend/rust/mod.rs`: add `use super::operations::*;` to the
  `tests.rs` header; lower preds (no return type) to `-> bool` in
  all four emitter paths; parenthesize the implication condition in
  the newtype validator.
- `src/backend/rust/expr_translator.rs`: add
  `translate_fun_app_with(args_by_ref)` helper and detect operation
  calls via `is_operation_call(name, ir)` so bare pred/fun calls
  emit `&arg` to match the `&T` parameter convention.
- `tests/test_generation.rs`: four TDD tests, one per bug.

## Test plan

- [x] `cargo test` — 891 passed (baseline 887 + 4 new), 0 failed
- [x] `cargo test --release --test target_validation -- --include-ignored rust_self_hosted_crate_compiles rust_self_hosted_tests_pass` — 2 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_019jLmQ3fGSGSqPjuzHbLtDG)_