### PR TITLE
fix(rust): emit valid nested mod declarations for slash-separated module paths

### DIFF
--- a/src/backend/rust/import_rewrite.rs
+++ b/src/backend/rust/import_rewrite.rs
@@ -12,7 +12,9 @@ pub(super) fn rewrite_models_import(
 ) -> String {
     let mut imports: Vec<String> = modules
         .iter()
-        .map(|m| format!("use super::{m}::*;"))
+        // Alloy module paths are slash-separated (`oxidtr/ast`); Rust paths
+        // are `::`-separated. File-system paths stay unchanged elsewhere.
+        .map(|m| format!("use super::{}::*;", m.replace('/', "::")))
         .collect();
     if has_models {
         imports.push("use super::models::*;".to_string());

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -3,6 +3,12 @@ mod import_rewrite;
 
 use self::import_rewrite::rewrite_models_import;
 
+/// Convert an Alloy module path (slash-separated, e.g. `oxidtr/ast`) to a
+/// Rust module path (`oxidtr::ast`). Filesystem paths stay slash-separated.
+fn module_path_to_rust(module_name: &str) -> String {
+    module_name.replace('/', "::")
+}
+
 use super::{GeneratedFile, TargetLang, is_native_type_alias, resolve_type};
 use crate::ir::nodes::*;
 use crate::parser::ast::{CompareOp, Expr, Multiplicity, SigMultiplicity, TemporalBinaryOp};
@@ -209,13 +215,61 @@ fn generate_modular(ir: &OxidtrIR, config: &RustBackendConfig) -> Vec<GeneratedF
         });
     }
 
-    // Generate lib.rs (top-level module declarations)
+    // Generate lib.rs (top-level module declarations).
+    // For nested Alloy module paths (e.g. `oxidtr/ast`), only the top-level
+    // segment is declared at the crate root; intermediate `<prefix>/mod.rs`
+    // files are synthesized below to declare their children.
     let mut lib_rs = String::new();
+    let mut top_level_seen: HashSet<String> = HashSet::new();
     for module_name in &module_order {
-        writeln!(lib_rs, "pub mod {module_name};").unwrap();
+        let top = module_name.split('/').next().unwrap().to_string();
+        if top_level_seen.insert(top.clone()) {
+            writeln!(lib_rs, "pub mod {top};").unwrap();
+        }
     }
     if !ungrouped.is_empty() {
         writeln!(lib_rs, "pub mod models;").unwrap();
+    }
+
+    // Synthesize / augment intermediate mod.rs files for each path prefix so
+    // that a module like `oxidtr/ast` compiles: lib.rs needs `pub mod oxidtr;`
+    // and `oxidtr/mod.rs` needs `pub mod ast;`.
+    //
+    // `prefix_children[prefix]` lists the direct child segment names, ordered
+    // by first appearance in `module_order` so output is deterministic.
+    let mut prefix_children: Vec<(String, Vec<String>)> = Vec::new();
+    let mut prefix_index: HashMap<String, usize> = HashMap::new();
+    for module_name in &module_order {
+        let segs: Vec<&str> = module_name.split('/').collect();
+        // Intermediate prefixes only (skip the leaf index = segs.len() - 1).
+        for i in 0..segs.len().saturating_sub(1) {
+            let parent = segs[..=i].join("/");
+            let child = segs[i + 1].to_string();
+            let idx = *prefix_index.entry(parent.clone()).or_insert_with(|| {
+                prefix_children.push((parent.clone(), Vec::new()));
+                prefix_children.len() - 1
+            });
+            if !prefix_children[idx].1.contains(&child) {
+                prefix_children[idx].1.push(child);
+            }
+        }
+    }
+    for (prefix, children) in &prefix_children {
+        let path = format!("{prefix}/mod.rs");
+        let mut decls = String::new();
+        for child in children {
+            writeln!(decls, "pub mod {child};").unwrap();
+        }
+        // If the prefix itself is a leaf module (has its own sigs), merge the
+        // child declarations into the existing mod.rs content; otherwise
+        // emit a fresh intermediate mod.rs.
+        if let Some(existing) = files.iter_mut().find(|f| f.path == path) {
+            let mut merged = decls;
+            merged.push_str(&existing.content);
+            existing.content = merged;
+        } else {
+            files.push(GeneratedFile { path, content: decls });
+        }
     }
 
     // Check if TC, operations, tests, fixtures, newtypes are needed
