### PR TITLE
fix(parser): support comma-separated sig name declarations

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -116,49 +116,61 @@ impl<'a> Parser<'a> {
             match self.peek() {
                 Token::Eof => break,
                 Token::Sig => {
-                    let mut sig = self.parse_sig(false, false)?;
-                    sig.module = self.current_module.clone();
-                    model.sigs.push(sig);
+                    let sigs = self.parse_sig(false, false)?;
+                    for mut sig in sigs {
+                        sig.module = self.current_module.clone();
+                        model.sigs.push(sig);
+                    }
                 }
                 Token::Var => {
                     // Alloy 6: `var sig` — mutable atom set
                     self.next();
-                    let mut sig = self.parse_sig(false, true)?;
-                    sig.module = self.current_module.clone();
-                    model.sigs.push(sig);
+                    let sigs = self.parse_sig(false, true)?;
+                    for mut sig in sigs {
+                        sig.module = self.current_module.clone();
+                        model.sigs.push(sig);
+                    }
                 }
                 Token::Abstract => {
                     self.next();
                     // Alloy 6: `abstract var sig` — not typical but handle gracefully
                     let is_var = if self.peek() == Token::Var { self.next(); true } else { false };
                     self.expect(&Token::Sig)?;
-                    let mut sig = self.parse_sig_body(true, is_var, SigMultiplicity::Default)?;
-                    sig.module = self.current_module.clone();
-                    model.sigs.push(sig);
+                    let sigs = self.parse_sig_body(true, is_var, SigMultiplicity::Default)?;
+                    for mut sig in sigs {
+                        sig.module = self.current_module.clone();
+                        model.sigs.push(sig);
+                    }
                 }
                 Token::One => {
                     self.next();
                     let is_var = if self.peek() == Token::Var { self.next(); true } else { false };
                     self.expect(&Token::Sig)?;
-                    let mut sig = self.parse_sig_body(false, is_var, SigMultiplicity::One)?;
-                    sig.module = self.current_module.clone();
-                    model.sigs.push(sig);
+                    let sigs = self.parse_sig_body(false, is_var, SigMultiplicity::One)?;
+                    for mut sig in sigs {
+                        sig.module = self.current_module.clone();
+                        model.sigs.push(sig);
+                    }
                 }
                 Token::Some_ => {
                     self.next();
                     let is_var = if self.peek() == Token::Var { self.next(); true } else { false };
                     self.expect(&Token::Sig)?;
-                    let mut sig = self.parse_sig_body(false, is_var, SigMultiplicity::Some)?;
-                    sig.module = self.current_module.clone();
-                    model.sigs.push(sig);
+                    let sigs = self.parse_sig_body(false, is_var, SigMultiplicity::Some)?;
+                    for mut sig in sigs {
+                        sig.module = self.current_module.clone();
+                        model.sigs.push(sig);
+                    }
                 }
                 Token::Lone => {
                     self.next();
                     let is_var = if self.peek() == Token::Var { self.next(); true } else { false };
                     self.expect(&Token::Sig)?;
-                    let mut sig = self.parse_sig_body(false, is_var, SigMultiplicity::Lone)?;
-                    sig.module = self.current_module.clone();
-                    model.sigs.push(sig);
+                    let sigs = self.parse_sig_body(false, is_var, SigMultiplicity::Lone)?;
+                    for mut sig in sigs {
+                        sig.module = self.current_module.clone();
+                        model.sigs.push(sig);
+                    }
                 }
                 Token::Module => {
                     let path = self.parse_module_decl();
@@ -269,14 +281,28 @@ impl<'a> Parser<'a> {
         Ok(sigs)
     }
 
-    fn parse_sig(&mut self, is_abstract: bool, is_var: bool) -> Result<SigDecl, ParseError> {
+    fn parse_sig(&mut self, is_abstract: bool, is_var: bool) -> Result<Vec<SigDecl>, ParseError> {
         self.expect(&Token::Sig)?;
         self.parse_sig_body(is_abstract, is_var, SigMultiplicity::Default)
     }
 
-    fn parse_sig_body(&mut self, is_abstract: bool, is_var: bool, multiplicity: SigMultiplicity) -> Result<SigDecl, ParseError> {
-        let name = self.expect_ident()?;
-        self.current_sig_name = name.clone(); // track for union annotation lookup
+    /// Parse one or more comma-separated sig names sharing the same body.
+    ///
+    /// Alloy 6 allows `one sig A, B, C extends Parent {}` — multiple sigs declared
+    /// at once. Each name produces an independent `SigDecl` with the same parent,
+    /// modifiers, and fields. Union/intersection annotations are looked up per
+    /// individual name. `current_sig_name` is left set to the first name so that
+    /// field-level union annotations (rare for the multi-name form, which is
+    /// typically used for enum-like singletons with empty bodies) remain
+    /// addressable through the conventional code path.
+    fn parse_sig_body(&mut self, is_abstract: bool, is_var: bool, multiplicity: SigMultiplicity) -> Result<Vec<SigDecl>, ParseError> {
+        let first_name = self.expect_ident()?;
+        let mut names = vec![first_name.clone()];
+        while self.peek() == Token::Comma {
+            self.next(); // consume comma
+            names.push(self.expect_ident()?);
+        }
+        self.current_sig_name = first_name; // track for union annotation lookup
 
         let parent = if self.peek() == Token::Extends {
             self.next();
@@ -297,20 +323,23 @@ impl<'a> Parser<'a> {
 
         self.expect(&Token::RBrace)?;
 
-        let intersection_of = self.intersection_annotations
-            .remove(&name)
-            .unwrap_or_default();
-
-        Ok(SigDecl {
-            name,
-            is_abstract,
-            is_var,
-            multiplicity,
-            parent,
-            fields,
-            intersection_of,
-            module: None, // set by parse_model from current_module
-        })
+        let mut sigs = Vec::with_capacity(names.len());
+        for name in names {
+            let intersection_of = self.intersection_annotations
+                .remove(&name)
+                .unwrap_or_default();
+            sigs.push(SigDecl {
+                name,
+                is_abstract,
+                is_var,
+                multiplicity: multiplicity.clone(),
+                parent: parent.clone(),
+                fields: fields.clone(),
+                intersection_of,
+                module: None, // set by parse_model from current_module
+            });
+        }
+        Ok(sigs)
     }
 
     fn parse_field(&mut self) -> Result<FieldDecl, ParseError> {

--- a/tests/parser_sig.rs
+++ b/tests/parser_sig.rs
@@ -262,6 +262,80 @@ fn parse_one_var_sig_extends() {
     assert_eq!(model.sigs[1].parent.as_deref(), Some("Base"));
 }
 
+// ── Alloy 6: comma-separated sig names sharing one body ──────────────────────
+
+#[test]
+fn parse_multi_name_one_sig() {
+    // Alloy 6 allows `one sig A, B, C extends Parent {}` — each name becomes
+    // its own SigDecl with the shared parent, modifiers, and (empty) body.
+    let model = parser::parse(
+        "abstract sig WeatherState {} one sig Clear, Cloudy, Rain extends WeatherState {}",
+    )
+    .unwrap();
+    assert_eq!(model.sigs.len(), 4);
+    assert!(model.sigs[0].is_abstract);
+
+    for (i, name) in ["Clear", "Cloudy", "Rain"].iter().enumerate() {
+        let sig = &model.sigs[i + 1];
+        assert_eq!(sig.name, *name);
+        assert_eq!(sig.multiplicity, SigMultiplicity::One);
+        assert_eq!(sig.parent.as_deref(), Some("WeatherState"));
+        assert!(sig.fields.is_empty());
+        assert!(!sig.is_abstract);
+    }
+}
+
+#[test]
+fn parse_multi_name_sig_default_multiplicity() {
+    let model = parser::parse("sig A, B {}").unwrap();
+    assert_eq!(model.sigs.len(), 2);
+    assert_eq!(model.sigs[0].name, "A");
+    assert_eq!(model.sigs[1].name, "B");
+    assert_eq!(model.sigs[0].multiplicity, SigMultiplicity::Default);
+    assert_eq!(model.sigs[1].multiplicity, SigMultiplicity::Default);
+}
+
+#[test]
+fn parse_multi_name_sig_shares_fields() {
+    // Fields declared inside a multi-name body are duplicated to every sig.
+    let model = parser::parse("sig Foo, Bar { x: one Int }").unwrap();
+    assert_eq!(model.sigs.len(), 2);
+    assert_eq!(model.sigs[0].name, "Foo");
+    assert_eq!(model.sigs[1].name, "Bar");
+    for sig in &model.sigs {
+        assert_eq!(sig.fields.len(), 1);
+        assert_eq!(sig.fields[0].name, "x");
+        assert_eq!(sig.fields[0].target, "Int");
+    }
+}
+
+#[test]
+fn parse_multi_name_some_sig_extends() {
+    let model = parser::parse("some sig A, B, C extends Base {}").unwrap();
+    assert_eq!(model.sigs.len(), 3);
+    for (i, name) in ["A", "B", "C"].iter().enumerate() {
+        assert_eq!(model.sigs[i].name, *name);
+        assert_eq!(model.sigs[i].multiplicity, SigMultiplicity::Some);
+        assert_eq!(model.sigs[i].parent.as_deref(), Some("Base"));
+    }
+}
+
+#[test]
+fn parse_multi_name_var_sig() {
+    let model = parser::parse("var sig X, Y {}").unwrap();
+    assert_eq!(model.sigs.len(), 2);
+    assert!(model.sigs[0].is_var);
+    assert!(model.sigs[1].is_var);
+}
+
+#[test]
+fn parse_single_name_sig_still_works() {
+    // Regression guard: the multi-name path must not break the common single-name case.
+    let model = parser::parse("sig Solo {}").unwrap();
+    assert_eq!(model.sigs.len(), 1);
+    assert_eq!(model.sigs[0].name, "Solo");
+}
+
 // ── intersection_of comment parsing ──────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

The Alloy 6 grammar allows declaring multiple sigs that share a body:

```alloy
abstract sig WeatherState {}
one sig Clear, Cloudy, Rain extends WeatherState {}
```

`parse_sig_body` only read a single ident, so the comma triggered `expected LBrace, found Comma`. This blocks .als specs that follow the standard Alloy idiom for enum-like singletons (each `one sig` produces a separate atom under a shared parent).

## Approach

- `parse_sig` / `parse_sig_body` now return `Vec<SigDecl>`. After the leading ident, the parser repeatedly consumes `, <ident>` until a non-comma is seen.
- Parent, modifiers, and fields are shared across all names.
- `intersection_annotations` are consumed per-name via `remove()` (each annotation still belongs to exactly one sig).
- `current_sig_name` retains the first name — field-level union annotation lookup is unchanged for the common single-name case and behaves consistently for the multi-name form (which is typically empty-bodied).
- Six call sites in `parse_model` (`sig` / `var sig` / `abstract sig` / `one sig` / `some sig` / `lone sig`) now iterate the returned `Vec` when assigning module context.

## Coverage

Six tests added in `tests/parser_sig.rs`:

| Test | Form |
|---|---|
| `parse_multi_name_one_sig` | `one sig A, B, C extends Parent {}` (the motivating case) |
| `parse_multi_name_sig_default_multiplicity` | `sig A, B {}` |
| `parse_multi_name_sig_shares_fields` | `sig Foo, Bar { x: one Int }` — fields duplicated to each |
| `parse_multi_name_some_sig_extends` | `some sig A, B, C extends Base {}` |
| `parse_multi_name_var_sig` | `var sig X, Y {}` |
| `parse_single_name_sig_still_works` | Regression guard for the existing single-name path |

## Verification

- `cargo build` — clean
- `cargo test` — **903/903 passing** (897 previously + 6 new). No existing test changed behavior.
- Verified `oxidtr generate` end-to-end on a probe spec using the multi-name form: the resulting `enum WeatherState { Clear, Cloudy, Rain }` is generated as expected.

## Why this matters

This unblocks projects (such as imagindow) whose Alloy specs are authored in idiomatic Alloy 6 style. Without the fix, every multi-name declaration has to be hand-expanded to one sig per line, which diverges from the source spec and bloats reviews.

## Test plan

- [ ] CI passes (cargo test, cargo fmt, cargo clippy)
- [ ] Verify the new `parse_multi_name_*` tests in `tests/parser_sig.rs` cover the intended forms
- [ ] Verify that `oxidtr generate` produces the same enum shape as the hand-expanded equivalent (`one sig Clear extends X {}` + `one sig Cloudy extends X {}` + `one sig Rain extends X {}`)