### PR TITLE
fix(parser): support comma-separated param names in pred / fun

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -406,7 +406,7 @@ impl<'a> Parser<'a> {
         if self.peek() == Token::LBracket {
             self.next();
             while self.peek() != Token::RBracket {
-                params.push(self.parse_param()?);
+                params.extend(self.parse_param()?);
                 if self.peek() == Token::Comma {
                     self.next();
                 }
@@ -441,7 +441,7 @@ impl<'a> Parser<'a> {
         if self.peek() == Token::LBracket {
             self.next();
             while self.peek() != Token::RBracket {
-                params.push(self.parse_param()?);
+                params.extend(self.parse_param()?);
                 if self.peek() == Token::Comma {
                     self.next();
                 }
@@ -461,12 +461,29 @@ impl<'a> Parser<'a> {
         Ok(FunDecl { name, receiver_sig, params, return_mult, return_type, body, module: None })
     }
 
-    fn parse_param(&mut self) -> Result<ParamDecl, ParseError> {
-        let name = self.expect_ident()?;
+    /// Parse one or more comma-separated parameter names sharing a single type.
+    ///
+    /// Alloy 6 allows `pred Foo[a, b: T]` and `fun Bar[a, b, c: T] : U` — multiple
+    /// params share one typed group. Returns one `ParamDecl` per name (each with
+    /// the same multiplicity and type). The caller's outer loop continues to use
+    /// the trailing comma (between typed groups) as a per-group separator.
+    fn parse_param(&mut self) -> Result<Vec<ParamDecl>, ParseError> {
+        let first = self.expect_ident()?;
+        let mut names = vec![first];
+        // Commas before the `:` mean another name shares the upcoming type.
+        // Commas after the `:` belong to the enclosing param list and are
+        // consumed by the caller's loop.
+        while self.peek() == Token::Comma {
+            self.next(); // consume comma
+            names.push(self.expect_ident()?);
+        }
         self.expect(&Token::Colon)?;
         let mult = self.parse_multiplicity()?;
         let type_name = self.expect_ident()?;
-        Ok(ParamDecl { name, mult, type_name })
+        Ok(names
+            .into_iter()
+            .map(|name| ParamDecl { name, mult: mult.clone(), type_name: type_name.clone() })
+            .collect())
     }
 
     fn parse_assert(&mut self) -> Result<AssertDecl, ParseError> {

--- a/tests/parser_sig.rs
+++ b/tests/parser_sig.rs
@@ -336,6 +336,57 @@ fn parse_single_name_sig_still_works() {
     assert_eq!(model.sigs[0].name, "Solo");
 }
 
+// ── Alloy 6: comma-separated param names sharing one type ────────────────────
+
+#[test]
+fn parse_multi_name_pred_params() {
+    // Alloy 6 allows `pred Foo[a, b: T]` — two params sharing the type.
+    let model = parser::parse("pred Eq[from, to: WeatherState] { from = to }").unwrap();
+    let pred = &model.preds[0];
+    assert_eq!(pred.params.len(), 2);
+    assert_eq!(pred.params[0].name, "from");
+    assert_eq!(pred.params[1].name, "to");
+    assert_eq!(pred.params[0].type_name, "WeatherState");
+    assert_eq!(pred.params[1].type_name, "WeatherState");
+}
+
+#[test]
+fn parse_multi_name_fun_params() {
+    // Alloy 6 allows `fun Bar[a, b, c: T] : U` — three params sharing the type.
+    let model = parser::parse(
+        "sig Pos { x: Int } fun first[a, b, c: Pos] : Int { a.x }",
+    ).unwrap();
+    let fun = &model.funs[0];
+    assert_eq!(fun.params.len(), 3);
+    assert_eq!(fun.params[0].name, "a");
+    assert_eq!(fun.params[1].name, "b");
+    assert_eq!(fun.params[2].name, "c");
+    for p in &fun.params {
+        assert_eq!(p.type_name, "Pos");
+    }
+}
+
+#[test]
+fn parse_mixed_multi_and_single_params() {
+    // [a, b: T, c: U] — first two share T, third is its own decl with U.
+    let model = parser::parse(
+        "pred Foo[a, b: Int, c: Bool] { c = c }",
+    ).unwrap();
+    let pred = &model.preds[0];
+    assert_eq!(pred.params.len(), 3);
+    assert_eq!(pred.params[0].type_name, "Int");
+    assert_eq!(pred.params[1].type_name, "Int");
+    assert_eq!(pred.params[2].type_name, "Bool");
+}
+
+#[test]
+fn parse_single_param_still_works() {
+    // Regression guard for the common single-param path.
+    let model = parser::parse("pred Foo[x: Int] { x = x }").unwrap();
+    assert_eq!(model.preds[0].params.len(), 1);
+    assert_eq!(model.preds[0].params[0].name, "x");
+}
+
 // ── intersection_of comment parsing ──────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Follow-up to #54 with the same shape of fix applied to the **param** path.

Alloy 6 allows multiple parameters to share one typed group:

```alloy
pred ValidWeatherTransition[from, to: WeatherState] {
    from = to or (from = Clear and to = Cloudy)
}

fun squared_distance[a, b: Position] : Int {
    a.x.mul[b.x].plus[a.z.mul[b.z]]
}
```

`parse_param` only read a single ident before requiring `:`, so the first comma triggered `expected Colon, found Comma`. This blocked .als specs that use the standard shared-type param form (and follows naturally from the docs idiom established for sigs).

## Approach

- `parse_param` returns `Vec<ParamDecl>`. After the leading ident, the parser greedily consumes `, <ident>` until the `:`. Each name becomes its own `ParamDecl` sharing the parsed multiplicity and type.
- Commas *after* the `:` belong to the enclosing param list and continue to be consumed by the caller's loop — so `[a, b: T, c: U]` still parses correctly as three params (two of type `T`, one of type `U`).
- `parse_pred` and `parse_fun` switch from `.push` to `.extend` on the param list.

Behavior is unchanged for the single-param case.

## Coverage

Four tests added in `tests/parser_sig.rs`:

| Test | Form |
|---|---|
| `parse_multi_name_pred_params` | `pred Eq[from, to: WeatherState] { ... }` |
| `parse_multi_name_fun_params` | `fun first[a, b, c: Pos] : Int { ... }` |
| `parse_mixed_multi_and_single_params` | `pred Foo[a, b: Int, c: Bool] { ... }` |
| `parse_single_param_still_works` | Regression guard for the existing single-param path |

## Verification

- `cargo build` — clean
- `cargo test` — **907/907 passing** (903 post-#54 + 4 new). No existing test changed behavior.
- Verified `oxidtr generate` end-to-end on a probe spec using `pred Foo[a, b: T]`: parses and codegens equivalently to the hand-expanded form (`a: T, b: T`).

## Test plan

- [ ] CI passes (cargo test, cargo fmt, cargo clippy)
- [ ] Verify `parse_multi_name_*_params` and the mixed-form test cover the intended cases
- [ ] Confirm that `pred X[a, b: T] { ... }` and `pred X[a: T, b: T] { ... }` produce identical generated code

## Why this matters

Together with #54, this lets .als specs use idiomatic Alloy 6 param syntax for predicates and functions — common in spec libraries that share types across many params for readability.