### PR TITLE
fix(rust): use BTreeSet idioms for `some`/`no`/`in` on set-valued fields

### DIFF
--- a/src/backend/rust/expr_translator.rs
+++ b/src/backend/rust/expr_translator.rs
@@ -483,6 +483,31 @@ fn collect_sig_names_set(ir: &OxidtrIR) -> HashSet<String> {
     ir.structures.iter().map(|s| s.name.clone()).collect()
 }
 
+/// True when `expr` is a field access whose multiplicity is `set` or
+/// `seq` — i.e. lowers to a Rust collection (`BTreeSet` / `Vec`) where
+/// "non-empty" and "empty" are spelled `.is_empty()`, not `.is_some()` /
+/// `.is_none()`.
+pub(super) fn is_collection_expr(expr: &Expr, ir: &OxidtrIR) -> bool {
+    if let Expr::FieldAccess { field, .. } = expr {
+        matches!(
+            field_mult(field, ir),
+            Some((Multiplicity::Set, _)) | Some((Multiplicity::Seq, _))
+        )
+    } else {
+        false
+    }
+}
+
+/// Stronger check: field access whose multiplicity is specifically `set`
+/// (not `seq`). Only `BTreeSet` has `.is_subset()`.
+pub(super) fn is_set_expr(expr: &Expr, ir: &OxidtrIR) -> bool {
+    if let Expr::FieldAccess { field, .. } = expr {
+        matches!(field_mult(field, ir), Some((Multiplicity::Set, _)))
+    } else {
+        false
+    }
+}
+
 /// Look up the multiplicity and boxing info of a named field.
 /// Returns (multiplicity, needs_box) where needs_box is true for self-ref or cyclic-ref fields.
 fn field_mult(field_name: &str, ir: &OxidtrIR) -> Option<(Multiplicity, bool)> {
@@ -635,6 +660,13 @@ fn translate_inner_ir(
                             };
                         }
                     }
+                    // If LHS is itself a set-typed expression, `A in B`
+                    // is a subset test, not an element-containment test —
+                    // BTreeSet::contains expects `&T`, not `&BTreeSet<T>`.
+                    if is_set_expr(left, ir) {
+                        let r = ti(right, false);
+                        return format!("{l}.is_subset(&{r})");
+                    }
                     // Default: Set / One field → .contains()
                     let r = ti(right, false);
                     format!("{r}.contains(&{l})")