@@ -330,7 +384,7 @@ fn generate_concept_file(
         let types = needed_imports.get(module).unwrap();
         let mut sorted_types: Vec<&String> = types.iter().collect();
         sorted_types.sort();
-        writeln!(out, "use crate::{}::{{{}}};", module, sorted_types.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", ")).unwrap();
+        writeln!(out, "use crate::{}::{{{}}};", module_path_to_rust(module), sorted_types.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", ")).unwrap();
     }
 
     // Intra-module imports: types from sibling files within the same module
@@ -475,7 +529,7 @@ fn generate_operations_modular(ir: &OxidtrIR, modules: &[String]) -> String {
     let mut out = String::new();
 
     for module in modules {
-        writeln!(out, "use super::{module}::*;").unwrap();
+        writeln!(out, "use super::{}::*;", module_path_to_rust(module)).unwrap();
     }
     writeln!(out).unwrap();
 
@@ -536,7 +590,7 @@ fn generate_tests_modular(ir: &OxidtrIR, modules: &[String]) -> String {
     let original = generate_tests(ir);
     // Replace `use crate::models::*` with module imports
     let mut result = original.replace("use super::models::*;",
-        &modules.iter().map(|m| format!("use super::{m}::*;")).collect::<Vec<_>>().join("\n    "));
+        &modules.iter().map(|m| format!("use super::{}::*;", module_path_to_rust(m))).collect::<Vec<_>>().join("\n    "));
     // Also update fixtures import
     result = result.replace("use super::fixtures::*;", "use super::fixtures::*;");
     result
@@ -546,7 +600,7 @@ fn generate_tests_modular(ir: &OxidtrIR, modules: &[String]) -> String {
 fn generate_fixtures_modular(ir: &OxidtrIR, modules: &[String]) -> String {
     let original = generate_fixtures(ir);
     original.replace("use super::models::*;",
-        &modules.iter().map(|m| format!("use super::{m}::*;")).collect::<Vec<_>>().join("\n"))
+        &modules.iter().map(|m| format!("use super::{}::*;", module_path_to_rust(m))).collect::<Vec<_>>().join("\n"))
 }
 
 /// Generate newtypes.rs with modular imports
@@ -554,7 +608,7 @@ fn generate_newtypes_modular(ir: &OxidtrIR, modules: &[String]) -> String {
     let original = generate_newtypes(ir);
     if original.is_empty() { return original; }
     original.replace("use super::models::*;",
-        &modules.iter().map(|m| format!("use super::{m}::*;")).collect::<Vec<_>>().join("\n"))
+        &modules.iter().map(|m| format!("use super::{}::*;", module_path_to_rust(m))).collect::<Vec<_>>().join("\n"))
 }
 
 

--- a/tests/cli_multi_file.rs
+++ b/tests/cli_multi_file.rs
@@ -134,3 +134,113 @@ fn extract_directory_output_writes_multiple_files() {
     assert!(has_ir, "expected ir file in {:?}",
         files.iter().map(|f| f.path.display().to_string()).collect::<Vec<_>>());
 }
+
+// ─── Modular Rust codegen: nested module paths ─────────────────────────────
+
+/// BUG: when an Alloy module name contains `/` (e.g. `oxidtr/ast`), the
+/// Rust backend emitted `pub mod oxidtr/ast;` in the crate-root mod.rs,
+/// which is invalid Rust. It must emit `pub mod oxidtr;` at the root and
+/// create an intermediate `oxidtr/mod.rs` that declares `pub mod ast;`.
+#[test]
+fn modular_codegen_uses_nested_mod_declarations() {
+    let root = fresh_dir("modular-nested");
+    let sub = root.join("oxidtr");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(
+        root.join("main.als"),
+        "module oxidtr\nopen oxidtr/ast\nopen oxidtr/ir\n",
+    ).unwrap();
+    fs::write(
+        sub.join("ast.als"),
+        "module oxidtr/ast\nsig AstNode {}\n",
+    ).unwrap();
+    fs::write(
+        sub.join("ir.als"),
+        "module oxidtr/ir\nsig IrNode { origin: one AstNode }\n",
+    ).unwrap();
+
+    let out = root.join("generated");
+    let config = GenerateConfig::new("rust", out.to_str().unwrap());
+    generate_run(root.join("main.als").to_str().unwrap(), &config)
+        .expect("generate");
+
+    // Crate root (emitted as `mod.rs`) must declare only the top-level
+    // segment, not the raw slashed path.
+    let root_mod = fs::read_to_string(out.join("mod.rs")).expect("root mod.rs");
+    assert!(
+        root_mod.contains("pub mod oxidtr;"),
+        "root mod.rs should declare `pub mod oxidtr;`, got:\n{root_mod}"
+    );
+    assert!(
+        !root_mod.contains("pub mod oxidtr/ast;")
+            && !root_mod.contains("pub mod oxidtr/ir;"),
+        "root mod.rs must not emit slash-separated `pub mod` paths:\n{root_mod}"
+    );
+
+    // An intermediate `oxidtr/mod.rs` must exist and declare its children.
+    let intermediate = fs::read_to_string(out.join("oxidtr/mod.rs"))
+        .expect("oxidtr/mod.rs should be generated as an intermediate");
+    assert!(
+        intermediate.contains("pub mod ast;"),
+        "oxidtr/mod.rs should declare `pub mod ast;`:\n{intermediate}"
+    );
+    assert!(
+        intermediate.contains("pub mod ir;"),
+        "oxidtr/mod.rs should declare `pub mod ir;`:\n{intermediate}"
+    );
+}
+
+/// BUG: cross-module imports in ops/newtypes also used raw slashed paths
+/// (`use super::oxidtr/ast::*;` or `use crate::oxidtr/ast::{...};`), which
+/// are invalid Rust. Slashes must be converted to `::` in all emitted
+/// Rust paths.
+#[test]
+fn modular_codegen_cross_module_imports_use_double_colon() {
+    let root = fresh_dir("modular-imports");
+    let sub = root.join("oxidtr");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(
+        root.join("main.als"),
+        "module oxidtr\nopen oxidtr/ast\nopen oxidtr/ir\n",
+    ).unwrap();
+    fs::write(
+        sub.join("ast.als"),
+        "module oxidtr/ast\nsig AstNode {}\n",
+    ).unwrap();
+    fs::write(
+        sub.join("ir.als"),
+        // IrNode references AstNode across modules.
+        "module oxidtr/ir\nsig IrNode { origin: one AstNode }\n",
+    ).unwrap();
+
+    let out = root.join("generated");
+    let config = GenerateConfig::new("rust", out.to_str().unwrap());
+    generate_run(root.join("main.als").to_str().unwrap(), &config)
+        .expect("generate");
+
+    // Read every .rs file under generated/ and confirm no slashed paths
+    // appear on any `use super::` / `use crate::` line.
+    fn walk(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        for e in fs::read_dir(dir).unwrap() {
+            let p = e.unwrap().path();
+            if p.is_dir() { walk(&p, out); }
+            else if p.extension().map_or(false, |x| x == "rs") { out.push(p); }
+        }
+    }
+    let mut rs_files = Vec::new();
+    walk(&out, &mut rs_files);
+
+    for p in &rs_files {
+        let content = fs::read_to_string(p).unwrap();
+        for (line_no, line) in content.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("use super::") || trimmed.starts_with("use crate::") {
+                assert!(
+                    !trimmed.contains('/'),
+                    "{}:{} contains slash in use path: {trimmed}",
+                    p.display(), line_no + 1,
+                );
+            }
+        }
+    }
+}