@@ -678,7 +710,13 @@ fn translate_inner_ir(
 
         Expr::MultFormula { kind, expr } => {
             let inner = ti(expr, false);
+            // For set/seq-valued inner expressions, `some X` / `no X`
+            // lower to `.is_empty()`-based checks — `.is_some()` /
+            // `.is_none()` belong to Option, not BTreeSet / Vec.
+            let collection = is_collection_expr(expr, ir);
             match kind {
+                QuantKind::Some if collection => format!("!{inner}.is_empty()"),
+                QuantKind::No   if collection => format!("{inner}.is_empty()"),
                 QuantKind::Some => format!("{inner}.is_some()"),
                 QuantKind::No => format!("{inner}.is_none()"),
                 _ => inner,

--- a/src/backend/rust/mod.rs
+++ b/src/backend/rust/mod.rs
@@ -2359,7 +2359,15 @@ fn translate_validator_expr_rust(expr: &Expr, sig_name: &str, ir: &OxidtrIR) -> 
                     }
                     op_str
                 }
-                CompareOp::In => return format!("{r}.contains(&{l})"),
+                CompareOp::In => {
+                    // `set_a in set_b` is a subset test; `.contains()`
+                    // takes an element reference and would type-mismatch
+                    // on a set-valued LHS.
+                    if expr_translator::is_set_expr(left, ir) {
+                        return format!("{l}.is_subset(&{r})");
+                    }
+                    return format!("{r}.contains(&{l})");
+                }
                 CompareOp::Lt | CompareOp::Gt | CompareOp::Lte | CompareOp::Gte => {
                     let op_str = match op {
                         CompareOp::Lt => "<",
@@ -2396,7 +2404,12 @@ fn translate_validator_expr_rust(expr: &Expr, sig_name: &str, ir: &OxidtrIR) -> 
         Expr::Not(inner) => format!("!({})", translate_validator_expr_rust(inner, sig_name, ir)),
         Expr::MultFormula { kind, expr: inner } => {
             let e = translate_validator_expr_rust(inner, sig_name, ir);
+            // For set/seq-valued inner expressions use `.is_empty()`;
+            // `.is_some()` / `.is_none()` belong to Option, not BTreeSet / Vec.
+            let collection = expr_translator::is_collection_expr(inner, ir);
             match kind {
+                QuantKind::Some if collection => format!("!{e}.is_empty()"),
+                QuantKind::No   if collection => format!("{e}.is_empty()"),
                 QuantKind::Some => format!("{e}.is_some()"),
                 QuantKind::No => format!("{e}.is_none()"),
                 _ => e,

--- a/tests/backend_rust.rs
+++ b/tests/backend_rust.rs
@@ -837,3 +837,104 @@ fn one_sig_fixed_value_generates_unit_variant_with_const_method() {
     assert!(models.contains("Self::Magma => 0"), "Magma.rank should be 0:\n{models}");
     assert!(models.contains("Self::Monoid => 1"), "Monoid.rank should be 1:\n{models}");
 }
+
+// ─── Set-valued expression codegen ─────────────────────────────────────────
+
+/// BUG: `some field` where `field` has multiplicity `set` lowered to
+/// `field.is_some()`, which is an Option method. BTreeSet doesn't have
+/// it — the generated code fails to compile. Must emit `!field.is_empty()`.
+#[test]
+fn some_on_set_field_uses_is_empty() {
+    let files = generate_from(r#"
+        sig Node {
+          children: set Node
+        }
+        fact HasChildren {
+          all n: Node | some n.children
+        }
+    "#);
+    let tests = find_file(&files, "tests.rs");
+    assert!(
+        tests.contains("!n.children.is_empty()") || tests.contains("! n.children.is_empty()"),
+        "`some set_field` should lower to `!field.is_empty()`, got:\n{tests}"
+    );
+    assert!(
+        !tests.contains("n.children.is_some()"),
+        "`some set_field` must not emit `.is_some()` on a BTreeSet:\n{tests}"
+    );
+}
+
+/// Mirror of the above: `no set_field` must lower to `field.is_empty()`.
+#[test]
+fn no_on_set_field_uses_is_empty() {
+    let files = generate_from(r#"
+        sig Node {
+          children: set Node
+        }
+        fact NoChildren {
+          all n: Node | no n.children
+        }
+    "#);
+    let tests = find_file(&files, "tests.rs");
+    assert!(
+        tests.contains("n.children.is_empty()"),
+        "`no set_field` should lower to `field.is_empty()`, got:\n{tests}"
+    );
+    assert!(
+        !tests.contains("n.children.is_none()"),
+        "`no set_field` must not emit `.is_none()` on a BTreeSet:\n{tests}"
+    );
+}
+
+/// BUG: `set_a in set_b` (subset) was lowered to `set_b.contains(&set_a)`,
+/// which is an element-membership test and a type error besides. For two
+/// set-typed operands, must emit `set_a.is_subset(&set_b)`.
+#[test]
+fn subset_between_set_fields_uses_is_subset() {
+    let files = generate_from(r#"
+        sig Group {
+          members: set Person,
+          admins:  set Person
+        }
+        sig Person {}
+        fact AdminsAreMembers {
+          all g: Group | g.admins in g.members
+        }
+    "#);
+    let tests = find_file(&files, "tests.rs");
+    assert!(
+        tests.contains("g.admins.is_subset(&g.members)"),
+        "`set in set` should lower to `.is_subset(&...)`, got:\n{tests}"
+    );
+    assert!(
+        !tests.contains("g.members.contains(&g.admins)"),
+        "`set in set` must not emit `.contains()` with a set-valued arg:\n{tests}"
+    );
+}
+
+/// Same fix applied at the validator (newtypes.rs) emission path: when a
+/// fact's antecedent uses `some set_field`, the generated TryFrom must
+/// not call `.is_some()` on a BTreeSet. The fact includes an explicit
+/// comparison (`capacity > 0`) so newtypes.rs is emitted for Room.
+#[test]
+fn validator_handles_some_set_field() {
+    let files = generate_from(r#"
+        sig Room {
+          occupants: set Person,
+          capacity:  one Int
+        }
+        sig Person {}
+        fact NonEmptyImpliesSized {
+          all r: Room | some r.occupants implies r.capacity > 0
+        }
+    "#);
+    let newtypes = find_file(&files, "newtypes.rs");
+    assert!(
+        !newtypes.contains(".occupants.is_some()"),
+        "validator must not call `.is_some()` on a BTreeSet:\n{newtypes}"
+    );
+    assert!(
+        newtypes.contains(".occupants.is_empty()"),
+        "validator should check `!is_empty()` on the set field:\n{newtypes}"
+    );
+}


### PR DESCRIPTION
## Summary

Three codegen paths in the Rust backend emitted Option methods on
set/seq field expressions, producing generated code that didn't
compile:

- `some <set-field>` → `field.is_some()` (BTreeSet has no such method)
- `no <set-field>`   → `field.is_none()`
- `set_a in set_b`   → `set_b.contains(&set_a)` (semantic + type error;
  `.contains` wants `&T`, not `&BTreeSet<T>`)

Downstream specs that model collections — e.g. a Chang-Atallah-style
guard network with `guard_edges: set Guard` and facts like
`some g.guard_edges` or `g.guard_edges in t.guards` — were previously
forced to hand-translate each idiom into a cardinality-based
equivalent (`#field > 0`, element-wise quantification). This PR
eliminates that workaround.

## Changes

- `src/backend/rust/expr_translator.rs`
  - Add `is_collection_expr(expr, ir)` and `is_set_expr(expr, ir)`
    helpers (`pub(super)` so `mod.rs` can share them)
  - In `translate_inner_ir`:
    - `MultFormula::Some` / `MultFormula::No` on a collection → emit
      `!X.is_empty()` / `X.is_empty()`
    - `CompareOp::In` with a set-valued LHS → emit
      `X.is_subset(&Y)` instead of `Y.contains(&X)`
- `src/backend/rust/mod.rs` (validator / newtypes path)
  - Same two fixes applied to `translate_validator_expr_rust`, so the
    `TryFrom` impls in `newtypes.rs` type-check for the same Alloy
    idioms.
- `tests/backend_rust.rs`
  - Four TDD tests: `some` on set, `no` on set, subset `in`, and the
    validator path. Each asserts both the presence of the new idiom
    and the absence of the broken one.

## Test plan

- [x] `cargo test` — 897 passed (baseline 893 + 4 new), 0 failed
- [x] `cargo build` — zero warnings
- [x] Self-host: `cargo run -- generate models/oxidtr.als --target rust --output generated` + `cargo run -- check --model models/oxidtr.als --impl generated` → `ok: model and implementation are in sync`

---
_Generated by [Claude Code](https://claude.ai/code/session_014GWzaLUaiF1DduyWDiUYUJ)_