--- a/tests/target_validation.rs
+++ b/tests/target_validation.rs
@@ -106,6 +106,39 @@ edition = "2021"
     }
 }
 
+/// Same as `rust_self_hosted_crate_compiles` but uses the Alloy-6
+/// spec-compliant multi-file variant (`models/oxidtr-split.als`). Exercises
+/// the modular codegen path — nested `module oxidtr/ast` etc. — and guards
+/// against regressions in intermediate `mod.rs` generation and `::`-path
+/// cross-module imports.
+#[test]
+#[ignore]
+fn rust_self_hosted_split_crate_compiles() {
+    let model = parser::parse_from_path(std::path::Path::new("models/oxidtr-split.als"))
+        .expect("parse oxidtr-split.als");
+    let ir = ir::lower(&model).expect("lower oxidtr-split.als");
+
+    let tmp = tempfile::tempdir().unwrap();
+    let crate_dir = tmp.path().join("selfhost_split_crate");
+    let crate_dir = crate_dir.to_str().unwrap();
+
+    write_rust_crate(&ir, crate_dir);
+
+    let output = std::process::Command::new("cargo")
+        .arg("check")
+        .current_dir(crate_dir)
+        .output()
+        .expect("failed to run cargo check");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "cargo check on split model crate failed!\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
 /// Generate a complete crate from oxidtr.als and verify it type-checks.
 #[test]
 #[ignore]


### PR DESCRIPTION
## Summary

Fix the modular Rust backend so Alloy-6 spec-compliant multi-file
specs — the recommended layout in `CLAUDE.md` — produce a crate that
actually compiles. Previously any qualified module declaration like
`module oxidtr/ast` caused the backend to emit invalid Rust:

- Crate-root `mod.rs` emitted `pub mod oxidtr/ast;` (Rust syntax error)
- Cross-module imports emitted `use crate::oxidtr/ast::{T};` and
  `use super::oxidtr/ast::*;` (same syntax error in every ops /
  newtypes / fixtures / tests file)
- No intermediate `oxidtr/mod.rs` was generated, so even had the
  top-level syntax been valid the children would have been unreachable

The `models/oxidtr-split.als` round-trip (`self_hosting_multi_file`)
passed only because `check` compares Alloy↔Rust structure but never
runs `cargo check` against the generated crate.

## Changes

- `src/backend/rust/mod.rs`
  - Add `module_path_to_rust(name)` — `oxidtr/ast` → `oxidtr::ast`
  - Rewrite the crate-root `pub mod` loop to emit one declaration per
    distinct top-level segment (in first-appearance order)
  - Build a prefix tree from `module_order` and synthesize an
    intermediate `<prefix>/mod.rs` for each non-leaf path; when a
    prefix coincides with a leaf module that has its own sigs, prepend
    the child `pub mod` declarations to its existing `mod.rs`
  - Apply `module_path_to_rust` to every `use crate::` / `use super::`
    emission site (`generate_concept_file`, `generate_operations_modular`,
    `generate_tests_modular`, `generate_fixtures_modular`,
    `generate_newtypes_modular`)
- `src/backend/rust/import_rewrite.rs`: same `::` translation in the
  models-import rewriter
- `tests/cli_multi_file.rs`: two new unit tests for nested `pub mod`
  emission and the absence of slashed paths in any `use`
- `tests/target_validation.rs`: new `#[ignore]`d
  `rust_self_hosted_split_crate_compiles` that runs `cargo check` on
  the crate generated from `models/oxidtr-split.als`, preventing
  silent regressions on the spec-recommended layout

## Test plan

- [x] `cargo test --release` — 893 passed (baseline 891 + 2 new),
      0 failed
- [x] `cargo test --release --test target_validation -- --include-ignored
      rust_self_hosted_crate_compiles rust_self_hosted_tests_pass
      rust_self_hosted_split_crate_compiles` — 3 passed
- [x] Manually regenerated `models/oxidtr-split.als` into a fresh
      cargo crate; `cargo check` passes with only `non_snake_case`
      style warnings (unrelated)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HdVxk9XtxbwcZSSj8ypLuz)_